### PR TITLE
🐛(tray) remove version immutable field in selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Tray: remove `version` immutable field in DC selector
+
 ## [1.2.0] - 2021-02-26
 
 ### Added

--- a/src/tray/templates/services/app/dc.yml.j2
+++ b/src/tray/templates/services/app/dc.yml.j2
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: ralph
     service: app
-    version: "{{ ralph_image_tag }}"
   name: "ralph-app"
   namespace: "{{ project_name }}"
 spec:
@@ -14,7 +13,6 @@ spec:
       labels:
         app: ralph
         service: app
-        version: "{{ ralph_image_tag }}"
         deploymentconfig: "ralph-app"
     spec:
       # Prefer running pods on different nodes for redundancy


### PR DESCRIPTION
## Purpose

As Ralph is not a blue-green application, we cannot have a variable `version` field in the DC's label (it should be immutable).

Without this fix, one cannot deploy a new Ralph's release as k8s refuses to patch the object.

## Proposal

- [x] remove the `version` label and selector in the DC

