### PR TITLE
✨(cli) allow to force push for database backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Support for Swift storage backend
+- Use the `push` command `--force` option to ignore ES bulk import errors
 
 ### Changed
 

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -13,5 +13,5 @@ class BaseDatabase(ABC):
         """Read chunk_size records and stream them to stdout"""
 
     @abstractmethod
-    def put(self, chunk_size=10):
+    def put(self, chunk_size=10, ignore_errors=False):
         """Write chunk_size records from stdin"""

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -47,7 +47,7 @@ class ESDatabase(BaseDatabase):
                 "_source": item,
             }
 
-    def put(self, chunk_size=500):
+    def put(self, chunk_size=500, ignore_errors=False):
         """Write documents streamed from the standard input to the instance index"""
 
         logger.debug(
@@ -59,6 +59,7 @@ class ESDatabase(BaseDatabase):
             client=self.client,
             actions=self.to_documents(sys.stdin, lambda d: d.get("id", None)),
             chunk_size=chunk_size,
+            raise_on_error=(not ignore_errors),
         ):
             documents += success
             logger.debug(

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -180,9 +180,20 @@ def fetch(backend, archive, chunk_size, **options):
     help="Get events by chunks of size #",
 )
 @click.option(
-    "-f", "--force", default=False, is_flag=True, help="Overwrite existing archives"
+    "-f",
+    "--force",
+    default=False,
+    is_flag=True,
+    help="Overwrite existing archives or records",
 )
-def push(backend, archive, chunk_size, force, **options):
+@click.option(
+    "-I",
+    "--ignore-errors",
+    default=False,
+    is_flag=True,
+    help="Continue writing regardless of raised errors",
+)
+def push(backend, archive, chunk_size, force, ignore_errors, **options):
     """Push an archive to a configured backend"""
 
     logger.info("Pushing archive %s to the configured %s backend", archive, backend)
@@ -195,7 +206,7 @@ def push(backend, archive, chunk_size, force, **options):
     if backend_type == BackendTypes.STORAGE:
         backend.write(archive, overwrite=force)
     elif backend_type == BackendTypes.DATABASE:
-        backend.put(chunk_size=chunk_size)
+        backend.put(chunk_size=chunk_size, ignore_errors=ignore_errors)
     elif backend_type is None:
         msg = "Cannot find an implemented backend type for backend %s"
         logger.error(msg, backend)


### PR DESCRIPTION
## Purpose

When bulk importing documents in ES, if a document is badly formatted (e.g. with mistyped fields), the bulk importation stops after the first chunk importation failure.

## Proposal

We now allow to force the importation regardless of indexation errors.
