### PR TITLE
🔖(minor) bump release to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-02-26
+
 ### Added
 
 - EdX server event pydantic model and factory
 - EdX page_close browser event pydantic model and factory
-- Ralph tray now allows to specify a self-generated elasticsearch cluster CA
-  certificate
+- Tray: allow to specify a self-generated elasticsearch cluster CA certificate
 
 ### Fixed
 
@@ -56,6 +57,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v1.1.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v1.2.0...master
+[1.2.0]: https://github.com/openfun/ralph/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/openfun/ralph/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/openfun/ralph/compare/3d03d85...v1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 1.1.0
+version = 1.2.0
 description = A learning logs processor to feed your LRS
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module"""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
### Added

- EdX server event pydantic model and factory
- EdX page_close browser event pydantic model and factory
- Tray: allow to specify a self-generated elasticsearch cluster CA certificate

### Fixed

- Tray: add missing Swift variables in the secret
- Tray: fix pods anti-affinity selector

### Removed

- `pandas` is no longer required
