### PR TITLE
✨(models) add edX page_close browser event model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - EdX server event pydantic model and factory
+- EdX page_close browser event pydantic model and factory
 
 ### Fixed
 

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,0 +1,45 @@
+"""Browser event model definitions"""
+
+from pathlib import Path
+from typing import Literal, Union
+
+from pydantic import AnyUrl, constr
+
+from .base import BaseEventModel
+
+
+class BaseBrowserEventModel(BaseEventModel):
+    """Represents the base browser event model all browser events inherit from.
+
+    This type of event is triggered on (XHR) POST/GET requests to the `/event` URL.
+
+    Attributes:
+        event_source (str): Consists of the value `browser`.
+        page (Path): Consists of the URL (with hostname) of the visited page.
+            Retrieved with:
+                `window.location.href` from the JavaScript front-end.
+        session (str): Consists of the md5 encrypted Django session key or an empty string
+    """
+
+    event_source: Literal["browser"]
+    page: Union[AnyUrl, Path]
+    session: Union[constr(regex=r"^[a-f0-9]{32}$"), Literal[""]]  # noqa: F722
+
+
+class PageCloseBrowserEventModel(BaseBrowserEventModel):
+    """Represents the page_close browser event.
+
+    This type of event is triggered when the user navigates to the next page
+    or closes the browser window (when the JavaScript `window.onunload` event
+    is called).
+
+    Attributes:
+        name (str): Consists of the value `page_close`
+        event_type (str): Consists of the value `page_close`
+        event (str): Consists of the string value `{}`
+    """
+
+    # pylint: disable=unsubscriptable-object
+    name: Literal["page_close"]
+    event_type: Literal["page_close"]
+    event: Literal["{}"]

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -36,11 +36,11 @@ class NamedClassEnum(Enum):
 
 @pytest.fixture
 def es():
-    """Create / delete an ElasticSearch test index and yield an instanciated client"""
+    """Create / delete an ElasticSearch test index and yield an instantiated client"""
     # pylint: disable=invalid-name
 
     client = Elasticsearch(ES_TEST_HOSTS)
-    client.indices.create(index=ES_TEST_INDEX, ignore=400)
+    client.indices.create(index=ES_TEST_INDEX)
     yield client
     client.indices.delete(index=ES_TEST_INDEX)
 

--- a/tests/fixtures/edx/browser.py
+++ b/tests/fixtures/edx/browser.py
@@ -1,0 +1,27 @@
+"""Browser event factory definitions"""
+
+from ralph.models.edx.browser import BaseBrowserEventModel, PageCloseBrowserEventModel
+
+from .base import FAKE, BaseEventFactory
+
+
+class BaseBrowserEventFactory(BaseEventFactory):
+    """Base browser event factory inherited by all browser event factories"""
+
+    class Meta:  # pylint: disable=missing-class-docstring
+        model = BaseBrowserEventModel
+
+    event_source = "browser"
+    page = FAKE.url()
+    session = FAKE.md5(raw_output=False)
+
+
+class PageCloseBrowserEventFactory(BaseBrowserEventFactory):
+    """Factory for the PageCloseBrowserEventModel"""
+
+    class Meta:  # pylint: disable=missing-class-docstring
+        model = PageCloseBrowserEventModel
+
+    name = "page_close"
+    event_type = "page_close"
+    event = "{}"

--- a/tests/models/edx/test_browser.py
+++ b/tests/models/edx/test_browser.py
@@ -1,0 +1,77 @@
+"""Tests for the browser event models"""
+
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from tests.fixtures.edx.browser import (
+    BaseBrowserEventFactory,
+    PageCloseBrowserEventFactory,
+)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"event_source": "browser"},
+        {"session": ""},
+        {"session": "cc7ee04f8e4eb7e84f8c4c441cc78f40"},
+        {"page": "https://www.fun-mooc.fr/"},
+        {"page": "/this/is/a/valid/relative/url"},
+        {"page": "/"},
+    ],
+)
+def test_models_edx_browser_base_browser_event_with_valid_content(kwargs):
+    """Test that a valid base browser event does not raise a ValidationError."""
+
+    try:
+        BaseBrowserEventFactory(**kwargs)
+    except ValidationError:
+        pytest.fail(
+            f"Valid base browser event with {kwargs} should not raise exceptions"
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        ({"event_source": "not_browser"}, "unexpected value; permitted: 'browser'"),
+        ({"session": "less_than_32_characters"}, "string does not match regex"),
+        (
+            {"session": "session_more_than_32_character_long"},
+            "string does not match regex",
+        ),
+        ({"session": None}, "not an allowed value"),
+        ({"page": None}, "not an allowed value"),
+    ],
+)
+def test_models_edx_browser_base_browser_event_with_invalid_content(kwargs, error):
+    """Test that an invalid base browser event raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        BaseBrowserEventFactory(**kwargs)
+
+
+def test_models_edx_browser_page_close_browser_event_with_valid_content():
+    """Test that a valid page_close browser event does not raise a ValidationError."""
+
+    try:
+        PageCloseBrowserEventFactory()
+    except ValidationError:
+        pytest.fail("Valid page_close browser event should not raise exceptions")
+
+
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        ({"name": "close"}, "unexpected value; permitted: 'page_close'"),
+        ({"event_type": "close"}, "unexpected value; permitted: 'page_close'"),
+        ({"event": ""}, "unexpected value; permitted: '{}'"),
+    ],
+)
+def test_models_edx_browser_page_close_browser_event_with_invalid_content(
+    kwargs, error
+):
+    """Test that an invalid page_close browser event raises a ValidationError."""
+
+    with pytest.raises(ValidationError, match=error):
+        PageCloseBrowserEventFactory(**kwargs)


### PR DESCRIPTION
## Purpose

The edX page_close browser events are the most simple and common browser events in the edX tracking logs. We want to validate them.

## Proposal

- [x] PageCloseBrowserEventModel
- [x] PageCloseBrowserEventFactory
- [x] Tests
