### PR TITLE
✨(backends) add Elasticsearch database backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,12 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+      - image: elasticsearch:7.8.1
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          discovery.type: single-node
     working_directory: ~/fun
     steps:
       - checkout
@@ -178,7 +184,11 @@ jobs:
             - v1-dependencies-{{ .Revision }}
       - run:
           name: Run tests
-          command: ~/.local/bin/pytest
+          command: |
+            dockerize \
+              -wait tcp://${HOSTNAME}:9200 \
+              -timeout 60s \
+              ~/.local/bin/pytest
 
   # ---- Packaging jobs ----
   package:

--- a/.env.dist
+++ b/.env.dist
@@ -16,3 +16,10 @@ RALPH_APP_DIR=/app/.ralph
 # RALPH_LDP_CONSUMER_KEY=
 # RALPH_LDP_SERVICE_NAME=
 # RALPH_LDP_STREAM_ID=
+
+# ES database backend
+
+# RALPH_ES_HOSTS=http://elasticsearch:9200
+# RALPH_ES_INDEX=statements
+# RALPH_ES_TEST_HOSTS=http://elasticsearch:9200
+# RALPH_ES_TEST_INDEX=test-index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Implement base CLI commands (list, extract, fetch & push) for supported
-  storage backends
+  backends
+- Support for ElasticSearch database backend
 - Support for LDP storage backend
 - Support for FS storage backend
 - Parse (gzipped) tracking logs in GELF format
+
 [unreleased]: https://github.com/openfun/ralph

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_TEST_RUN     = $(COMPOSE_RUN)
 COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app
 
+# -- Elasticsearch
+ES_PROTOCOL = http
+ES_HOST     = localhost
+ES_PORT     = 9200
+ES_INDEX    = statements
+ES_URL      = $(ES_PROTOCOL)://$(ES_HOST):$(ES_PORT)
+
 # ==============================================================================
 # RULES
 
@@ -21,7 +28,8 @@ bootstrap: ## bootstrap the project for development
 bootstrap: \
   .env \
   build \
-  dev
+  dev \
+  es-index
 .PHONY: bootstrap
 build: ## build the app container
 	@$(COMPOSE) build app
@@ -30,6 +38,16 @@ build: ## build the app container
 dev: ## perform editable install from mounted project sources
 	DOCKER_USER=0 docker-compose run --rm app pip install -e ".[dev]"
 .PHONY: dev
+
+down: ## stop and remove backend containers
+	@$(COMPOSE) down
+.PHONY: down
+
+es-index:  ## create elasticsearch index and sample documents
+es-index: run
+	@echo "Creating $(ES_INDEX) index"
+	bin/es index $(ES_INDEX)
+.PHONY: es-index
 
 # Nota bene: Black should come after isort just in case they don't agree...
 lint: ## lint back-end python sources
@@ -70,11 +88,22 @@ logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app
 .PHONY: logs
 
+run: ## starts supported backends servers
+	@$(COMPOSE) up -d
+	@echo "Waiting for elasticsearch to be up and running..."
+	@$(COMPOSE_RUN) dockerize -wait tcp://elasticsearch:9200 -timeout 60s
+.PHONY: run
+
 status: ## an alias for "docker-compose ps"
 	@$(COMPOSE) ps
 .PHONY: status
 
+stop: ## stops backend servers
+	@$(COMPOSE) stop
+.PHONY: stop
+
 test: ## run back-end tests
+test: run
 	bin/pytest
 .PHONY: test
 
@@ -82,4 +111,3 @@ test: ## run back-end tests
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
-

--- a/bin/es
+++ b/bin/es
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+declare ES_PROTOCOL="http"
+declare ES_HOST="localhost"
+declare -i ES_PORT=9200
+declare ES_INDEX="statements"
+declare ES_URL="${ES_PROTOCOL}://${ES_HOST}:${ES_PORT}"
+
+
+function usage(){
+    declare -i exit_code="${1:-0}"
+
+    echo "Usage: bin/es COMMAND
+
+COMMAND:
+
+  index       create elasticsearch index and fake documents
+    "
+
+    exit "${exit_code}"
+}
+
+
+function index(){
+
+  declare data
+  declare index="${1:-${ES_INDEX}}"
+
+  # timestamp in ms (as required by elasticsearch)
+  declare now=$(echo "$(date +%s.%N) * 1000" | bc)
+
+  for i in $(seq 100); do
+    uuid=$(uuidgen)
+    # Simulate one event per minute
+    at=$(echo "${now} - (60 * 1000 * ${i})" | bc)
+    data="${data}
+{\"create\": {\"_index\": \"${index}\", \"_id\": \"${uuid}\"}}
+{\"id\": \"${uuid}\", \"timestamp\": \"${at}\"}
+"
+  done
+
+  curl -X PUT "${ES_URL}/_bulk?pretty" -H "Content-Type: application/json" -d "${data}"
+}
+
+declare action="${1:-usage}"
+
+# Remove current action from arguments array
+if [[ -n "${1}" ]]; then
+  shift
+fi
+
+"${action}" "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,15 @@ services:
       PYLINTHOME: /app/.pylint.d
     volumes:
       - .:/app
+    depends_on:
+      - elasticsearch
+
+  elasticsearch:
+    image: elasticsearch:7.8.1
+    environment:
+      discovery.type: single-node
+    ports:
+      - "9200:9200"
+
+  dockerize:
+    image: jwilder/dockerize

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     click==7.1.2
     click-log==0.3.2
     click-option-group==0.5.1
+    elasticsearch==7.9.1
     ovh==0.5.0
     pandas==1.1.4
     requests==2.25.0

--- a/src/ralph/backends/__init__.py
+++ b/src/ralph/backends/__init__.py
@@ -1,0 +1,10 @@
+"""Backends for Ralph"""
+
+from enum import Enum, auto
+
+
+class BackendTypes(Enum):
+    """Backend types"""
+
+    DATABASE = auto()
+    STORAGE = auto()

--- a/src/ralph/backends/database/__init__.py
+++ b/src/ralph/backends/database/__init__.py
@@ -1,0 +1,4 @@
+"""Database backends for Ralph"""
+
+from .base import BaseDatabase  # noqa: F401
+from .es import ESDatabase  # noqa: F401

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -1,0 +1,17 @@
+"""Base storage backend for Ralph"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseDatabase(ABC):
+    """Base database backend interface"""
+
+    name = "base"
+
+    @abstractmethod
+    def get(self, chunk_size=10):
+        """Read chunk_size records and stream them to stdout"""
+
+    @abstractmethod
+    def put(self, chunk_size=10):
+        """Write chunk_size records from stdin"""

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -1,0 +1,66 @@
+"""Elasticsearch storage backend for Ralph"""
+
+import json
+import logging
+import sys
+
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import scan, streaming_bulk
+
+from .base import BaseDatabase
+
+logger = logging.getLogger(__name__)
+
+
+class ESDatabase(BaseDatabase):
+    """Elasticsearch database backend"""
+
+    name = "es"
+
+    def __init__(self, hosts, index):
+        """Instantiate the Elasticsearch client.
+
+        hosts is supposed to be a list
+
+        """
+
+        self._hosts = hosts
+        self.index = index
+        self.client = Elasticsearch(self._hosts)
+
+    def get(self, chunk_size=500):
+        """Get index documents and stream them"""
+
+        for document in scan(self.client, index=self.index, size=chunk_size):
+            sys.stdout.buffer.write(
+                bytes(json.dumps(document.get("_source")) + "\n", encoding="utf-8")
+            )
+
+    def to_documents(self, stream, get_id):
+        """Convert stream lines to ES documents"""
+
+        for line in stream:
+            item = json.loads(line)
+            yield {
+                "_index": self.index,
+                "_id": get_id(item),
+                "_source": item,
+            }
+
+    def put(self, chunk_size=500):
+        """Write documents streamed from the standard input to the instance index"""
+
+        logger.debug(
+            "Start writing to the %s index (chunk size: %d)", self.index, chunk_size
+        )
+
+        documents = 0
+        for success, action in streaming_bulk(
+            client=self.client,
+            actions=self.to_documents(sys.stdin, lambda d: d.get("id", None)),
+            chunk_size=chunk_size,
+        ):
+            documents += success
+            logger.debug(
+                "Wrote %d documents [action: %s ok: %d]", documents, action, success
+            )

--- a/src/ralph/backends/storage/__init__.py
+++ b/src/ralph/backends/storage/__init__.py
@@ -1,1 +1,4 @@
 """Storage backends for Ralph"""
+
+from .base import BaseStorage  # noqa: F401
+from .ldp import LDPStorage  # noqa: F401

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 from click import get_app_dir
 
-from .utils import import_string
+
+class DatabaseBackends(Enum):
+    """Enumerate active database backend modules.
+
+    Adding an entry to this enum will make it available to the CLI.
+    """
+
+    ES = "ralph.backends.database.es.ESDatabase"
 
 
 class Parsers(Enum):
@@ -29,11 +36,8 @@ class StorageBackends(Enum):
 
 
 APP_DIR = Path(environ.get("RALPH_APP_DIR", get_app_dir("ralph")))
-AVAILABLE_PARSERS = (lambda: (import_string(parser.value).name for parser in Parsers))()
-AVAILABLE_STORAGE_BACKENDS = (
-    lambda: (import_string(backend.value).name for backend in StorageBackends)
-)()
 DEFAULT_GELF_PARSER_CHUNCK_SIZE = 5000
+DEFAULT_BACKEND_CHUNCK_SIZE = 500
 ENVVAR_PREFIX = "RALPH"
 HISTORY_FILE = Path(environ.get("RALPH_HISTORY_FILE", APP_DIR / "history.json"))
 FS_STORAGE_DEFAULT_PATH = Path("./archives")

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -9,3 +9,7 @@ class BackendParameterException(Exception):
 
 class EventKeyError(Exception):
     """Raised when an expected event key has not been found."""
+
+
+class UnsupportedBackendException(Exception):
+    """Raised when trying to use an unsupported backend type"""

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -5,6 +5,10 @@ from importlib import import_module
 
 import click_log
 
+from ralph.backends import BackendTypes
+from ralph.backends.database import BaseDatabase as BaseDatabaseBackend
+from ralph.backends.storage import BaseStorage as BaseStorageBackend
+
 
 # Taken from Django utilities
 # https://docs.djangoproject.com/en/3.1/_modules/django/utils/module_loading/#import_string
@@ -29,11 +33,27 @@ def import_string(dotted_path):
         ) from err
 
 
+def get_backend_type(backend_class):
+    """Get backend type from a backend class"""
+
+    if BaseStorageBackend in backend_class.__mro__:
+        return BackendTypes.STORAGE
+    if BaseDatabaseBackend in backend_class.__mro__:
+        return BackendTypes.DATABASE
+    return None
+
+
+def get_class_names(modules):
+    """Get class name attributes from class modules list"""
+
+    return [import_string(module).name for module in modules]
+
+
 def get_class_from_name(name, modules):
-    """Get class given its name in a module enum"""
+    """Get class given its name in a modules list"""
 
     for module in modules:
-        klass = import_string(module.value)
+        klass = import_string(module)
         if klass.name == name:
             return klass
     raise ImportError(f"{name} class is not available")

--- a/tests/backends/database/test_es.py
+++ b/tests/backends/database/test_es.py
@@ -1,0 +1,128 @@
+"""Tests for Ralph es database backend"""
+
+import json
+import sys
+from collections.abc import Iterable
+from io import BytesIO, StringIO
+from pathlib import Path
+
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import bulk
+
+from ralph.backends.database.es import ESDatabase
+from ralph.defaults import APP_DIR, HISTORY_FILE
+
+from tests.fixtures.backends import ES_TEST_HOSTS, ES_TEST_INDEX
+
+
+def test_es_database_instanciation(es):
+    """Test the ES backend instanciation"""
+    # pylint: disable=invalid-name,unused-argument,protected-access
+
+    assert ESDatabase.name == "es"
+
+    database = ESDatabase(
+        hosts=ES_TEST_HOSTS,
+        index=ES_TEST_INDEX,
+    )
+
+    # When running locally host is 'elasticsearch', while it's localhost when
+    # running from the CI
+    assert any(
+        (
+            "http://elasticsearch:9200" in database._hosts,
+            "http://localhost:9200" in database._hosts,
+        )
+    )
+    assert database.index == ES_TEST_INDEX
+    assert isinstance(database.client, Elasticsearch)
+
+
+def test_to_documents_method(es):
+    """Test to_documents method"""
+    # pylint: disable=invalid-name,unused-argument
+
+    # Create stream data
+    stream = StringIO("\n".join([json.dumps({"id": idx}) for idx in range(10)]))
+    stream.seek(0)
+
+    database = ESDatabase(
+        hosts=ES_TEST_HOSTS,
+        index=ES_TEST_INDEX,
+    )
+    documents = database.to_documents(stream, lambda item: item.get("id"))
+    assert isinstance(documents, Iterable)
+
+    documents = list(documents)
+    assert len(documents) == 10
+    assert documents == [
+        {"_index": database.index, "_id": idx, "_source": {"id": idx}}
+        for idx in range(10)
+    ]
+
+
+def test_get_method(es, monkeypatch):
+    """Test ES get method"""
+    # pylint: disable=invalid-name
+
+    # Insert documents
+    bulk(
+        es,
+        (
+            {"_index": ES_TEST_INDEX, "_id": idx, "_source": {"id": idx}}
+            for idx in range(10)
+        ),
+    )
+    # As we bulk insert documents, the index needs to be refreshed before making
+    # queries.
+    es.indices.refresh(index=ES_TEST_INDEX)
+
+    # Mock stdout stream
+    class MockStdout:
+        """A simple mock for sys.stdout.buffer"""
+
+        buffer = BytesIO()
+
+    mock_stdout = MockStdout()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    database = ESDatabase(
+        hosts=ES_TEST_HOSTS,
+        index=ES_TEST_INDEX,
+    )
+    database.get()
+
+    mock_stdout.buffer.seek(0)
+    documents = [json.loads(line) for line in mock_stdout.buffer.readlines()]
+    assert documents == [{"id": idx} for idx in range(10)]
+
+
+def test_write_method(es, fs, monkeypatch):
+    """Test ES write method"""
+    # pylint: disable=invalid-name
+
+    # Prepare fake file system
+    fs.create_dir(str(APP_DIR))
+    # Force Path instanciation with fake FS
+    history_file = Path(str(HISTORY_FILE))
+    assert not history_file.exists()
+
+    monkeypatch.setattr(
+        "sys.stdin", StringIO("\n".join([json.dumps({"id": idx}) for idx in range(10)]))
+    )
+
+    assert len(es.search(index=ES_TEST_INDEX)["hits"]["hits"]) == 0
+
+    database = ESDatabase(
+        hosts=ES_TEST_HOSTS,
+        index=ES_TEST_INDEX,
+    )
+    database.put(chunk_size=5)
+
+    # As we bulk insert documents, the index needs to be refreshed before making
+    # queries.
+    es.indices.refresh(index=ES_TEST_INDEX)
+
+    hits = es.search(index=ES_TEST_INDEX)["hits"]["hits"]
+    assert len(hits) == 10
+    assert sorted([hit["_source"]["id"] for hit in hits]) == list(range(10))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,5 @@ Module py.test fixtures
 """
 # pylint: disable=unused-import
 
+from .fixtures.backends import es  # noqa: F401
 from .fixtures.logs import gelf_logger  # noqa: F401

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -1,6 +1,16 @@
 """Test fixtures for backends"""
 
+import os
 from enum import Enum
+
+import pytest
+from elasticsearch import Elasticsearch
+
+# Elasticsearch backend defaults
+ES_TEST_INDEX = os.environ.get("RALPH_ES_TEST_INDEX", "test-index")
+ES_TEST_HOSTS = os.environ.get("RALPH_ES_TEST_HOSTS", "http://localhost:9200").split(
+    ","
+)
 
 
 class NamedClassA:
@@ -20,3 +30,14 @@ class NamedClassEnum(Enum):
 
     A = "tests.fixtures.backends.NamedClassA"
     B = "tests.fixtures.backends.NamedClassB"
+
+
+@pytest.fixture
+def es():
+    """Create / delete an ElasticSearch test index and yield an instanciated client"""
+    # pylint: disable=invalid-name
+
+    client = Elasticsearch(ES_TEST_HOSTS)
+    client.indices.create(index=ES_TEST_INDEX, ignore=400)
+    yield client
+    client.indices.delete(index=ES_TEST_INDEX)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,9 @@
 import pytest
 
 from ralph import utils as ralph_utils
+from ralph.backends import BackendTypes
+from ralph.backends.database import ESDatabase
+from ralph.backends.storage import LDPStorage
 
 from .fixtures.backends import NamedClassEnum
 
@@ -23,13 +26,48 @@ def test_import_string():
     assert http_status.OK == 200
 
 
+def test_get_backend_type():
+    """Test get_backend_type utility"""
+
+    class TestBackend:
+        """Dumb test backend that does not inherit from a supported backend type"""
+
+    assert ralph_utils.get_backend_type(ESDatabase) == BackendTypes.DATABASE
+    assert ralph_utils.get_backend_type(LDPStorage) == BackendTypes.STORAGE
+    assert ralph_utils.get_backend_type(TestBackend) is None
+
+
+def test_get_class_names():
+    """Test get_class_names utility"""
+
+    assert ralph_utils.get_class_names([module.value for module in NamedClassEnum]) == [
+        "A",
+        "B",
+    ]
+
+
 def test_get_class_from_name():
     """Test get_class_from_name utility"""
 
-    assert ralph_utils.get_class_from_name("A", NamedClassEnum).name == "A"
-    assert ralph_utils.get_class_from_name("B", NamedClassEnum).name == "B"
+    assert (
+        ralph_utils.get_class_from_name(
+            "A", [module.value for module in NamedClassEnum]
+        ).name
+        == "A"
+    )
+    assert (
+        ralph_utils.get_class_from_name(
+            "B", [module.value for module in NamedClassEnum]
+        ).name
+        == "B"
+    )
     with pytest.raises(ImportError, match="C class is not available"):
-        assert ralph_utils.get_class_from_name("C", NamedClassEnum).name == "B"
+        assert (
+            ralph_utils.get_class_from_name(
+                "C", [module.value for module in NamedClassEnum]
+            ).name
+            == "B"
+        )
 
 
 def test_get_instance_from_class():


### PR DESCRIPTION
## Purpose

Ralph should be able to publish or get statements from database backends; our first implementation of such support should be Elasticsearch since its used in production to mine collected xAPI statements.

## Proposal

- [x] add `ESDatabase` backend
- [x] adapt the `fetch` command to support both database & storage backends ; to get all database records (from an index, a collection, a table depending on supported backend)
- [x] adapt the `push` command to support both database & storage backends
- [x] add an `elasticsearch` service in the CI to run tests

Fix #16 
Fix #17 