### PR TITLE
➖(parsers) remove pandas dependency in GELF parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Tray: add missing Swift variables in the secret
 - Tray: fix pods anti-affinity selector
 
+### Removed
+
+- `pandas` is no longer required
+
 ## [1.1.0] - 2021-02-04
 
 ### Added
@@ -29,9 +33,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Remove click_log package dependency
 - Upgrade pyyaml to 5.4.1
 - Upgrade pandas to 1.2.1
+
+### Removed
+
+- `click_log` is no longer required as we are able to configure logging
 
 ## [1.0.0] - 2021-01-13
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     click-option-group==0.5.2
     elasticsearch==7.10.1
     ovh==0.5.0
-    pandas==1.2.1
     pydantic==1.7.3
     python-keystoneclient==4.2.0
     python-swiftclient==3.11.0

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -4,19 +4,24 @@ Ralph tracking logs filters.
 from .exceptions import EventKeyError
 
 
-def anonymous(events):
+def anonymous(event):
     """Remove anonymous events.
 
     Args:
-        events (DataFrame): events to filter
+        event (dict): event to filter
 
     Returns:
-        Filtered pandas DataFrame.
+        event (dict): when event is not anonymous
+        None: otherwise
+
+    Raises:
+        EventKeyError: When the event does not contain the `username` key.
 
     """
 
-    if events.get("username", None) is None:
-        raise EventKeyError(
-            "Cannot filter anonymous filters without 'username' column."
-        )
-    return events.loc[lambda df: df["username"] != "", :]
+    if "username" not in event:
+        raise EventKeyError("Cannot filter anonymous event without 'username' key.")
+    if not event.get("username", ""):
+        return None
+
+    return event

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,7 @@
 """
 Tests for the ralph.filters module
 """
-import pandas as pd
+
 import pytest
 
 from ralph import filters
@@ -9,19 +9,19 @@ from ralph.exceptions import EventKeyError
 
 
 def test_anonymous_with_empty_events():
-    """Test the anonymous filter when input DataFrame has not the expected
+    """Test the anonymous filter when input dict has not the expected
     'username' key.
     """
 
-    events = pd.DataFrame()
+    event = {}
     with pytest.raises(EventKeyError):
-        filters.anonymous(events)
+        filters.anonymous(event)
 
 
 def test_anonymous_filtering():
     """Test anonymous filtering reliability."""
 
-    events = pd.DataFrame({"username": ["john", ""]})
-    assert len(events) == 2
-    assert len(filters.anonymous(events)) == 1
-    assert filters.anonymous(events).equals(pd.DataFrame({"username": ["john"]}))
+    event = {"username": "john"}
+    anonymous_event = {"username": ""}
+    assert filters.anonymous(event) == event
+    assert filters.anonymous(anonymous_event) is None

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -2,34 +2,24 @@
 Tests for ralph.parsers module.
 """
 import gzip
+import logging
 import shutil
+from io import StringIO
 
 import pytest
 
 from ralph.parsers import GELFParser
 
 
-def test_gelfparser_parse_non_existing_file():
-    """Test the GELFParser with a file path that does not exist."""
-
-    parser = GELFParser()
-
-    # Input log file does not exists
-    with pytest.raises(OSError):
-        next(parser.parse("/i/do/not/exist"))
-
-
 # pylint: disable=invalid-name
-def test_gelfparser_parse_empty_file(fs):
+def test_gelfparser_parse_empty_file():
     """Test the GELFParser parsing with an empty file."""
 
     parser = GELFParser()
 
-    # Input log file is empty
-    empty_file_path = "/var/log/empty"
-    fs.create_file(empty_file_path)
+    empty_file = StringIO()
     with pytest.raises(StopIteration):
-        next(parser.parse(empty_file_path))
+        next(parser.parse(empty_file))
 
 
 def test_gelfparser_parse_raw_file(gelf_logger):
@@ -41,7 +31,9 @@ def test_gelfparser_parse_raw_file(gelf_logger):
     gelf_logger.info('{"username": "foo"}')
     gelf_logger.info('{"username": ""}')
 
-    events = list(parser.parse(gelf_logger.handlers[0].stream.name))
+    with open(gelf_logger.handlers[0].stream.name) as stream:
+        events = list(parser.parse(stream))
+
     assert len(events) == 2
     assert events[0] == '{"username": "foo"}'
     assert events[1] == '{"username": ""}'
@@ -62,41 +54,99 @@ def test_gelfparser_parse_gzipped_file(fs, gelf_logger):
             shutil.copyfileobj(log_file, gzipped_log_file)
 
     parser = GELFParser()
-    events = list(parser.parse(gelf_logger.handlers[0].stream.name))
+    with open(gelf_logger.handlers[0].stream.name) as stream:
+        events = list(parser.parse(stream))
+
     assert len(events) == 2
     assert events[0] == '{"username": "foo"}'
     assert events[1] == '{"username": "bar"}'
 
 
-# pylint: disable=invalid-name,unused-argument
-def test_gelfparser_parse_with_various_chunksizes(fs, gelf_logger):
-    """Test the GELFParser parsing using different chunksizes."""
+def test_gelfparser_parse_partially_invalid_file(caplog):
+    """Test the GELFParser with a file containing invalid JSON strings"""
 
-    gelf_logger.info('{"username": "foo"}')
-    gelf_logger.info('{"username": "bar"}')
-    gelf_logger.info('{"username": "baz"}')
-    gelf_logger.info('{"username": "lol"}')
+    with StringIO() as file:
+        file.writelines(
+            [
+                # This is invalid gelf but we assume it's valid in our case
+                '{"short_message": "This seems valid."}\n',
+                # Invalid json
+                "{ This is not valid json and raises json.decoder.JSONDecodeError\n",
+                # Valid json but invalid gelf - raises KeyError: key "short_message" not found
+                "{}\n",
+                # As above but raises TypeError: list indices must be integers or slices, not str
+                "[]\n",
+                # Another assumed valid gelf
+                '{"short_message": {"username": "This seems valid too."}}\n',
+            ]
+        )
 
-    parser = GELFParser()
-    events = list(parser.parse(gelf_logger.handlers[0].stream.name, chunksize=1))
-    assert len(events) == 4
-    assert events[0] == '{"username": "foo"}'
-    assert events[1] == '{"username": "bar"}'
-    assert events[2] == '{"username": "baz"}'
-    assert events[3] == '{"username": "lol"}'
+        file.seek(0)
+        parser = GELFParser()
+        events = list(parser.parse(file))
 
-    parser = GELFParser()
-    events = list(parser.parse(gelf_logger.handlers[0].stream.name, chunksize=2))
-    assert len(events) == 4
-    assert events[0] == '{"username": "foo"}'
-    assert events[1] == '{"username": "bar"}'
-    assert events[2] == '{"username": "baz"}'
-    assert events[3] == '{"username": "lol"}'
+    assert len(events) == 2
+    assert events[0] == "This seems valid."
+    assert events[1] == {"username": "This seems valid too."}
 
-    parser = GELFParser()
-    events = list(parser.parse(gelf_logger.handlers[0].stream.name, chunksize=10))
-    assert len(events) == 4
-    assert events[0] == '{"username": "foo"}'
-    assert events[1] == '{"username": "bar"}'
-    assert events[2] == '{"username": "baz"}'
-    assert events[3] == '{"username": "lol"}'
+    caplog.clear()
+    with StringIO() as file:
+        file.write("{ This is not valid json and raises json.decoder.JSONDecodeError\n")
+        file.seek(0)
+        parser = GELFParser()
+        with caplog.at_level(logging.DEBUG):
+            events = list(parser.parse(file))
+
+    assert len(events) == 0
+    assert (
+        "ralph.parsers",
+        logging.ERROR,
+        "Input event '{ This is not valid json and raises json.decoder.JSONDecodeError\n' "
+        "is not a valid JSON string! It will be ignored.",
+    ) in caplog.record_tuples
+    assert (
+        "ralph.parsers",
+        logging.DEBUG,
+        "Raised error was: Expecting property name enclosed in double quotes: "
+        "line 1 column 3 (char 2)",
+    ) in caplog.record_tuples
+
+    caplog.clear()
+    with StringIO() as file:
+        file.write("{}")
+        file.seek(0)
+        parser = GELFParser()
+        with caplog.at_level(logging.DEBUG):
+            events = list(parser.parse(file))
+
+    assert len(events) == 0
+    assert (
+        "ralph.parsers",
+        logging.ERROR,
+        "Input event '{}' doesn't comply with GELF format! It will be ignored.",
+    ) in caplog.record_tuples
+    assert (
+        "ralph.parsers",
+        logging.DEBUG,
+        "Raised error was: 'short_message'",
+    ) in caplog.record_tuples
+
+    caplog.clear()
+    with StringIO() as file:
+        file.write("[]")
+        file.seek(0)
+        parser = GELFParser()
+        with caplog.at_level(logging.DEBUG):
+            events = list(parser.parse(file))
+
+    assert len(events) == 0
+    assert (
+        "ralph.parsers",
+        logging.ERROR,
+        "Input event '[]' is not a valid JSON string! It will be ignored.",
+    ) in caplog.record_tuples
+    assert (
+        "ralph.parsers",
+        logging.DEBUG,
+        "Raised error was: list indices must be integers or slices, not str",
+    ) in caplog.record_tuples


### PR DESCRIPTION
## Purpose

Pandas was introduced as a Ralph dependency for preliminary performance assessment and is now only used in the GELF parser. We think it's not worth it to have such dependency for a small use case.

## Proposal

The pandas dependancy have been completely removed and `json.loads()` is used instead of `dataframe` in the GELF parser.
`parsers` [code](https://github.com/SergioSim/ralph/blob/55b088b47ba0ccc1df1eae0102be6c6ba811ebe8/src/ralph/parsers.py) and [tests](https://github.com/SergioSim/ralph/blob/55b088b47ba0ccc1df1eae0102be6c6ba811ebe8/tests/test_parsers.py) have been readapted from commit `55b088b47ba0ccc1df1eae0102be6c6ba811ebe8`. 
`filters` [code](https://github.com/SergioSim/ralph/blob/55b088b47ba0ccc1df1eae0102be6c6ba811ebe8/src/ralph/filters.py) and [tests](https://github.com/SergioSim/ralph/blob/55b088b47ba0ccc1df1eae0102be6c6ba811ebe8/tests/test_filters.py) have been readapted from commit `55b088b47ba0ccc1df1eae0102be6c6ba811ebe8`.
