### PR TITLE
Custom logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,8 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+        environment:
+          RALPH_APP_DIR: ~/fun/.ralph
       - image: elasticsearch:7.8.1
         auth:
           username: $DOCKER_USER

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ venv.bak/
 # Logs
 *.log
 
-# history
+# History
 .ralph
 
 # Test & lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Support for LDP storage backend
 - Support for FS storage backend
 - Parse (gzipped) tracking logs in GELF format
+- Support for application's configuration file
 
 [unreleased]: https://github.com/openfun/ralph

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ dev =
     pylint==2.6.0
     pytest==6.1.2
     pytest-cov==2.10.1
+    pyyaml==5.3.1
 ci =
     twine==3.2.0
 

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,0 +1,3 @@
+"""Ralph module"""
+
+__version__ = "0.0.1"

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -19,6 +19,7 @@ from ralph.defaults import (
     StorageBackends,
 )
 from ralph.exceptions import UnsupportedBackendException
+from ralph.logger import configure_logging
 from ralph.utils import (
     get_backend_type,
     get_class_from_name,
@@ -42,6 +43,8 @@ BACKENDS = (lambda: DATABASE_BACKENDS + STORAGE_BACKENDS)()
 @click_log.simple_verbosity_option(get_root_logger())
 def cli():
     """Ralph is a stream-based tool to play with your logs"""
+
+    configure_logging()
 
 
 def backends_options(name=None, backends=None):

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -4,7 +4,10 @@ from enum import Enum
 from os import environ
 from pathlib import Path
 
+import yaml
 from click import get_app_dir
+
+from ralph.exceptions import ConfigurationException
 
 
 class DatabaseBackends(Enum):
@@ -35,9 +38,66 @@ class StorageBackends(Enum):
     FS = "ralph.backends.storage.fs.FSStorage"
 
 
+def load_config(config_file_path):
+    """Return a dictionnary representing Ralph's configuration"""
+
+    try:
+        with open(config_file_path) as config_file:
+            return yaml.safe_load(config_file)
+    except yaml.scanner.ScannerError as exc:
+        raise ConfigurationException("Configuration could not be loaded") from exc
+    except FileNotFoundError:
+        return None
+
+
+def config(key, default_value):
+    """
+    Get a value based on its key returning the first of (in order):
+        1. Environment
+        2. Config file
+        3. default_value
+    """
+
+    value = environ.get(key, None)
+    if value is not None:
+        return value
+
+    if CONFIG is not None and key in CONFIG:
+        return CONFIG[key]
+
+    return default_value
+
+
+DEFAULT_LOGGING_CONFIG = {
+    "version": 1,
+    "propagate": True,
+    "formatters": {
+        "ralph": {"format": "%(asctime)-23s %(levelname)-8s %(name)-8s %(message)s"},
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "stream": "ext://sys.stderr",
+            "formatter": "ralph",
+        },
+    },
+    "loggers": {
+        "ralph": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+    },
+}
+
 APP_DIR = Path(environ.get("RALPH_APP_DIR", get_app_dir("ralph")))
-DEFAULT_GELF_PARSER_CHUNCK_SIZE = 5000
-DEFAULT_BACKEND_CHUNCK_SIZE = 500
+CONFIG_FILE = APP_DIR / "config.yml"
+CONFIG = load_config(CONFIG_FILE)
 ENVVAR_PREFIX = "RALPH"
-HISTORY_FILE = Path(environ.get("RALPH_HISTORY_FILE", APP_DIR / "history.json"))
-FS_STORAGE_DEFAULT_PATH = Path("./archives")
+DEFAULT_GELF_PARSER_CHUNCK_SIZE = config("RALPH_DEFAULT_GELF_PARSER_CHUNCK_SIZE", 5000)
+DEFAULT_BACKEND_CHUNCK_SIZE = config("RALPH_DEFAULT_BACKEND_CHUNCK_SIZE", 500)
+FS_STORAGE_DEFAULT_PATH = Path(
+    config("RALPH_FS_STORAGE_DEFAULT_PATH", APP_DIR / "archives")
+)
+HISTORY_FILE = Path(config("RALPH_HISTORY_FILE", APP_DIR / "history.json"))
+LOGGING_CONFIG = config("RALPH_LOGGING", DEFAULT_LOGGING_CONFIG)

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -7,6 +7,10 @@ class BackendParameterException(Exception):
     """Raised when a backend parameter value is not valid"""
 
 
+class ConfigurationException(Exception):
+    """Raised when the configuration is not valid"""
+
+
 class EventKeyError(Exception):
     """Raised when an expected event key has not been found."""
 

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -1,0 +1,15 @@
+""""Ralph logging manager"""
+
+from logging.config import dictConfig
+
+from ralph.defaults import LOGGING_CONFIG
+from ralph.exceptions import ConfigurationException
+
+
+def configure_logging():
+    """Set up Ralph logging configuration"""
+
+    try:
+        dictConfig(LOGGING_CONFIG)
+    except Exception as error:
+        raise ConfigurationException("Improperly configured logging") from error

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,79 @@
+"""
+Tests for Ralph's configuration loading
+"""
+
+from os import environ
+
+import pytest
+
+import ralph.defaults
+from ralph.defaults import APP_DIR, config, load_config
+from ralph.exceptions import ConfigurationException
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_config_default(fs, monkeypatch):
+    """Test that when no value is given, the default parameter is chosen"""
+
+    assert environ.get("RALPH_HISTORY_FILE", None) is None
+    assert config("RALPH_HISTORY_FILE", "history_default") == "history_default"
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_config_file(fs, monkeypatch):
+    """Test that when the environment and command-line arguments don't specify a
+    value, the value from the config file is taken instead"""
+
+    config_mock = {"RALPH_HISTORY_FILE": "history_config_file"}
+
+    monkeypatch.setattr(ralph.defaults, "CONFIG", config_mock)
+
+    assert environ.get("RALPH_HISTORY_FILE", None) is None
+    assert config("RALPH_HISTORY_FILE", "history_default") == "history_config_file"
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_config_env(fs, monkeypatch):
+    """Test that when the environment specifies a value, it is chosen instead of
+    the configuration file's value"""
+
+    config_mock = {"RALPH_HISTORY_FILE": "history_config_file"}
+
+    monkeypatch.setattr(ralph.defaults, "CONFIG", config_mock)
+    monkeypatch.setenv("RALPH_HISTORY_FILE", "history_env")
+
+    assert config("RALPH_HISTORY_FILE", "history_default") == "history_env"
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_load_config_no_config(fs, monkeypatch):
+    """Test that loading when no configuration file is available results in
+    load_config returning None"""
+
+    config_path = APP_DIR / "config.yml"
+
+    assert load_config(config_path) is None
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_load_config_correct_config(fs, monkeypatch):
+    """Test that loading a correct configuration file works as intended"""
+
+    config_path = APP_DIR / "config.yml"
+
+    fs.create_file(config_path, contents="DEFAULT_BACKEND_CHUNCK_SIZE: 5678")
+
+    assert load_config(config_path)["DEFAULT_BACKEND_CHUNCK_SIZE"] == 5678
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_load_config_incorrect_config(fs, monkeypatch):
+    """Test that loading an incorrect configuration file raises a configuration
+    exception"""
+
+    config_path = APP_DIR / "config.yml"
+
+    fs.create_file(config_path, contents="A: B: C")
+
+    with pytest.raises(ConfigurationException):
+        load_config(config_path)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,84 @@
+"""
+Tests for the ralph.logger module
+"""
+
+import pytest
+from click.testing import CliRunner
+
+import ralph.logger
+from ralph.cli import cli
+from ralph.exceptions import ConfigurationException
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_logger_exists(fs, monkeypatch):
+    """Test the logging system when a correct configuration is provided"""
+
+    mock_default_config = {
+        "version": 1,
+        "propagate": True,
+        "formatters": {
+            "ralph_format": {
+                "format": "%(asctime)-23s %(levelname)-8s %(name)-8s %(message)s"
+            },
+        },
+        "handlers": {
+            "ralph_stderr": {
+                "class": "logging.StreamHandler",
+                "level": "DEBUG",
+                "stream": "ext://sys.stderr",
+                "formatter": "ralph_format",
+            },
+        },
+        "loggers": {
+            "ralph": {
+                "handlers": ["ralph_stderr"],
+                "level": "DEBUG",
+            },
+        },
+    }
+
+    fs.create_dir("/dev")
+
+    monkeypatch.setattr(ralph.logger, "LOGGING_CONFIG", mock_default_config)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["push", "-b", "fs", "test_file"],
+        input="test input",
+    )
+
+    assert result.exit_code == 0
+    assert "Pushing archive test_file to the configured fs backend" in result.output
+    assert "Backend parameters:" in result.output
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_logger_no_config(fs, monkeypatch):
+    """Test that an error occurs when no logging configuration exists"""
+
+    mock_default_config = None
+
+    monkeypatch.setattr(ralph.logger, "LOGGING_CONFIG", mock_default_config)
+
+    runner = CliRunner()
+
+    with pytest.raises(ConfigurationException):
+        result = runner.invoke(cli, ["list", "-b", "fs"], catch_exceptions=False)
+        assert result.exit_code == 1
+
+
+# pylint: disable=invalid-name, unused-argument
+def test_logger_bad_config(fs, monkeypatch):
+    """Test that an error occurs when a logging is improperly configured"""
+
+    mock_default_config = "this is not a valid json"
+
+    monkeypatch.setattr(ralph.logger, "LOGGING_CONFIG", mock_default_config)
+
+    runner = CliRunner()
+
+    with pytest.raises(ConfigurationException):
+        result = runner.invoke(cli, ["list", "-b", "fs"], catch_exceptions=False)
+        assert result.exit_code == 1


### PR DESCRIPTION
## Purpose

Ralph logs were quite simple and could not be configured

## Proposal

Using python's standard `logging` library, the logging can be customized from a configuration file, `defaults.py`