### PR TITLE
Add --no-deps argument to ralph

### DIFF
--- a/bin/ralph
+++ b/bin/ralph
@@ -3,4 +3,10 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm -T app ralph ${@}
+NO_DEPS=""
+if [ "$1" == "--no-deps" ]; then
+    NO_DEPS="--no-deps"
+    shift
+fi
+
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm -T ${NO_DEPS} app ralph ${@}


### PR DESCRIPTION
### Purpose

Some ralph commands do not require additional docker dependencies

Example: extract command or push -b fs command

Also, when docker-compose loads additional dependencies it writes to the standard output, which inferences ralph commands reading from the standard output.

Example: stream | ralph extract ... | read output
```
Starting ralph_elasticsearch_1 ... done
extracted stream
```

### Proposal

- [X] add --no-deps argument to launch ralph without docker dependencies (./bin/ralph --no-deps)
