### PR TITLE
Add LDP backend and base CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@ docs
 .git
 .pylint.d
 .pytest_cache
+.ralph
 
 # Assets
 data

--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,18 @@
+# Configuration
+RALPH_APP_DIR=/app/.ralph
+
+# LDP storage backend
+#
+# You need to generate an API token for your OVH's account and fill the service
+# name and stream id you are targetting.
+#
+# Note that defining the following environment variables is not required. We
+# define them for convenience purpose during development, but they can be
+# passed as CLI options.
+
+# RALPH_LDP_ENDPOINT=
+# RALPH_LDP_APPLICATION_KEY=
+# RALPH_LDP_APPLICATION_SECRET=
+# RALPH_LDP_CONSUMER_KEY=
+# RALPH_LDP_SERVICE_NAME=
+# RALPH_LDP_STREAM_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ venv.bak/
 # Logs
 *.log
 
+# history
+.ralph
+
 # Test & lint
 .coverage
 .pylint.d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Support for LDP storage backend
 - Parse (gzipped) tracking logs in GELF format
 
 [unreleased]: https://github.com/openfun/ralph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Implement base CLI commands (list, extract & fetch) for supported storage
+  backends
 - Support for LDP storage backend
 - Parse (gzipped) tracking logs in GELF format
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,18 +19,11 @@ FROM base as core
 
 COPY --from=builder /usr/local /usr/local
 
-# Un-privileged user running the application
-USER ${DOCKER_USER:-1000}
-
 WORKDIR /app
 
-CMD python -m ralph
 
 # -- Development --
 FROM core as development
-
-# Switch back to the root user to install development dependencies
-USER root:root
 
 # Copy all sources, not only runtime-required files
 COPY . /app/
@@ -44,9 +37,14 @@ RUN apt-get update && \
 RUN pip uninstall -y ralph-malph
 RUN pip install -e .[dev]
 
-# Restore the un-privileged user running the application
+# Un-privileged user running the application
 USER ${DOCKER_USER:-1000}
 
 
 # -- Production --
 FROM core as production
+
+# Un-privileged user running the application
+USER ${DOCKER_USER:-1000}
+
+ENTRYPOINT ralph

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
 COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker-compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_TEST_RUN     = $(COMPOSE_RUN)
-COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) ralph
+COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app
 
 # ==============================================================================
 # RULES
@@ -15,8 +15,12 @@ default: help
 
 # -- Docker/compose
 build: ## build the app container
-	@$(COMPOSE) build ralph
+	@$(COMPOSE) build app
 .PHONY: build
+
+dev: ## perform editable install from mounted project sources
+	DOCKER_USER=0 docker-compose run --rm app pip install -e ".[dev]"
+.PHONY: dev
 
 # Nota bene: Black should come after isort just in case they don't agree...
 lint: ## lint back-end python sources
@@ -54,7 +58,7 @@ lint-bandit: ## lint back-end python sources with bandit
 .PHONY: lint-bandit
 
 logs: ## display app logs (follow mode)
-	@$(COMPOSE) logs -f ralph
+	@$(COMPOSE) logs -f app
 .PHONY: logs
 
 status: ## an alias for "docker-compose ps"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,16 @@ COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app
 
 default: help
 
+.env:
+	cp .env.dist .env
+
 # -- Docker/compose
+bootstrap: ## bootstrap the project for development
+bootstrap: \
+  .env \
+  build \
+  dev
+.PHONY: bootstrap
 build: ## build the app container
 	@$(COMPOSE) build app
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,43 @@
 # Ralph, an OpenEdx's tracking logs processor to feed your LRS
 
+## Getting started with development
+
+To start playing with `ralph`, you should build it using the `bootstrap` Make target:
+
+```
+$ make bootstrap
+```
+
+Now you can start playing the CLI:
+
+```
+$ bin/ralph --help
+```
+
+To lint your code, either use the `lint` meta target or one of the linting tools we use:
+
+```bash
+# Run all linters
+$ make lint
+
+# Run pylint
+$ make lint-pylint
+
+# List available linters
+$ make help | grep lint-
+```
+
+To run tests on your code, either use the `test` Make target or the
+`bin/pytest` script to pass specific arguments to the test runner:
+
+```bash
+# Run all tests
+$ make test
+
+# Run pytest with options
+$ bin/pytest -x -k mixins
+```
+
 ## Contributing
 
 This project is intended to be community-driven, so please, do not hesitate to

--- a/bin/pylint
+++ b/bin/pylint
@@ -3,4 +3,4 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm ralph pylint "$@"
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm app pylint "$@"

--- a/bin/pytest
+++ b/bin/pytest
@@ -3,4 +3,4 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm ralph pytest "$@"
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm app pytest "$@"

--- a/bin/ralph
+++ b/bin/ralph
@@ -3,4 +3,4 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run ralph
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm -T app ralph ${@}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 services:
-  ralph:
+  app:
     build:
       context: .
       target: development
@@ -9,6 +9,8 @@ services:
         DOCKER_USER: ${DOCKER_USER:-1000}
     user: ${DOCKER_USER:-1000}
     image: ralph:development
+    env_file:
+      - .env
     environment:
       PYLINTHOME: /app/.pylint.d
     volumes:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,9 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
+    ovh==0.5.0
     pandas==1.0.0
+    requests==2.24.0
 package_dir =
     =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,12 +41,12 @@ dev =
     bandit==1.6.2
     black==19.10b0
     djehouty==0.1.5
-    flake8==3.7.9
+    flake8==3.8.4
     ipdb==0.12.2
     ipython==7.9.0
     isort==4.3.21
     memory-profiler==0.57.0
-    pyfakefs==3.7.1
+    pyfakefs==4.1.0
     pylint==2.4.3
     pytest==5.2.2
     pytest-cov==2.8.1
@@ -86,7 +86,7 @@ sections=FUTURE,STDLIB,THIRDPARTY,RALPH,FIRSTPARTY,LOCALFOLDER
 skip_glob=venv
 
 [tool:pytest]
-addopts = -v --cov-report term-missing
+addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=src/ralph
 python_files =
     test_*.py
     tests.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
+    click==7.1.2
+    click-log==0.3.2
+    click-option-group==0.5.1
     ovh==0.5.0
     pandas==1.0.0
     requests==2.24.0
@@ -52,6 +55,10 @@ ci =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+console_scripts =
+  ralph = ralph.__main__:cli
 
 [wheel]
 universal = 1

--- a/src/ralph/__main__.py
+++ b/src/ralph/__main__.py
@@ -6,17 +6,6 @@ Ralph main entrypoint.
 This script is a POC for now, we aim to make ralph a nice CLI to use.
 """
 
-import logging
+from . import cli
 
-from ralph.filters import anonymous
-from ralph.parsers import GELFParser
-
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(levelname)s - %(name)s - %(message)s"
-)
-logger = logging.getLogger()
-
-for c, events in enumerate(
-    GELFParser().parse("data/2020-02-02.gz", filters=[anonymous], chunksize=5000)
-):
-    logger.info("Chunk[%06d]: %d events (after filtering)", c, len(events))
+cli.cli()

--- a/src/ralph/backends/mixins.py
+++ b/src/ralph/backends/mixins.py
@@ -1,8 +1,11 @@
 """Backend mixins for Ralph"""
 
 import json
+import logging
 
 from ralph.defaults import HISTORY_FILE
+
+logger = logging.getLogger(__name__)
 
 
 class HistoryMixin:
@@ -12,6 +15,9 @@ class HistoryMixin:
     @property
     def history(self):
         """Get backend history"""
+
+        logging.debug("Loading history file: %s", str(HISTORY_FILE))
+
         if not hasattr(self, "_history"):
             try:
                 with HISTORY_FILE.open() as history_file:
@@ -23,6 +29,8 @@ class HistoryMixin:
     # pylint: disable=no-self-use
     def write_history(self, history):
         """Write given history as a JSON file"""
+
+        logging.debug("Writting history file: %s", str(HISTORY_FILE))
 
         if not HISTORY_FILE.parent.exists():
             HISTORY_FILE.parent.mkdir(parents=True)

--- a/src/ralph/backends/mixins.py
+++ b/src/ralph/backends/mixins.py
@@ -38,6 +38,9 @@ class HistoryMixin:
         with HISTORY_FILE.open("w") as history_file:
             json.dump(history, history_file)
 
+        # Update history
+        self._history = history
+
     def clean_history(self, selector):
         """Clean selected events from the history.
 

--- a/src/ralph/backends/mixins.py
+++ b/src/ralph/backends/mixins.py
@@ -1,0 +1,44 @@
+"""Backend mixins for Ralph"""
+
+import json
+
+from ralph.defaults import HISTORY_FILE
+
+
+class HistoryMixin:
+    """Handle backend download history to avoid fetching same files multiple
+    times if they are already available."""
+
+    @property
+    def history(self):
+        """Get backend history"""
+        if not hasattr(self, "_history"):
+            try:
+                with HISTORY_FILE.open() as history_file:
+                    self._history = json.load(history_file)
+            except FileNotFoundError:
+                self._history = []
+        return self._history
+
+    # pylint: disable=no-self-use
+    def write_history(self, history):
+        """Write given history as a JSON file"""
+
+        if not HISTORY_FILE.parent.exists():
+            HISTORY_FILE.parent.mkdir(parents=True)
+
+        with HISTORY_FILE.open("w") as history_file:
+            json.dump(history, history_file)
+
+    def clean_history(self, selector):
+        """Clean selected events from the history.
+
+        selector: a callable that selects events that need to be removed
+        """
+        self._history = list(filter(lambda event: not selector(event), self.history))
+        self.write_history(self._history)
+
+    def append_to_history(self, event):
+        """Append event to history"""
+
+        self.write_history(self.history + [event])

--- a/src/ralph/backends/storage/__init__.py
+++ b/src/ralph/backends/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage backends for Ralph"""

--- a/src/ralph/backends/storage/base.py
+++ b/src/ralph/backends/storage/base.py
@@ -1,0 +1,25 @@
+"""Base storage backend for Ralph"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseStorage(ABC):
+    """Base storage backend interface"""
+
+    name = "base"
+
+    @abstractmethod
+    def list(self):
+        """List files in the storage backend"""
+
+    @abstractmethod
+    def url(self, name):
+        """Get `name` file absolute URL"""
+
+    @abstractmethod
+    def read(self, name, chunk_size=4096):
+        """Read `name` file and stream its content by chunks of a given size"""
+
+    @abstractmethod
+    def write(self, name, content):
+        """Write content to the `name` target"""

--- a/src/ralph/backends/storage/base.py
+++ b/src/ralph/backends/storage/base.py
@@ -9,7 +9,7 @@ class BaseStorage(ABC):
     name = "base"
 
     @abstractmethod
-    def list(self, details=False):
+    def list(self, details=False, new=False):
         """List files in the storage backend"""
 
     @abstractmethod

--- a/src/ralph/backends/storage/base.py
+++ b/src/ralph/backends/storage/base.py
@@ -9,7 +9,7 @@ class BaseStorage(ABC):
     name = "base"
 
     @abstractmethod
-    def list(self):
+    def list(self, details=False):
         """List files in the storage backend"""
 
     @abstractmethod

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -1,7 +1,6 @@
 """OVH's LDP storage backend for Ralph"""
 
 import logging
-import re
 import sys
 
 import ovh
@@ -64,16 +63,20 @@ class LDPStorage(HistoryMixin, BaseStorage):
 
         return download_url
 
-    def list(self):
+    def list(self, details=False):
         """List archives for a given stream"""
 
         list_archives_endpoint = self._archive_endpoint
         logger.debug("List archives endpoint: %s", list_archives_endpoint)
+        logger.debug("List archives details: %s", str(details))
 
         archives = self.client.get(list_archives_endpoint)
         logger.debug("Found %d archives", len(archives))
 
-        return archives
+        for archive in archives:
+            yield self.client.get(
+                f"{self._archive_endpoint}/{archive}"
+            ) if details else archive
 
     def read(self, name, chunk_size=4096):
         """Read the `name` archive file and stream its content"""

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -1,8 +1,8 @@
 """OVH's LDP storage backend for Ralph"""
 
+import datetime
 import logging
 import sys
-from datetime import datetime, timezone
 
 import ovh
 import requests

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from datetime import datetime, timezone
 
 import ovh
 import requests
@@ -52,6 +53,24 @@ class LDPStorage(HistoryMixin, BaseStorage):
             raise BackendParameterException(msg)
         return f"/dbaas/logs/{self.service_name}/output/graylog/stream/{self.stream_id}/archive"
 
+    def _details(self, name):
+        """Get name archive details
+
+        Expected JSON response looks like:
+
+            {
+                "archiveId": "5d49d1b3-a3eb-498c-9039-6a482166f888",
+                "createdAt": "2020-06-18T04:38:59.436634+02:00",
+                "filename": "2020-06-16.gz",
+                "md5": "01585b394be0495e38dbb60b20cb40a9",
+                "retrievalDelay": 0,
+                "retrievalState": "sealed",
+                "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+                "size": 67906662,
+            }
+        """
+        return self.client.get(f"{self._archive_endpoint}/{name}")
+
     def url(self, name):
         """Get archive absolute URL"""
 
@@ -63,8 +82,14 @@ class LDPStorage(HistoryMixin, BaseStorage):
 
         return download_url
 
-    def list(self, details=False):
-        """List archives for a given stream"""
+    def list(self, details=False, new=False):
+        """List archives for a given stream.
+
+        details: get detailled information about archives instead of their ids
+
+        new: given the history, list only not already fetched archives
+
+        """
 
         list_archives_endpoint = self._archive_endpoint
         logger.debug("List archives endpoint: %s", list_archives_endpoint)
@@ -73,15 +98,26 @@ class LDPStorage(HistoryMixin, BaseStorage):
         archives = self.client.get(list_archives_endpoint)
         logger.debug("Found %d archives", len(archives))
 
+        if new:
+            archives = set(archives) - set(
+                entry.get("id")
+                for entry in filter(
+                    lambda e: e["backend"] == self.name and e["command"] == "fetch",
+                    self.history,
+                )
+            )
+            logger.debug("New archives: %d", len(archives))
+
         for archive in archives:
-            yield self.client.get(
-                f"{self._archive_endpoint}/{archive}"
-            ) if details else archive
+            yield self._details(archive) if details else archive
 
     def read(self, name, chunk_size=4096):
         """Read the `name` archive file and stream its content"""
 
         logger.debug("Getting archive: %s", name)
+
+        # Get detailled information about the archive to fetch
+        details = self._details(name)
 
         # Stream response (archive content)
         with requests.get(self.url(name), stream=True) as result:

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -1,0 +1,109 @@
+"""OVH's LDP storage backend for Ralph"""
+
+import logging
+import re
+import sys
+
+import ovh
+import requests
+
+from ralph.exceptions import BackendParameterException
+
+from ..mixins import HistoryMixin
+from .base import BaseStorage
+
+logger = logging.getLogger(__name__)
+
+
+class LDPStorage(HistoryMixin, BaseStorage):
+    """OVH's LDP storage backend"""
+
+    # pylint: disable=too-many-arguments
+
+    name = "ldp"
+
+    def __init__(
+        self,
+        endpoint,
+        application_key,
+        application_secret,
+        consumer_key,
+        service_name=None,
+        stream_id=None,
+    ):
+        self._endpoint = endpoint
+        self._application_key = application_key
+        self._application_secret = application_secret
+        self._consumer_key = consumer_key
+        self.service_name = service_name
+        self.stream_id = stream_id
+
+        self.client = ovh.Client(
+            endpoint=self._endpoint,
+            application_key=self._application_key,
+            application_secret=self._application_secret,
+            consumer_key=self._consumer_key,
+        )
+
+    @property
+    def _archive_endpoint(self):
+        if None in (self.service_name, self.stream_id):
+            msg = "LDPStorage backend instance requires to set both service_name and stream_id"
+            logger.error(msg)
+            raise BackendParameterException(msg)
+        return f"/dbaas/logs/{self.service_name}/output/graylog/stream/{self.stream_id}/archive"
+
+    def url(self, name):
+        """Get archive absolute URL"""
+
+        download_url_endpoint = f"{self._archive_endpoint}/{name}/url"
+
+        response = self.client.post(download_url_endpoint)
+        download_url = response.get("url")
+        logger.debug("Temporary URL: %s", download_url)
+
+        return download_url
+
+    def list(self):
+        """List archives for a given stream"""
+
+        list_archives_endpoint = self._archive_endpoint
+        logger.debug("List archives endpoint: %s", list_archives_endpoint)
+
+        archives = self.client.get(list_archives_endpoint)
+        logger.debug("Found %d archives", len(archives))
+
+        return archives
+
+    def read(self, name, chunk_size=4096):
+        """Read the `name` archive file and stream its content"""
+
+        logger.debug("Getting archive: %s", name)
+
+        # Stream response (archive content)
+        with requests.get(self.url(name), stream=True) as result:
+            result.raise_for_status()
+            for chunk in result.iter_content(chunk_size=chunk_size):
+                sys.stdout.buffer.write(chunk)
+
+        # Archive is supposed to have been fully fetched, add a new entry to
+        # the history.
+        self.append_to_history(
+            {
+                "backend": self.name,
+                "command": "fetch",
+                "id": name,
+                "filename": details.get("filename"),
+                "size": details.get("size"),
+                "fetched_at": datetime.datetime.now(
+                    tz=datetime.timezone.utc
+                ).isoformat(),
+            }
+        )
+
+    def write(self, name, content):
+        """LDP storage backend is read-only, calling this method will raise an error"""
+
+        msg = "LDP storage backend is read-only, cannot write to %s"
+        logger.error(msg, name)
+        raise NotImplementedError(msg % name)

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -1,0 +1,125 @@
+"""Ralph CLI entrypoint"""
+
+import logging
+import sys
+from inspect import signature
+
+import click
+import click_log
+from click_option_group import optgroup
+
+from ralph.defaults import (
+    AVAILABLE_PARSERS,
+    AVAILABLE_STORAGE_BACKENDS,
+    DEFAULT_GELF_PARSER_CHUNCK_SIZE,
+    ENVVAR_PREFIX,
+    Parsers,
+    StorageBackends,
+)
+from ralph.utils import get_class_from_name, get_instance_from_class, get_root_logger
+
+# cli module logger
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+
+PARSERS = list(AVAILABLE_PARSERS)
+STORAGE_BACKENDS = list(AVAILABLE_STORAGE_BACKENDS)
+
+
+@click.group(name="ralph")
+@click_log.simple_verbosity_option(get_root_logger())
+def cli():
+    """Ralph is a stream-based tool to play with your logs"""
+
+
+def backends_options(name=None, backends=None):
+    """Backend-related options decorator for Ralph commands"""
+
+    def wrapper(command):
+        command = (
+            click.option(
+                "-b",
+                "--backend",
+                type=click.Choice(backends),
+                required=True,
+                help="Storage backend",
+            )
+        )(command)
+
+        for backend in backends:
+            backend_class = get_class_from_name(backend, StorageBackends)
+
+            for parameter in signature(backend_class.__init__).parameters.values():
+                if parameter.name == "self":
+                    continue
+                option = f"--{backend_class.name}-{parameter.name}".replace("_", "-")
+                envvar = (
+                    f"{ENVVAR_PREFIX}_{backend_class.name}_{parameter.name}".upper()
+                )
+                command = (optgroup.option(option, envvar=envvar))(command)
+            command = (optgroup.group(f"{backend_class.name} storage backend"))(command)
+
+        command = (cli.command(name=name or command.__name__))(command)
+        return command
+
+    return wrapper
+
+
+@cli.command()
+@click.option(
+    "-p",
+    "--parser",
+    type=click.Choice(PARSERS),
+    required=True,
+    help="Container format parser used to extract events",
+)
+@click.option(
+    "-c",
+    "--chunksize",
+    type=int,
+    default=DEFAULT_GELF_PARSER_CHUNCK_SIZE,
+    help="Parse events by chunks of size #",
+)
+def extract(parser, chunksize):
+    """Extract input events from a container format using a dedicated parser"""
+
+    logger.info(
+        "Extracting events using the %s parser (chunk size: %d)", parser, chunksize
+    )
+
+    parser = get_class_from_name(parser, Parsers)()
+
+    for event in parser.parse(sys.stdin, chunksize=chunksize):
+        click.echo(event)
+
+
+@click.argument("archive")
+@backends_options(backends=STORAGE_BACKENDS)
+def fetch(backend, archive, **options):
+    """Fetch an archive from a configured storage backend"""
+
+    logger.info("Fetching archive %s from the configured %s backend", archive, backend)
+    logger.debug("Backend parameters: %s", options)
+
+    storage = get_instance_from_class(
+        get_class_from_name(backend, StorageBackends), **options
+    )
+    storage.read(archive)
+
+
+@backends_options(name="list", backends=STORAGE_BACKENDS)
+def list_(backend, **options):
+    """List available archives from a configured storage backend"""
+
+    logger.info("Listing archives for the configured %s backend", backend)
+    logger.debug("Backend parameters: %s", options)
+
+    storage = get_instance_from_class(
+        get_class_from_name(backend, StorageBackends), **options
+    )
+    archives = storage.list()
+    if len(archives) == 0:
+        logger.warning("Configured %s backend contains no archive", backend)
+    else:
+        click.echo("\n".join(archives))

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -111,12 +111,15 @@ def fetch(backend, archive, **options):
 
 @backends_options(name="list", backends=STORAGE_BACKENDS)
 @click.option(
+    "-n/-a", "--new/--all", default=False, help="List not fetched (or all) archives",
+)
+@click.option(
     "-D/-I",
     "--details/--ids",
     default=False,
     help="Get archives detailled output (JSON)",
 )
-def list_(details, backend, **options):
+def list_(details, new, backend, **options):
     """List available archives from a configured storage backend"""
 
     logger.info("Listing archives for the configured %s backend", backend)
@@ -126,7 +129,7 @@ def list_(details, backend, **options):
     storage = get_instance_from_class(
         get_class_from_name(backend, StorageBackends), **options
     )
-    archives = storage.list(details=details)
+    archives = storage.list(details=details, new=new)
 
     counter = 0
     for archive in archives:

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -1,0 +1,34 @@
+"""Default configurations for Ralph"""
+
+from enum import Enum
+from os import environ
+from pathlib import Path
+
+from .utils import import_string
+
+
+class Parsers(Enum):
+    """Enumerate active parsers modules.
+
+    Adding an entry to this enum will make it available to the CLI.
+    """
+
+    GELF = "ralph.parsers.GELFParser"
+
+
+class StorageBackends(Enum):
+    """Enumerate active storage backend modules.
+
+    Adding an entry to this enum will make it available to the CLI.
+    """
+
+    LDP = "ralph.backends.storage.ldp.LDPStorage"
+
+
+APP_DIR = Path(environ.get("RALPH_APP_DIR", Path(environ.get("HOME")) / ".ralph"))
+AVAILABLE_PARSERS = (lambda: (import_string(parser.value).name for parser in Parsers))()
+AVAILABLE_STORAGE_BACKENDS = (
+    lambda: (import_string(backend.value).name for backend in StorageBackends)
+)()
+ENVVAR_PREFIX = "RALPH"
+HISTORY_FILE = Path(environ.get("RALPH_HISTORY_FILE", APP_DIR / "history.json"))

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -4,6 +4,8 @@ from enum import Enum
 from os import environ
 from pathlib import Path
 
+from click import get_app_dir
+
 from .utils import import_string
 
 
@@ -25,7 +27,7 @@ class StorageBackends(Enum):
     LDP = "ralph.backends.storage.ldp.LDPStorage"
 
 
-APP_DIR = Path(environ.get("RALPH_APP_DIR", Path(environ.get("HOME")) / ".ralph"))
+APP_DIR = Path(environ.get("RALPH_APP_DIR", get_app_dir("ralph")))
 AVAILABLE_PARSERS = (lambda: (import_string(parser.value).name for parser in Parsers))()
 AVAILABLE_STORAGE_BACKENDS = (
     lambda: (import_string(backend.value).name for backend in StorageBackends)

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -30,5 +30,6 @@ AVAILABLE_PARSERS = (lambda: (import_string(parser.value).name for parser in Par
 AVAILABLE_STORAGE_BACKENDS = (
     lambda: (import_string(backend.value).name for backend in StorageBackends)
 )()
+DEFAULT_GELF_PARSER_CHUNCK_SIZE = 5000
 ENVVAR_PREFIX = "RALPH"
 HISTORY_FILE = Path(environ.get("RALPH_HISTORY_FILE", APP_DIR / "history.json"))

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -3,5 +3,9 @@ Ralph exceptions.
 """
 
 
+class BackendParameterException(Exception):
+    """Raised when a backend parameter value is not valid"""
+
+
 class EventKeyError(Exception):
     """Raised when an expected event key has not been found."""

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from .defaults import DEFAULT_GELF_PARSER_CHUNCK_SIZE
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,7 +41,7 @@ class GELFParser(BaseParser):
 
     name = "gelf"
 
-    def parse(self, input_file, chunksize=50000):
+    def parse(self, input_file, chunksize=DEFAULT_GELF_PARSER_CHUNCK_SIZE):
         """Parse GELF formatted logs (one json string event per row).
 
         Args:

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -3,30 +3,31 @@ Ralph tracking logs parsers.
 """
 
 import logging
-import os
+from abc import ABC, abstractmethod
+from pathlib import Path
 
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 
-class BaseParser:
+class BaseParser(ABC):
     """Base tracking logs parser."""
 
-    def parse(self, input_file, filters=None, chunksize=1):
+    name = "base"
+
+    @abstractmethod
+    def parse(self, input_file, chunksize=1):
         """Parse GELF formatted logs (one json string event per row).
 
         Args:
             input_file (string): Path to the log file to parse.
-            filters (list): A list of functions to apply on parsed results to
-                filter them.
             chunksize (int): The amount of log records to process at a time.
 
         Yields:
-            DataFrame: parsed and filtered events from the current file chunk.
+            event: raw event as extracted from its container
 
         """
-        raise NotImplementedError
 
 
 class GELFParser(BaseParser):
@@ -36,45 +37,31 @@ class GELFParser(BaseParser):
     documentation: https://docs.graylog.org/en/latest/pages/gelf.html
     """
 
-    def parse(self, input_file, filters=None, chunksize=50000):
+    name = "gelf"
+
+    def parse(self, input_file, chunksize=50000):
         """Parse GELF formatted logs (one json string event per row).
 
         Args:
             input_file (string): Path to the log file to parse (could be
                 gunzipped).
-            filters (list): A list of functions to apply on parsed results to
-                filter them.
             chunksize (int): The amount of log records to process at a time. A
                 value between 3.000 and 10.000 seems to be a reasonnable choice
                 to parse 1.5M records in a few minutes (typically 2 or 3
                 minutes on a modern computer).
 
         Yields:
-            DataFrame: parsed and filtered events from the current file chunk.
+            event: events raw short_message string
 
         """
         logger.info("Parsing: %s", input_file)
 
-        if not os.path.exists(input_file):
+        if isinstance(input_file, str) and not Path(input_file).exists():
             msg = "Input GELF log file '%s' does not exist"
             logger.error(msg, input_file)
             raise OSError(msg % (input_file))
 
-        filters = filters or []
-
         chunks = pd.read_json(input_file, lines=True, chunksize=chunksize)
         for chunk in chunks:
-            events = pd.read_json("\n".join(chunk["short_message"]), lines=True)
-            logger.debug("Events before filtering: %d", len(events))
-
-            for _filter in filters:
-                logger.debug("Current filter: %s", _filter.__name__)
-                if events.empty:
-                    logger.warning(
-                        "Current chunk contains no events, will stop filtering."
-                    )
-                    break
-                events = _filter(events)
-                logger.debug("Filter: %s (events: %d)", _filter.__name__, len(events))
-
-            yield events
+            for event in chunk["short_message"].values:
+                yield event

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -1,0 +1,62 @@
+"""Utilities for Ralph"""
+
+import logging
+from importlib import import_module
+
+import click_log
+
+
+# Taken from Django utilities
+# https://docs.djangoproject.com/en/3.1/_modules/django/utils/module_loading/#import_string
+def import_string(dotted_path):
+    """
+    Import a dotted module path and return the attribute/class designated by the
+    last name in the path. Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit(".", 1)
+    except ValueError as err:
+        raise ImportError("%s doesn't look like a module path" % dotted_path) from err
+
+    module = import_module(module_path)
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError as err:
+        raise ImportError(
+            'Module "%s" does not define a "%s" attribute/class'
+            % (module_path, class_name)
+        ) from err
+
+
+def get_class_from_name(name, modules):
+    """Get class given its name in a module enum"""
+
+    for module in modules:
+        klass = import_string(module.value)
+        if klass.name == name:
+            return klass
+    raise ImportError(f"{name} class is not available")
+
+
+def get_instance_from_class(klass, **init_parameters):
+    """Return a class instance given class-name-prefixed init parameters"""
+
+    # Filter backend-related parameters. Parameter name is supposed to start
+    # with the backend name
+    names = filter(lambda p: p.startswith(klass.name), init_parameters.keys())
+    parameters = {
+        name.replace(f"{klass.name}_", ""): init_parameters[name] for name in names
+    }
+
+    return klass(**parameters)
+
+
+def get_root_logger():
+    """Get main Ralph logger"""
+
+    ralph_logger = logging.getLogger("ralph")
+    click_log.basic_config(ralph_logger)
+    ralph_logger.propagate = True
+
+    return ralph_logger

--- a/tests/backends/storage/test_base.py
+++ b/tests/backends/storage/test_base.py
@@ -1,0 +1,28 @@
+"""Tests for Ralph base storage backend"""
+
+from ralph.backends.storage.base import BaseStorage
+
+
+def test_abstract_interface_with_implemented_abstract_method():
+    """Test interface mechanism with properly implemented abstract methods"""
+
+    class GoodStorage(BaseStorage):
+        """Correct implementation with required abstract methods"""
+
+        name = "good"
+
+        def list(self, details=False, new=False):
+            """Fake list"""
+
+        def url(self, name):
+            """Fake url"""
+
+        def read(self, name, chunk_size=0):
+            """Fake read"""
+
+        def write(self, name, content):
+            """Fake write"""
+
+    GoodStorage()
+
+    assert GoodStorage.name == "good"

--- a/tests/backends/storage/test_ldp.py
+++ b/tests/backends/storage/test_ldp.py
@@ -1,0 +1,459 @@
+"""Tests for Ralph ldp storage backend"""
+
+import datetime
+import gzip
+import json
+import os.path
+import sys
+import uuid
+from collections.abc import Iterable
+from io import BytesIO
+from pathlib import Path, PurePath
+from urllib.parse import urlparse
+
+import ovh
+import pytest
+import requests
+
+from ralph.backends.storage.ldp import LDPStorage
+from ralph.defaults import APP_DIR, HISTORY_FILE
+from ralph.exceptions import BackendParameterException
+
+
+def test_ldp_storage_instanciation():
+    """Test the LDPStorage backend instanciation"""
+    # pylint: disable=protected-access
+
+    assert LDPStorage.name == "ldp"
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+    )
+
+    assert storage._endpoint == "ovh-eu"
+    assert storage._application_key == "fake_key"
+    assert storage._application_secret == "fake_secret"
+    assert storage._consumer_key == "another_fake_key"
+    assert storage.service_name is None
+    assert storage.stream_id is None
+    assert isinstance(storage.client, ovh.Client)
+
+
+def test_archive_endpoint_property():
+    """Test the LDPStorage _archive_endpoint property"""
+    # pylint: disable=protected-access, pointless-statement
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="foo",
+        stream_id="bar",
+    )
+    assert (
+        storage._archive_endpoint == "/dbaas/logs/foo/output/graylog/stream/bar/archive"
+    )
+
+    storage.service_name = None
+    with pytest.raises(
+        BackendParameterException,
+        match="LDPStorage backend instance requires to set both service_name and stream_id",
+    ):
+        storage._archive_endpoint
+
+    storage.service_name = "foo"
+    storage.stream_id = None
+    with pytest.raises(
+        BackendParameterException,
+        match="LDPStorage backend instance requires to set both service_name and stream_id",
+    ):
+        storage._archive_endpoint
+
+    storage.service_name = None
+    with pytest.raises(
+        BackendParameterException,
+        match="LDPStorage backend instance requires to set both service_name and stream_id",
+    ):
+        storage._archive_endpoint
+
+
+def test_details_method(monkeypatch):
+    """Test the LDPStorage _details method"""
+    # pylint: disable=protected-access
+
+    def mock_get(url):
+        """Mock OVH client get request"""
+
+        name = PurePath(urlparse(url).path).name
+        return {
+            "archiveId": str(uuid.UUID(name)),
+            "createdAt": "2020-06-18T04:38:59.436634+02:00",
+            "filename": "2020-06-16.gz",
+            "md5": "01585b394be0495e38dbb60b20cb40a9",
+            "retrievalDelay": 0,
+            "retrievalState": "sealed",
+            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "size": 67906662,
+        }
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    # Apply the monkeypatch for requests.get to mock_get
+    monkeypatch.setattr(storage.client, "get", mock_get)
+
+    details = storage._details("5d49d1b3a3eb498c90396a482166f888")
+    assert details.get("archiveId") == "5d49d1b3-a3eb-498c-9039-6a482166f888"
+
+
+def test_url_method(monkeypatch):
+    """Test the LDPStorage url method"""
+
+    def mock_post(url):
+        """Mock OVH Client post request"""
+        # pylint: disable=unused-argument
+        return {
+            "expirationDate": "2020-10-13T12:59:37.326131+00:00",
+            "url": (
+                "https://storage.gra.cloud.ovh.net/v1/"
+                "AUTH_-c3b123f595c46e789acdd1227eefc13/"
+                "gra2-pcs/5eba98fb4fcb481001180e4b/"
+                "2020-06-01.gz?"
+                "temp_url_sig=e1b3ab10a9149a4ff5dcb95f40f21063780d26f7&"
+                "temp_url_expires=1602593977"
+            ),
+        }
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    # Apply the monkeypatch for requests.post to mock_get
+    monkeypatch.setattr(storage.client, "post", mock_post)
+
+    assert storage.url("5d49d1b3-a3eb-498c-9039-6a482166f888") == (
+        "https://storage.gra.cloud.ovh.net/v1/"
+        "AUTH_-c3b123f595c46e789acdd1227eefc13/"
+        "gra2-pcs/5eba98fb4fcb481001180e4b/"
+        "2020-06-01.gz?"
+        "temp_url_sig=e1b3ab10a9149a4ff5dcb95f40f21063780d26f7&"
+        "temp_url_expires=1602593977"
+    )
+
+
+def test_list_method(monkeypatch):
+    """Test the LDPStorage list method with a blank history"""
+
+    def mock_list(url):
+        """Mock OVH client list stream archives get request"""
+        # pylint: disable=unused-argument
+        return [
+            "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+            "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+            "08075b54-8d24-42ea-a509-9f10b0e3b416",
+            "75c865fd-b4eb-4b2b-9290-e8166a187d50",
+            "72e82041-7245-4ef1-b876-01964c6a8c50",
+        ]
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    # Apply the monkeypatch for requests.post to mock_get
+    monkeypatch.setattr(storage.client, "get", mock_list)
+
+    archives = storage.list(details=False, new=False)
+    assert isinstance(archives, Iterable)
+    assert list(archives) == [
+        "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+        "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+        "08075b54-8d24-42ea-a509-9f10b0e3b416",
+        "75c865fd-b4eb-4b2b-9290-e8166a187d50",
+        "72e82041-7245-4ef1-b876-01964c6a8c50",
+    ]
+
+
+def test_list_method_history_management(monkeypatch, fs):
+    """Test the LDPStorage list method with an history"""
+    # pylint: disable=invalid-name
+
+    def mock_list(url):
+        """Mock OVH client list stream archives get request"""
+        # pylint: disable=unused-argument
+        return [
+            "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+            "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+            "08075b54-8d24-42ea-a509-9f10b0e3b416",
+            "75c865fd-b4eb-4b2b-9290-e8166a187d50",
+            "72e82041-7245-4ef1-b876-01964c6a8c50",
+        ]
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    # Apply the monkeypatch for requests.post to mock_get
+    monkeypatch.setattr(storage.client, "get", mock_list)
+
+    # Create a fetch history
+    fs.create_file(
+        HISTORY_FILE,
+        contents=json.dumps(
+            [
+                {
+                    "backend": "ldp",
+                    "command": "fetch",
+                    "id": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+                    "filename": "20201002.tgz",
+                    "size": 23424233,
+                    "fetched_at": "2020-10-07T16:37:25.887664+00:00",
+                },
+                {
+                    "backend": "ldp",
+                    "command": "fetch",
+                    "id": "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+                    "filename": "20201002.tgz",
+                    "size": 23424233,
+                    "fetched_at": "2020-10-07T16:40:25.887664+00:00",
+                },
+                {
+                    "backend": "ldp",
+                    "command": "fetch",
+                    "id": "08075b54-8d24-42ea-a509-9f10b0e3b416",
+                    "filename": "20201002.tgz",
+                    "size": 23424233,
+                    "fetched_at": "2020-10-07T19:37:25.887664+00:00",
+                },
+            ]
+        ),
+    )
+
+    archives = storage.list(details=False, new=True)
+    assert isinstance(archives, Iterable)
+    assert sorted(list(archives)) == sorted(
+        [
+            "75c865fd-b4eb-4b2b-9290-e8166a187d50",
+            "72e82041-7245-4ef1-b876-01964c6a8c50",
+        ]
+    )
+
+
+def test_list_method_with_details(monkeypatch):
+    """Test the LDPStorage list method with detailled output"""
+
+    details_responses = [
+        {
+            "archiveId": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+            "createdAt": "2020-06-18T04:38:59.436634+02:00",
+            "filename": "2020-06-16.gz",
+            "md5": "01585b394be0495e38dbb60b20cb40a9",
+            "retrievalDelay": 0,
+            "retrievalState": "sealed",
+            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "size": 67906662,
+        },
+        {
+            "archiveId": "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+            "createdAt": "2020-06-18T04:38:59.436634+02:00",
+            "filename": "2020-06-17.gz",
+            "md5": "01585b394be0495e38dbb60b20cb40a9",
+            "retrievalDelay": 0,
+            "retrievalState": "sealed",
+            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "size": 67906662,
+        },
+    ]
+    get_details_response = (response for response in details_responses)
+
+    def mock_get(url):
+        """Mock OVH client get requests"""
+
+        # list request
+        if url.endswith("archive"):
+            return [
+                "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+                "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+            ]
+        # details request
+        return next(get_details_response)
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    # Apply the monkeypatch for requests.post to mock_get
+    monkeypatch.setattr(storage.client, "get", mock_get)
+
+    archives = storage.list(details=True, new=False)
+    assert isinstance(archives, Iterable)
+    assert list(archives) == details_responses
+
+
+def test_read_method(monkeypatch, fs):
+    """Test the LDPStorage read method with detailled output"""
+    # pylint: disable=invalid-name
+
+    # Create fake archive to stream
+    archive_path = Path("/tmp/2020-06-16.gz")
+    archive_content = {"foo": "bar"}
+    with gzip.open(archive_path, "wb") as archive_file:
+        archive_file.write(bytes(json.dumps(archive_content), encoding="utf-8"))
+
+    def mock_ovh_post(url):
+        """Mock OVH Client post request"""
+        # pylint: disable=unused-argument
+
+        return {
+            "expirationDate": "2020-10-13T12:59:37.326131+00:00",
+            "url": (
+                "https://storage.gra.cloud.ovh.net/v1/"
+                "AUTH_-c3b123f595c46e789acdd1227eefc13/"
+                "gra2-pcs/5eba98fb4fcb481001180e4b/"
+                "2020-06-01.gz?"
+                "temp_url_sig=e1b3ab10a9149a4ff5dcb95f40f21063780d26f7&"
+                "temp_url_expires=1602593977"
+            ),
+        }
+
+    def mock_ovh_get(url):
+        """Mock OVH client get requests"""
+        # pylint: disable=unused-argument
+
+        return {
+            "archiveId": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+            "createdAt": "2020-06-18T04:38:59.436634+02:00",
+            "filename": "2020-06-16.gz",
+            "md5": "01585b394be0495e38dbb60b20cb40a9",
+            "retrievalDelay": 0,
+            "retrievalState": "sealed",
+            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "size": 67906662,
+        }
+
+    class MockRequestsResponse:
+        """A basic mock for a requests response"""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def iter_content(self, chunk_size):
+            """Fake content file iteration"""
+            # pylint: disable=no-self-use
+
+            with archive_path.open("rb") as archive:
+                while chunk := archive.read(chunk_size):
+                    yield chunk
+
+        def raise_for_status(self):
+            """Do nothing for now"""
+
+    def mock_requests_get(url, stream=True):
+        """Mock requests get requests"""
+        # pylint: disable=unused-argument
+
+        return MockRequestsResponse()
+
+    # Freeze the datetime.datetime.now() value
+    freezed_now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    class MockDatetime:
+        """A mock class for a fixed datetime.now() value"""
+
+        @classmethod
+        def now(cls, **kwargs):
+            """Always return the same testable now value"""
+            # pylint: disable=unused-argument
+
+            return freezed_now
+
+    # Mock stdout stream
+    mock_stdout = BytesIO()
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    # Apply monkeypatches
+    monkeypatch.setattr(storage.client, "post", mock_ovh_post)
+    monkeypatch.setattr(storage.client, "get", mock_ovh_get)
+    monkeypatch.setattr(requests, "get", mock_requests_get)
+    monkeypatch.setattr(datetime, "datetime", MockDatetime)
+    monkeypatch.setattr(sys.stdout, "buffer", mock_stdout)
+
+    fs.create_dir(str(APP_DIR))
+    assert not os.path.exists(str(HISTORY_FILE))
+
+    storage.read(name="5d5c4c93-04a4-42c5-9860-f51fa4044aa1")
+
+    assert os.path.exists(str(HISTORY_FILE))
+    assert storage.history == [
+        {
+            "backend": "ldp",
+            "command": "fetch",
+            "id": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+            "filename": "2020-06-16.gz",
+            "size": 67906662,
+            "fetched_at": freezed_now.isoformat(),
+        }
+    ]
+
+    mock_stdout.seek(0)
+    with gzip.open(mock_stdout, "rb") as output:
+        assert json.loads(output.read()) == archive_content
+
+
+def test_write_method_with_details():
+    """Test the LDPStorage write method"""
+
+    storage = LDPStorage(
+        endpoint="ovh-eu",
+        application_key="fake_key",
+        application_secret="fake_secret",
+        consumer_key="another_fake_key",
+        service_name="ldp_fake",
+        stream_id="bbf2d9fb-b092-4003-958b-1262dc902a1c",
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="LDP storage backend is read-only, cannot write to fake",
+    ):
+        storage.write("fake", "content")

--- a/tests/backends/test_mixins.py
+++ b/tests/backends/test_mixins.py
@@ -1,0 +1,116 @@
+"""Tests for ralph backends mixins"""
+
+import json
+import os.path
+
+from ralph.backends.mixins import HistoryMixin
+from ralph.defaults import APP_DIR, HISTORY_FILE
+
+
+def test_history_mixin_empty_history(fs):
+    """Test the history method of the HistoryMixin when history is empty"""
+    # pylint: disable=unused-argument, invalid-name, protected-access
+
+    history = HistoryMixin()
+
+    # Property has not been cached yet.
+    assert not hasattr(history, "_history")
+
+    # History file or even the APP_DIR are not supposed to exist before trying
+    # to access the history for the first time.
+    assert not os.path.exists(str(APP_DIR))
+    assert not os.path.exists(str(HISTORY_FILE))
+    assert history.history == []
+
+    # Even after trying to read the history for the first time, the file system
+    # should stay pristine.
+    assert not os.path.exists(str(APP_DIR))
+    assert not os.path.exists(str(HISTORY_FILE))
+
+    # Cached property should be effective now.
+    assert hasattr(history, "_history")
+    assert history._history == history.history
+
+
+def test_history_mixin_with_history(fs):
+    """Test the history method of the HistoryMixin when history is filled"""
+    # pylint: disable=invalid-name
+
+    history = HistoryMixin()
+
+    # Add history events
+    events = [{"event": "foo"}]
+    fs.create_file(HISTORY_FILE, contents=json.dumps(events))
+
+    assert history.history == events
+
+
+def test_history_mixin_write_history(fs):
+    """Test the write_history method of the HistoryMixin"""
+    # pylint: disable=invalid-name, protected-access
+
+    history = HistoryMixin()
+
+    # History file or even the APP_DIR are not supposed to exist before trying
+    # to write the history for the first time.
+    assert not os.path.exists(str(APP_DIR))
+    assert not os.path.exists(str(HISTORY_FILE))
+
+    # Looks like pyfakefs needs some help with pathlib overrides (we are using
+    # Path().parent in our implementation).
+    fs.create_dir(str(APP_DIR))
+
+    # Write history
+    events = [{"event": "foo"}]
+    history.write_history(events)
+    assert os.path.exists(str(APP_DIR))
+    assert os.path.exists(str(HISTORY_FILE))
+    assert HISTORY_FILE.read_text() == json.dumps(events)
+    assert history._history == events
+    assert history.history == events
+
+
+def test_history_mixin_clean_history(fs):
+    """Test the clean_history method of the HistoryMixin"""
+    # pylint: disable=invalid-name
+
+    history = HistoryMixin()
+
+    # Add history events
+    events = [
+        {"command": "foo"},
+        {"command": "bar"},
+        {"command": "foo"},
+        {"command": "lol"},
+        {"command": "bar"},
+    ]
+    fs.create_file(HISTORY_FILE, contents=json.dumps(events))
+
+    history.clean_history(lambda event: event.get("command") == "foo")
+    assert history.history == [
+        {"command": "bar"},
+        {"command": "lol"},
+        {"command": "bar"},
+    ]
+
+
+def test_history_mixin_append_to_history(fs):
+    """Test the append_to_history method of the HistoryMixin"""
+    # pylint: disable=invalid-name, protected-access
+
+    history = HistoryMixin()
+
+    # Looks like pyfakefs needs some help with pathlib overrides (we are using
+    # Path().parent in our implementation).
+    fs.create_dir(str(APP_DIR))
+
+    # Write history
+    events = [{"event": "foo"}]
+    history.write_history(events)
+
+    # Append new event
+    history.append_to_history({"event": "bar"})
+    expected = [{"event": "foo"}, {"event": "bar"}]
+    assert HISTORY_FILE.read_text() == json.dumps(expected)
+    assert history._history == expected
+    assert history.history == expected

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -1,0 +1,22 @@
+"""Test fixtures for backends"""
+
+from enum import Enum
+
+
+class NamedClassA:
+    """An example named class"""
+
+    name = "A"
+
+
+class NamedClassB:
+    """A second example named class"""
+
+    name = "B"
+
+
+class NamedClassEnum(Enum):
+    """A named test classes Enum"""
+
+    A = "tests.fixtures.backends.NamedClassA"
+    B = "tests.fixtures.backends.NamedClassB"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,210 @@
+"""Tests for Ralph cli"""
+
+import json
+import sys
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from ralph.backends.storage.ldp import LDPStorage
+from ralph.cli import cli
+
+
+def test_help_option():
+    """Test ralph --help command"""
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert (
+        "-v, --verbosity LVL  Either CRITICAL, ERROR, WARNING, INFO or DEBUG"
+        in result.output
+    )
+
+
+def test_extract_command_usage():
+    """Test ralph extract command usage"""
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "--help"])
+
+    assert result.exit_code == 0
+    assert (
+        "Options:\n"
+        "  -p, --parser [gelf]      Container format parser used to extract events\n"
+        "                           [required]\n\n"
+        "  -c, --chunksize INTEGER  Parse events by chunks of size #\n"
+    ) in result.output
+
+    result = runner.invoke(cli, ["extract"])
+    assert result.exit_code > 0
+    assert (
+        "Error: Missing option '-p' / '--parser'.  Choose from:\n\tgelf."
+    ) in result.output
+
+
+def test_extract_command_with_gelf_parser(gelf_logger):
+    """Test the extract command using the GELF parser"""
+
+    gelf_logger.info('{"username": "foo"}')
+
+    runner = CliRunner()
+    with Path(gelf_logger.handlers[0].stream.name).open() as log_file:
+        gelf_content = log_file.read()
+        result = runner.invoke(cli, ["extract", "-p", "gelf"], input=gelf_content)
+        assert '{"username": "foo"}' in result.output
+
+
+def test_fetch_command_usage():
+    """Test ralph fetch command usage"""
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fetch", "--help"])
+
+    assert result.exit_code == 0
+    assert (
+        "Options:\n"
+        "  ldp storage backend: \n"
+        "    --ldp-stream-id TEXT\n"
+        "    --ldp-service-name TEXT\n"
+        "    --ldp-consumer-key TEXT\n"
+        "    --ldp-application-secret TEXT\n"
+        "    --ldp-application-key TEXT\n"
+        "    --ldp-endpoint TEXT\n"
+        "  -b, --backend [ldp]             Storage backend  [required]\n"
+    ) in result.output
+
+    result = runner.invoke(cli, ["fetch"])
+    assert result.exit_code > 0
+    assert "Error: Missing argument 'ARCHIVE'." in result.output
+
+
+def test_fetch_command_with_ldp_backend(monkeypatch):
+    """Test the fetch command using the LDP backend"""
+
+    archive_content = {"foo": "bar"}
+
+    def mock_read(this, name):
+        """Always return the same archive"""
+        # pylint: disable=unused-argument
+
+        sys.stdout.buffer.write(bytes(json.dumps(archive_content), encoding="utf-8"))
+
+    monkeypatch.setattr(LDPStorage, "read", mock_read)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "fetch",
+            "-b",
+            "ldp",
+            "--ldp-endpoint",
+            "ovh-eu",
+            "a547d9b3-6f2f-4913-a872-cf4efe699a66",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert '{"foo": "bar"}' in result.output
+
+
+def test_list_command_usage():
+    """Test ralph list command usage"""
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--help"])
+
+    assert result.exit_code == 0
+    assert (
+        "Options:\n"
+        "  ldp storage backend: \n"
+        "    --ldp-stream-id TEXT\n"
+        "    --ldp-service-name TEXT\n"
+        "    --ldp-consumer-key TEXT\n"
+        "    --ldp-application-secret TEXT\n"
+        "    --ldp-application-key TEXT\n"
+        "    --ldp-endpoint TEXT\n"
+        "  -b, --backend [ldp]             Storage backend  [required]\n"
+        "  -n, --new / -a, --all           List not fetched (or all) archives\n"
+        "  -D, --details / -I, --ids       Get archives detailled output (JSON)\n"
+    ) in result.output
+
+    result = runner.invoke(cli, ["list"])
+    assert result.exit_code > 0
+    assert (
+        "Error: Missing option '-b' / '--backend'.  Choose from:\n\tldp."
+        in result.output
+    )
+
+
+def test_list_command_with_ldp_backend(monkeypatch):
+    """Test the list command using the LDP backend"""
+
+    archive_list = [
+        "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+        "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+    ]
+    archive_list_details = [
+        {
+            "archiveId": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
+            "createdAt": "2020-06-18T04:38:59.436634+02:00",
+            "filename": "2020-06-16.gz",
+            "md5": "01585b394be0495e38dbb60b20cb40a9",
+            "retrievalDelay": 0,
+            "retrievalState": "sealed",
+            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "size": 67906662,
+        },
+        {
+            "archiveId": "997db3eb-b9ca-485d-810f-b530a6cef7c6",
+            "createdAt": "2020-06-18T04:38:59.436634+02:00",
+            "filename": "2020-06-17.gz",
+            "md5": "01585b394be0495e38dbb60b20cb40a9",
+            "retrievalDelay": 0,
+            "retrievalState": "sealed",
+            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "size": 67906662,
+        },
+    ]
+
+    def mock_list(this, details=False, new=False):
+        """Mock LDP backend list method"""
+        # pylint: disable=unused-argument
+
+        response = archive_list
+        if details:
+            response = archive_list_details
+        if new:
+            response = response[1:]
+        return response
+
+    monkeypatch.setattr(LDPStorage, "list", mock_list)
+
+    runner = CliRunner()
+
+    # List archives with default options
+    result = runner.invoke(cli, ["list", "-b", "ldp", "--ldp-endpoint", "ovh-eu"])
+    assert result.exit_code == 0
+    assert "\n".join(archive_list) in result.output
+
+    # List archives with detailled output
+    result = runner.invoke(cli, ["list", "-b", "ldp", "--ldp-endpoint", "ovh-eu", "-D"])
+    assert result.exit_code == 0
+    assert (
+        "\n".join(json.dumps(detail) for detail in archive_list_details)
+        in result.output
+    )
+
+    # List new archives only
+    result = runner.invoke(cli, ["list", "-b", "ldp", "--ldp-endpoint", "ovh-eu", "-n"])
+    assert result.exit_code == 0
+    assert "997db3eb-b9ca-485d-810f-b530a6cef7c6" in result.output
+    assert "5d5c4c93-04a4-42c5-9860-f51fa4044aa1" not in result.output
+
+    # Edge case: stream contains no archive
+    monkeypatch.setattr(LDPStorage, "list", lambda this, details, new: ())
+    result = runner.invoke(cli, ["list", "-b", "ldp", "--ldp-endpoint", "ovh-eu"])
+    assert result.exit_code == 0
+    assert "Configured ldp backend contains no archive" in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+"""Tests for Ralph utils"""
+
+
+import pytest
+
+from ralph import utils as ralph_utils
+
+from .fixtures.backends import NamedClassEnum
+
+
+def test_import_string():
+    """Test import_string utility taken from Django utilities"""
+
+    with pytest.raises(ImportError, match="foo doesn't look like a module path"):
+        ralph_utils.import_string("foo")
+
+    with pytest.raises(
+        ImportError, match='Module "requests" does not define a "foo" attribute/class'
+    ):
+        ralph_utils.import_string("requests.foo")
+
+    http_status = ralph_utils.import_string("http.HTTPStatus")
+    assert http_status.OK == 200
+
+
+def test_get_class_from_name():
+    """Test get_class_from_name utility"""
+
+    assert ralph_utils.get_class_from_name("A", NamedClassEnum).name == "A"
+    assert ralph_utils.get_class_from_name("B", NamedClassEnum).name == "B"
+    with pytest.raises(ImportError, match="C class is not available"):
+        assert ralph_utils.get_class_from_name("C", NamedClassEnum).name == "B"
+
+
+def test_get_instance_from_class():
+    """Test get_instance_from_class utility"""
+
+    class NamedTestClass:
+        """Named test class"""
+
+        name = "test"
+
+        def __init__(self, force=False, verbose=0):
+            self.force = force
+            self.verbose = verbose
+
+    test = ralph_utils.get_instance_from_class(
+        NamedTestClass, test_force=True, test_verbose=2
+    )
+    assert test.force
+    assert test.verbose == 2
+
+    # Extra parameters are ignored
+    test = ralph_utils.get_instance_from_class(
+        NamedTestClass, test_force=True, test_verbose=2, misc=True
+    )
+    assert test.force
+    assert test.verbose == 2


### PR DESCRIPTION
### Purpose

We need to automate fetching new LDP-stored events and push them to our ES instance. To achieve this, `ralph` should be used as a stream-based CLI that can pull / convert / push learning events from a storage backend to a database backend.

### Proposal

Current work mostly focuses on defining a shared architecture for parsers, storage backends and CLI commands. An example usage follows:

```
$ ralph list -b ldp
ARCHIVE_ID_01
ARCHIVE_ID_02
ARCHIVE_ID_03
ARCHIVE_ID_04
ARCHIVE_ID_05

$ ralph fetch -b ldp ARCHIVE_ID_02 | gunzip | ralph extract -p gelf
{
  ... event ...
}
```

- [x] implement LDP storage backend
- [x] add base CLI structure
- [x] add the `list` command
- [x] add the `fetch` command
- [x] add the `extract` command
- [x] add history management to be able to list only new archives (`list --new`)
- [x] add tests
- [x] document project bootstrapping
- [x] update the changelog :sweat_smile: 