### PR TITLE
💚(circle) allow docker hub anonymous mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,10 @@ docker-login: &docker-login
   #   - DOCKER_HUB_PASSWORD
   run:
     name: Login to DockerHub
-    command: echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin
+    command: >
+      test -n "$DOCKER_HUB_USER" &&
+        echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin ||
+        echo "Docker Hub anonymous mode"
 
 version: 2
 jobs:


### PR DESCRIPTION
## Purpose

External contributions cannot inject secret environment variables in the CI execution context, leading some jobs to fail when a DockerHub login is required.

## Proposal

We should allow anonymous docker images pulling to mitigate the issue. It should work as long as CircleCI has an agreement with DockerHub to prevent bandwidth restrictions from their IPs.
