### PR TITLE
✏️(project) fix docstring typos for ralph documentation

### DIFF
--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -39,12 +39,12 @@ BACKENDS = (lambda: DATABASE_BACKENDS + STORAGE_BACKENDS)()
 
 
 class CommaSeparatedKeyValueParamType(click.ParamType):
-    """Comma separated key=value parameter type"""
+    """Comma separated key=value parameter type."""
 
     name = "key=value,key=value"
 
     def convert(self, value, param, ctx):
-        """Split value by comma and equal sign to return a dict build with key/value pairs"""
+        """Split value by comma and equal sign to return a dict build with key/value pairs."""
 
         # Parse options string
         try:
@@ -82,7 +82,7 @@ class CommaSeparatedKeyValueParamType(click.ParamType):
     help="Either CRITICAL, ERROR, WARNING, INFO (default) or DEBUG",
 )
 def cli(verbosity=None):
-    """Ralph is a stream-based tool to play with your logs"""
+    """Ralph is a stream-based tool to play with your logs."""
 
     configure_logging()
     if verbosity is not None:
@@ -93,7 +93,7 @@ def cli(verbosity=None):
 
 
 def backends_options(name=None, backends=None):
-    """Backend-related options decorator for Ralph commands"""
+    """Backend-related options decorator for Ralph commands."""
 
     backend_names = get_class_names(backends)
 
@@ -161,7 +161,7 @@ def backends_options(name=None, backends=None):
     help="Parse events by chunks of size #",
 )
 def extract(parser, chunksize):
-    """Extract input events from a container format using a dedicated parser"""
+    """Extract input events from a container format using a dedicated parser."""
 
     logger.info(
         "Extracting events using the %s parser (chunk size: %d)", parser, chunksize
@@ -183,7 +183,7 @@ def extract(parser, chunksize):
     help="Get events by chunks of size #",
 )
 def fetch(backend, archive, chunk_size, **options):
-    """Fetch an archive or records from a configured backend"""
+    """Fetch an archive or records from a configured backend."""
 
     logger.info(
         "Fetching data from the configured %s backend (archive: %s | chunk size: %s)",
@@ -231,7 +231,7 @@ def fetch(backend, archive, chunk_size, **options):
     help="Continue writing regardless of raised errors",
 )
 def push(backend, archive, chunk_size, force, ignore_errors, **options):
-    """Push an archive to a configured backend"""
+    """Push an archive to a configured backend."""
 
     logger.info("Pushing archive %s to the configured %s backend", archive, backend)
     logger.debug("Backend parameters: %s", options)
@@ -264,7 +264,7 @@ def push(backend, archive, chunk_size, force, ignore_errors, **options):
     help="Get archives detailed output (JSON)",
 )
 def list_(details, new, backend, **options):
-    """List available archives from a configured storage backend"""
+    """List available archives from a configured storage backend."""
 
     logger.info("Listing archives for the configured %s backend", backend)
     logger.debug("Fetch details: %s", str(details))

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -40,7 +40,7 @@ class StorageBackends(Enum):
 
 
 def load_config(config_file_path):
-    """Return a dictionary representing Ralph's configuration"""
+    """Return a dictionary representing Ralph's configuration."""
 
     try:
         with open(config_file_path) as config_file:

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -4,15 +4,15 @@ Ralph exceptions.
 
 
 class BackendException(Exception):
-    """Raised when a backend has a failure"""
+    """Raised when a backend has a failure."""
 
 
 class BackendParameterException(Exception):
-    """Raised when a backend parameter value is not valid"""
+    """Raised when a backend parameter value is not valid."""
 
 
 class ConfigurationException(Exception):
-    """Raised when the configuration is not valid"""
+    """Raised when the configuration is not valid."""
 
 
 class EventKeyError(Exception):
@@ -20,4 +20,4 @@ class EventKeyError(Exception):
 
 
 class UnsupportedBackendException(Exception):
-    """Raised when trying to use an unsupported backend type"""
+    """Raised when trying to use an unsupported backend type."""

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -8,11 +8,11 @@ def anonymous(event):
     """Remove anonymous events.
 
     Args:
-        event (dict): event to filter
+        event (dict): Event to filter.
 
     Returns:
-        event (dict): when event is not anonymous
-        None: otherwise
+        event (dict): When event is not anonymous.
+        None: Otherwise.
 
     Raises:
         EventKeyError: When the event does not contain the `username` key.

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -7,7 +7,7 @@ from ralph.exceptions import ConfigurationException
 
 
 def configure_logging():
-    """Set up Ralph logging configuration"""
+    """Set up Ralph logging configuration."""
 
     try:
         dictConfig(LOGGING_CONFIG)

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -16,19 +16,19 @@ ES_TEST_HOSTS = os.environ.get("RALPH_ES_TEST_HOSTS", "http://localhost:9200").s
 
 
 class NamedClassA:
-    """An example named class"""
+    """An example named class."""
 
     name = "A"
 
 
 class NamedClassB:
-    """A second example named class"""
+    """A second example named class."""
 
     name = "B"
 
 
 class NamedClassEnum(Enum):
-    """A named test classes Enum"""
+    """A named test classes Enum."""
 
     A = "tests.fixtures.backends.NamedClassA"
     B = "tests.fixtures.backends.NamedClassB"
@@ -36,7 +36,7 @@ class NamedClassEnum(Enum):
 
 @pytest.fixture
 def es():
-    """Create / delete an ElasticSearch test index and yield an instantiated client"""
+    """Create / delete an ElasticSearch test index and yield an instantiated client."""
     # pylint: disable=invalid-name
 
     client = Elasticsearch(ES_TEST_HOSTS)
@@ -47,10 +47,10 @@ def es():
 
 @pytest.fixture
 def swift():
-    """Returns get_swift_storage function"""
+    """Returns get_swift_storage function."""
 
     def get_swift_storage():
-        """Returns an instance of SwiftStorage"""
+        """Returns an instance of SwiftStorage."""
         return SwiftStorage(
             os_tenant_id="os_tenant_id",
             os_tenant_name="os_tenant_name",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ test_logger = logging.getLogger("ralph")
 
 
 def test_comma_separated_key_value_param_type():
-    """Test the CommaSeparatedKeyValueParamType custom parameter type"""
+    """Test the CommaSeparatedKeyValueParamType custom parameter type."""
 
     param_type = CommaSeparatedKeyValueParamType()
 
@@ -82,7 +82,7 @@ def test_comma_separated_key_value_param_type():
 
 
 def test_help_option():
-    """Test ralph --help command"""
+    """Test ralph --help command."""
 
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
@@ -95,7 +95,7 @@ def test_help_option():
 
 
 def test_extract_command_usage():
-    """Test ralph extract command usage"""
+    """Test ralph extract command usage."""
 
     runner = CliRunner()
     result = runner.invoke(cli, ["extract", "--help"])
@@ -116,7 +116,7 @@ def test_extract_command_usage():
 
 
 def test_extract_command_with_gelf_parser(gelf_logger):
-    """Test the extract command using the GELF parser"""
+    """Test the extract command using the GELF parser."""
 
     gelf_logger.info('{"username": "foo"}')
 
@@ -129,7 +129,7 @@ def test_extract_command_with_gelf_parser(gelf_logger):
 
 @cli.command()
 def dummy_verbosity_check():
-    """Adding a dummy command to the cli with all logging levels"""
+    """Adding a dummy command to the cli with all logging levels."""
 
     test_logger.critical("CRITICAL")
     test_logger.error("ERROR")
@@ -140,7 +140,7 @@ def dummy_verbosity_check():
 
 @pytest.mark.parametrize("verbosity", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
 def test_verbosity_option_should_impact_logging_behaviour(verbosity):
-    """Test that the verbosity option impacts logging output"""
+    """Test that the verbosity option impacts logging output."""
 
     runner = CliRunner()
     result = runner.invoke(cli, ["-v", verbosity, "dummy-verbosity-check"])
@@ -148,7 +148,7 @@ def test_verbosity_option_should_impact_logging_behaviour(verbosity):
 
 
 def test_fetch_command_usage():
-    """Test ralph fetch command usage"""
+    """Test ralph fetch command usage."""
 
     runner = CliRunner()
     result = runner.invoke(cli, ["fetch", "--help"])
@@ -194,12 +194,12 @@ def test_fetch_command_usage():
 
 
 def test_fetch_command_with_ldp_backend(monkeypatch):
-    """Test the fetch command using the LDP backend"""
+    """Test the fetch command using the LDP backend."""
 
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size=500):
-        """Always return the same archive"""
+        """Always return the same archive."""
         # pylint: disable=unused-argument
 
         sys.stdout.buffer.write(bytes(json.dumps(archive_content), encoding="utf-8"))
@@ -226,12 +226,12 @@ def test_fetch_command_with_ldp_backend(monkeypatch):
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 def test_fetch_command_with_fs_backend(fs, monkeypatch):
-    """Test the fetch command using the FS backend"""
+    """Test the fetch command using the FS backend."""
 
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size):
-        """Always return the same archive"""
+        """Always return the same archive."""
         # pylint: disable=unused-argument
 
         sys.stdout.buffer.write(bytes(json.dumps(archive_content), encoding="utf-8"))
@@ -254,7 +254,7 @@ def test_fetch_command_with_fs_backend(fs, monkeypatch):
 
 
 def test_fetch_command_with_es_backend(es):
-    """Test ralph fetch command using the es backend"""
+    """Test ralph fetch command using the es backend."""
     # pylint: disable=invalid-name
 
     # Insert documents
@@ -279,7 +279,7 @@ def test_fetch_command_with_es_backend(es):
 
 
 def test_list_command_usage():
-    """Test ralph list command usage"""
+    """Test ralph list command usage."""
 
     runner = CliRunner()
     result = runner.invoke(cli, ["list", "--help"])
@@ -321,7 +321,7 @@ def test_list_command_usage():
 
 
 def test_list_command_with_ldp_backend(monkeypatch):
-    """Test the list command using the LDP backend"""
+    """Test the list command using the LDP backend."""
 
     archive_list = [
         "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
@@ -351,7 +351,7 @@ def test_list_command_with_ldp_backend(monkeypatch):
     ]
 
     def mock_list(this, details=False, new=False):
-        """Mock LDP backend list method"""
+        """Mock LDP backend list method."""
         # pylint: disable=unused-argument
 
         response = archive_list
@@ -394,7 +394,7 @@ def test_list_command_with_ldp_backend(monkeypatch):
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 def test_list_command_with_fs_backend(fs, monkeypatch):
-    """Test the list command using the LDP backend"""
+    """Test the list command using the LDP backend."""
 
     archive_list = [
         "file1",
@@ -414,7 +414,7 @@ def test_list_command_with_fs_backend(fs, monkeypatch):
     ]
 
     def mock_list(this, details=False, new=False):
-        """Mock LDP backend list method"""
+        """Mock LDP backend list method."""
         # pylint: disable=unused-argument
 
         response = archive_list
@@ -456,7 +456,7 @@ def test_list_command_with_fs_backend(fs, monkeypatch):
 
 # pylint: disable=invalid-name
 def test_push_command_with_fs_backend(fs):
-    """Test the push command using the FS backend"""
+    """Test the push command using the FS backend."""
 
     fs.create_dir(str(APP_DIR))
 
@@ -521,7 +521,7 @@ def test_push_command_with_fs_backend(fs):
 
 
 def test_push_command_with_es_backend(es):
-    """Test ralph push command using the es backend"""
+    """Test ralph push command using the es backend."""
     # pylint: disable=invalid-name
 
     # Documents

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -13,7 +13,7 @@ from ralph.exceptions import ConfigurationException
 
 # pylint: disable=invalid-name, unused-argument
 def test_config_default(fs, monkeypatch):
-    """Test that when no value is given, the default parameter is chosen"""
+    """Test that when no value is given, the default parameter is chosen."""
 
     assert environ.get("RALPH_HISTORY_FILE", None) is None
     assert config("RALPH_HISTORY_FILE", "history_default") == "history_default"
@@ -22,7 +22,7 @@ def test_config_default(fs, monkeypatch):
 # pylint: disable=invalid-name, unused-argument
 def test_config_file(fs, monkeypatch):
     """Test that when the environment and command-line arguments don't specify a
-    value, the value from the config file is taken instead"""
+    value, the value from the config file is taken instead."""
 
     config_mock = {"RALPH_HISTORY_FILE": "history_config_file"}
 
@@ -35,7 +35,7 @@ def test_config_file(fs, monkeypatch):
 # pylint: disable=invalid-name, unused-argument
 def test_config_env(fs, monkeypatch):
     """Test that when the environment specifies a value, it is chosen instead of
-    the configuration file's value"""
+    the configuration file's value."""
 
     config_mock = {"RALPH_HISTORY_FILE": "history_config_file"}
 
@@ -48,7 +48,7 @@ def test_config_env(fs, monkeypatch):
 # pylint: disable=invalid-name, unused-argument
 def test_load_config_no_config(fs, monkeypatch):
     """Test that loading when no configuration file is available results in
-    load_config returning None"""
+    load_config returning None."""
 
     config_path = APP_DIR / "config.yml"
 
@@ -57,7 +57,7 @@ def test_load_config_no_config(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_load_config_correct_config(fs, monkeypatch):
-    """Test that loading a correct configuration file works as intended"""
+    """Test that loading a correct configuration file works as intended."""
 
     config_path = APP_DIR / "config.yml"
 
@@ -69,7 +69,7 @@ def test_load_config_correct_config(fs, monkeypatch):
 # pylint: disable=invalid-name, unused-argument
 def test_load_config_incorrect_config(fs, monkeypatch):
     """Test that loading an incorrect configuration file raises a configuration
-    exception"""
+    exception."""
 
     config_path = APP_DIR / "config.yml"
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -12,7 +12,7 @@ from ralph.exceptions import ConfigurationException
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_exists(fs, monkeypatch):
-    """Test the logging system when a correct configuration is provided"""
+    """Test the logging system when a correct configuration is provided."""
 
     mock_default_config = {
         "version": 1,
@@ -56,7 +56,7 @@ def test_logger_exists(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_no_config(fs, monkeypatch):
-    """Test that an error occurs when no logging configuration exists"""
+    """Test that an error occurs when no logging configuration exists."""
 
     mock_default_config = None
 
@@ -71,7 +71,7 @@ def test_logger_no_config(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_bad_config(fs, monkeypatch):
-    """Test that an error occurs when a logging is improperly configured"""
+    """Test that an error occurs when a logging is improperly configured."""
 
     mock_default_config = "this is not a valid json"
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -63,7 +63,7 @@ def test_gelfparser_parse_gzipped_file(fs, gelf_logger):
 
 
 def test_gelfparser_parse_partially_invalid_file(caplog):
-    """Test the GELFParser with a file containing invalid JSON strings"""
+    """Test the GELFParser with a file containing invalid JSON strings."""
 
     with StringIO() as file:
         file.writelines(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from .fixtures.backends import NamedClassEnum
 
 
 def test_import_string():
-    """Test import_string utility taken from Django utilities"""
+    """Test import_string utility taken from Django utilities."""
 
     with pytest.raises(ImportError, match="foo doesn't look like a module path"):
         ralph_utils.import_string("foo")
@@ -27,10 +27,10 @@ def test_import_string():
 
 
 def test_get_backend_type():
-    """Test get_backend_type utility"""
+    """Test get_backend_type utility."""
 
     class TestBackend:
-        """Dumb test backend that does not inherit from a supported backend type"""
+        """Dumb test backend that does not inherit from a supported backend type."""
 
     assert ralph_utils.get_backend_type(ESDatabase) == BackendTypes.DATABASE
     assert ralph_utils.get_backend_type(LDPStorage) == BackendTypes.STORAGE
@@ -38,7 +38,7 @@ def test_get_backend_type():
 
 
 def test_get_class_names():
-    """Test get_class_names utility"""
+    """Test get_class_names utility."""
 
     assert ralph_utils.get_class_names([module.value for module in NamedClassEnum]) == [
         "A",
@@ -47,7 +47,7 @@ def test_get_class_names():
 
 
 def test_get_class_from_name():
-    """Test get_class_from_name utility"""
+    """Test get_class_from_name utility."""
 
     assert (
         ralph_utils.get_class_from_name(
@@ -71,10 +71,10 @@ def test_get_class_from_name():
 
 
 def test_get_instance_from_class():
-    """Test get_instance_from_class utility"""
+    """Test get_instance_from_class utility."""
 
     class NamedTestClass:
-        """Named test class"""
+        """Named test class."""
 
         name = "test"
 


### PR DESCRIPTION
## Purpose

The documentation of ralph is partially updated with docstrings. 
It has been noticed during review of PR #60. 
However, format of docstrings is not the same in each class or function. 
Some points are missing. 

## Proposal

To get a cleaner documentation, sentences format has been harmonized.

