### PR TITLE
⬆️(project) move to a python3 compatible GELF library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,11 +40,11 @@ python_requires = >= 3.7
 dev =
     bandit==1.6.2
     black==19.10b0
-    djehouty==0.1.5
     flake8==3.8.4
     ipdb==0.12.2
     ipython==7.9.0
     isort==4.3.21
+    logging-gelf==0.0.26
     memory-profiler==0.57.0
     pyfakefs==4.1.0
     pylint==2.4.3

--- a/tests/fixtures/logs.py
+++ b/tests/fixtures/logs.py
@@ -6,7 +6,7 @@ from secrets import token_hex
 from tempfile import NamedTemporaryFile
 
 import pytest
-from djehouty.libgelf.formatters import GELFFormatter
+from logging_gelf.formatters import GELFFormatter
 
 
 @pytest.fixture


### PR DESCRIPTION
### Purpose

Djehouty is a legacy library theoretically only compatible with python2. Hat tip to @pyup-bot 

### Proposal

Djehouty has been rewritten by the OVH team to be fully compatible with python3. Let's switch to it even if we only use the GELF formatter for testing.