### PR TITLE
✨(backends:es) add support for supported client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Support for Swift storage backend
 - Use the `push` command `--force` option to ignore ES bulk import errors
+- The elasticsearch backend now accepts passing all supported client options
 
 ### Changed
 

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -17,16 +17,21 @@ class ESDatabase(BaseDatabase):
 
     name = "es"
 
-    def __init__(self, hosts, index, verify_certs=True):
+    def __init__(self, hosts: list, index: str, client_options: dict = None):
         """Instantiate the Elasticsearch client.
 
-        hosts is supposed to be a list
+        hosts: supposed to be a list
+        index: the index name
+        es_client_options: a dict of valid options for the Elasticsearch class
+                           initialization
 
         """
+        if client_options is None:
+            client_options = {}
 
         self._hosts = hosts
         self.index = index
-        self.client = Elasticsearch(self._hosts, verify_certs=verify_certs)
+        self.client = Elasticsearch(self._hosts, **client_options)
 
     def get(self, chunk_size=500):
         """Get index documents and stream them"""


### PR DESCRIPTION
## Purpose

The elasticsearch client supports various options to support a lot of connection scenarii with an elasticsearch cluster. Unfortunately current implementation of ralph is restricted to the `verify_certs` option only.

## Proposal

We now also support passing those options from the CLI using coma-separated key=value pairs:

```
$ ralph push --backend es --es-client-options ca_certs=/path/to/ca/certs,client_cert=/path/to/client/cert.pem
```
