### PR TITLE
✨(tray) add support for ES cluster CA certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - EdX server event pydantic model and factory
 - EdX page_close browser event pydantic model and factory
+- Ralph tray now allows to specify a self-generated elasticsearch cluster CA
+  certificate
 
 ### Fixed
 

--- a/src/tray/templates/services/app/cronjob_pipeline.yml.j2
+++ b/src/tray/templates/services/app/cronjob_pipeline.yml.j2
@@ -42,9 +42,18 @@ items:
                   volumeMounts:
                     - name: ralph-v-history
                       mountPath: /app/.ralph
+{% if ralph_mount_es_ca_secret %}
+                    - name: es-ca-certificate
+                      mountPath: /usr/local/share/ca-certificates/
+{% endif %}
               volumes:
                 - name: ralph-v-history
                   persistentVolumeClaim:
                     claimName: ralph-pvc-history
+{% if ralph_mount_es_ca_secret %}
+                - name: es-ca-certificate
+                  secret:
+                    secretName: "{{ ralph_es_ca_secret_name }}"
+{% endif %}
               restartPolicy: Never
 {% endfor %}

--- a/src/tray/templates/services/app/dc.yml.j2
+++ b/src/tray/templates/services/app/dc.yml.j2
@@ -58,7 +58,16 @@ spec:
           volumeMounts:
             - name: ralph-v-history
               mountPath: /app/.ralph
+{% if ralph_mount_es_ca_secret %}
+            - name: es-ca-certificate
+              mountPath: /usr/local/share/ca-certificates/
+{% endif %}
       volumes:
         - name: ralph-v-history
           persistentVolumeClaim:
             claimName: ralph-pvc-history
+{% if ralph_mount_es_ca_secret %}
+        - name: es-ca-certificate
+          secret:
+            secretName: "{{ ralph_es_ca_secret_name }}"
+{% endif %}

--- a/src/tray/templates/services/app/secret-es-ca.yml.j2
+++ b/src/tray/templates/services/app/secret-es-ca.yml.j2
@@ -1,0 +1,12 @@
+{% if RALPH_VAULT.ES_CA_CERTIFICATE is defined %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: ralph
+    service: app
+  name: "{{ ralph_es_ca_secret_name }}"
+  namespace: "{{ project_name }}"
+data:
+  es-cluster.pem: {{ RALPH_VAULT.ES_CA_CERTIFICATE | b64encode }}
+{% endif %}

--- a/src/tray/templates/services/app/secret.yml.j2
+++ b/src/tray/templates/services/app/secret.yml.j2
@@ -7,9 +7,11 @@ metadata:
   name: "{{ ralph_secret_name }}"
   namespace: "{{ project_name }}"
 data:
-# Create a secret entry per vault variable as most variables are backend
-# credentials that will be used as environment variables to login to various
-# backends.
+# Create a secret entry per vault variable whose name starts by RALPH_ as most
+# variables are backend credentials that will be used as environment variables
+# to login to various backends.
 {% for k, v in RALPH_VAULT.items() %}
+{% if "RALPH_" in k %}
   {{ k }}: {{ v | b64encode }}
+{% endif %}
 {% endfor %}

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -4,6 +4,8 @@ ralph_image_tag: "latest"
 ralph_app_replicas: 0
 ralph_history_volume_size: 2Gi
 ralph_secret_name: "ralph-backends-{{ ralph_vault_checksum | default('undefined_ralph_vault_checksum') }}"
+ralph_es_ca_secret_name: "ralph-es-ca-{{ ralph_vault_checksum | default('undefined_ralph_vault_checksum') }}"
+ralph_mount_es_ca_secret: false
 
 # Cronjob pipelines
 #
@@ -18,5 +20,7 @@ ralph_secret_name: "ralph-backends-{{ ralph_vault_checksum | default('undefined_
 #             ralph fetch --backend ldp {} |
 #             gunzip |
 #             ralph extract -p gelf |
-#             ralph push --backend es --no-es-verify-certs"
+#             ralph push \
+#               --backend es \
+#               --es-client-options ca_certs=/usr/local/share/ca-certificates/es-cluster.pem"
 ralph_cronjobs: []

--- a/src/tray/vars/vault/main.yml.j2
+++ b/src/tray/vars/vault/main.yml.j2
@@ -31,6 +31,14 @@
 # RALPH_ES_HOSTS: http://elasticsearch:9200
 # RALPH_ES_INDEX: statements
 
+# If you have self-generated a CA certificate for your ES cluster nodes, you may
+# also need this CA certificate to check certificates while requesting the
+# cluster. If defined, this CA certificate will be mounted to
+# /usr/local/share/ca-certificates/es-cluster.pem
+#
+# We expect this certificate to be pasted in PEM format
+# ES_CA_CERTIFICATE:
+
 # Sentry
 
 # RALPH_SENTRY_DSN: https://fake@key.ingest.sentry.io/1234567


### PR DESCRIPTION
## Purpose

When requesting an elasticsearch cluster using self-generated CA certificates, the elasticsearch client is raising a warning message as it cannot verify the authenticity of SSL certificates.

To mitigate the issue, one need to copy the CA certificate in ralph's container and specify the CA certificate path for the "es" backend using the `--es-client-options ca_certs=/path/to/ca.pem` option.

## Proposal

If the `ES_CA_CERTIFICATE` is defined in ralph's vault, a dedicated secret will be generated and mounted in the following path `/usr/local/share/ca-certificates/es-cluster.pem` so that execution logs are not polluted with warning messages.
