### PR TITLE
🔖(minor) bump release to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2021-02-04
+
 ### Added
 
 - Support for Swift storage backend
-- Use the `push` command `--force` option to ignore ES bulk import errors
+- Use the `push` command `--ignore-errors` option to ignore ES bulk import
+  errors
 - The elasticsearch backend now accepts passing all supported client options
 
 ### Changed
@@ -34,5 +37,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/v1.0.0...master
+[unreleased]: https://github.com/openfun/v1.1.0...master
+[1.1.0]: https://github.com/openfun/ashley/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/openfun/ashley/compare/3d03d85...v1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 1.0.0
+version = 1.1.0
 description = An OpenEdx's tracking logs processor to feed your LRS
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module"""
 
-__version__ = "0.0.1"
+__version__ = "1.1.0"


### PR DESCRIPTION
### Added

- Support for Swift storage backend
- Use the `push` command `--ignore-errors` option to ignore ES bulk import errors
- The elasticsearch backend now accepts passing all supported client options

### Changed

- Remove click_log package dependency
- Upgrade pyyaml to 5.4.1
- Upgrade pandas to 1.2.1
