### PR TITLE
✨(models) add edx navigational event pydantic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Implement edx navigational events pydantic models
 - Install security updates in project Docker images
 - Model selector to retrieve associated pydantic model of a given event
 - `validate` command to lint edx events using pydantic models

--- a/src/ralph/models/edx/__init__.py
+++ b/src/ralph/models/edx/__init__.py
@@ -2,5 +2,5 @@
 
 # flake8: noqa
 
-from .browser import PageClose
+from .navigational import UIPageClose, UISeqGoto, UISeqNext, UISeqPrev
 from .server import ServerEvent

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, HttpUrl, constr
 
 
 class BaseModelWithConfig(BaseModel):
-    """Base model defining configuration shared among all models"""
+    """Base model defining configuration shared among all models."""
 
     class Config:  # pylint: disable=missing-class-docstring
         extra = "forbid"
@@ -72,7 +72,7 @@ class AbstractBaseEventField(BaseModelWithConfig):
 class BaseEvent(BaseModelWithConfig):
     """Represents the base event model all events inherit from.
 
-    WARNING: it does not define the event, event_source and event_type fields.
+    WARNING: it does not define the `event`, `event_type` and `event_source` fields.
 
     Attributes:
         username (str): Consists of the unique username identifying the logged in user.

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -5,8 +5,6 @@ from typing import Literal, Union
 
 from pydantic import AnyUrl, constr
 
-from ralph.models.selector import selector
-
 from .base import BaseEvent
 
 
@@ -20,30 +18,9 @@ class BaseBrowserEvent(BaseEvent):
         page (Path): Consists of the URL (with hostname) of the visited page.
             Retrieved with:
                 `window.location.href` from the JavaScript front-end.
-        session (str): Consists of the md5 encrypted Django session key or an empty string
+        session (str): Consists of the md5 encrypted Django session key or an empty string.
     """
 
     event_source: Literal["browser"]
     page: Union[AnyUrl, Path]
-    session: constr(regex=r"^$|^[a-f0-9]{32}$")  # noqa: F722
-
-
-class PageClose(BaseBrowserEvent):
-    """Represents the page_close browser event.
-
-    This type of event is triggered when the user navigates to the next page
-    or closes the browser window (when the JavaScript `window.onunload` event
-    is called).
-
-    Attributes:
-        name (str): Consists of the value `page_close`
-        event_type (str): Consists of the value `page_close`
-        event (str): Consists of the string value `{}`
-    """
-
-    __selector__ = selector(event_source="browser", event_type="page_close")
-
-    # pylint: disable=unsubscriptable-object
-    name: Literal["page_close"]
-    event_type: Literal["page_close"]
-    event: Literal["{}"]
+    session: Union[constr(regex=r"^[a-f0-9]{32}$"), Literal[""]]  # noqa: F722

--- a/src/ralph/models/edx/navigational.py
+++ b/src/ralph/models/edx/navigational.py
@@ -1,0 +1,138 @@
+"""Navigational event model definitions"""
+
+from typing import Literal, Union
+
+from pydantic import Json, constr, validator
+
+from ralph.models.selector import selector
+
+from .base import AbstractBaseEventField
+from .browser import BaseBrowserEvent
+
+
+class UIPageClose(BaseBrowserEvent):
+    """Represents the `page_close` browser event.
+
+    This type of event is triggered when the user navigates to the next page
+    or closes the browser window (when the JavaScript `window.onunload` event
+    is called).
+
+    Attributes:
+        event (str): Consists of the string value `{}`.
+        event_type (str): Consists of the value `page_close`.
+        name (str): Consists of the value `page_close`.
+    """
+
+    __selector__ = selector(event_source="browser", event_type="page_close")
+
+    # pylint: disable=unsubscriptable-object
+    event: Literal["{}"]
+    event_type: Literal["page_close"]
+    name: Literal["page_close"]
+
+
+class NavigationalEventField(AbstractBaseEventField):
+    """Represents the event field of navigational events.
+
+    Note: All navigational events are `browser` events.
+
+    Attributes:
+        id (str): Consists of the edX ID of the sequence.
+        old (int): For `seq_goto`, it consists of the index of the unit being jumped to.
+            For `seq_next` and `seq_prev`, it consists of the index of the unit being navigated to.
+        new (int): For `seq_goto`, it consists of the index of the unit being jumped from.
+            For `seq_next` and `seq_prev`, it consists of the index of the unit being navigated
+            away from.
+    """
+
+    id: constr(
+        regex=(
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type"  # noqa : F722
+            r"@sequential\+block@[a-f0-9]{32}$"  # noqa : F722
+        )
+    )
+    new: int
+    old: int
+
+
+class UISeqGoto(BaseBrowserEvent):
+    """Represents the `seq_goto` browser event.
+
+    The browser emits such event when a user selects a navigational control.
+    `seq_goto` is emitted when a user jumps between units in a sequence.
+
+    Attributes:
+        event (obj): Consists of member fields that identify specifics triggered event.
+        event_type (str): Consists of the value `seq_goto`.
+        name (str): Consists of the value `seq_goto`.
+    """
+
+    __selector__ = selector(event_source="browser", event_type="seq_goto")
+
+    # pylint: disable=unsubscriptable-object
+    event: Union[Json[NavigationalEventField], NavigationalEventField]
+    event_type: Literal["seq_goto"]
+    name: Literal["seq_goto"]
+
+
+class UISeqNext(BaseBrowserEvent):
+    """Represents the `seq_next` browser event.
+
+    The browser emits such event when a user selects a navigational control.
+    `seq_next` is emitted when a user navigates to the next unit in a sequence.
+
+    Attributes:
+        event (obj): Consists of member fields that identify specifics triggered event.
+        event_type (str): Consists of the value `seq_next`.
+        name (str): Consists of the value `seq_next`.
+    """
+
+    __selector__ = selector(event_source="browser", event_type="seq_next")
+
+    # pylint: disable=unsubscriptable-object
+    event: Union[Json[NavigationalEventField], NavigationalEventField]
+    event_type: Literal["seq_next"]
+    name: Literal["seq_next"]
+
+    @validator("event")
+    def validate_next_jump_event_field(
+        cls, value
+    ):  # pylint: disable=no-self-argument, no-self-use
+        """Checks that event.new is equal to event.old + 1."""
+
+        if value.new != value.old + 1:
+            raise ValueError("event.new - event.old should be equal to 1")
+
+        return value
+
+
+class UISeqPrev(BaseBrowserEvent):
+    """Represents the `seq_prev` browser event.
+
+    The browser emits such event when a user selects a navigational control.
+    `seq_prev` is emitted when a user navigates to the previous unit in a sequence.
+
+    Attributes:
+        event (obj): Consists of member fields that identify specifics triggered event.
+        event_type (str): Consists of the value `seq_prev`.
+        name (str): Consists of the value `seq_prev`.
+
+    """
+
+    __selector__ = selector(event_source="browser", event_type="seq_prev")
+
+    # pylint: disable=unsubscriptable-object
+    event: Union[Json[NavigationalEventField], NavigationalEventField]
+    event_type: Literal["seq_prev"]
+    name: Literal["seq_prev"]
+
+    @validator("event")
+    def validate_prev_jump_event_field(
+        cls, value
+    ):  # pylint: disable=no-self-argument, no-self-use
+        """Checks that event.new is equal to event.old - 1."""
+
+        if value.new != value.old - 1:
+            raise ValueError("event.old - event.new should be equal to 1")
+
+        return value

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -46,8 +46,6 @@ class ServerEvent(BaseServerEvent):
         event_source="server", event_type=LazyModelField("context__path")
     )
 
+    # pylint: disable=unsubscriptable-object
     event_type: Path
-    event: Union[
-        Json[ServerEventField],  # pylint: disable=unsubscriptable-object
-        ServerEventField,
-    ]
+    event: Union[Json[ServerEventField], ServerEventField]

--- a/src/ralph/models/selector.py
+++ b/src/ralph/models/selector.py
@@ -30,7 +30,7 @@ class Rule:
     """Represents a rule used for selection."""
 
     field: LazyModelField
-    value: Union[LazyModelField, Any]
+    value: Union[LazyModelField, Any]  # pylint: disable=unsubscriptable-object
 
     def check(self, event):
         """Checks if event matches the rule.

--- a/tests/models/edx/test_browser.py
+++ b/tests/models/edx/test_browser.py
@@ -8,9 +8,7 @@ from hypothesis import given, provisional, settings
 from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
-from ralph.exceptions import UnknownEventException
-from ralph.models.edx.browser import BaseBrowserEvent, PageClose
-from ralph.models.selector import ModelSelector
+from ralph.models.edx.browser import BaseBrowserEvent
 
 
 @settings(max_examples=1)
@@ -44,19 +42,3 @@ def test_models_edx_browser_base_browser_event_with_invalid_content(
 
     with pytest.raises(ValidationError, match=error):
         BaseBrowserEvent(**invalid_event)
-
-
-@settings(max_examples=1)
-@given(st.builds(PageClose, referer=provisional.urls(), page=provisional.urls()))
-def test_models_selector_model_selector_get_model_with_valid_event(event):
-    """Tests given a page_close event the get_model method should return PageClose model."""
-
-    event = json.loads(event.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(event) is PageClose
-
-
-def test_models_selector_model_selector_get_model_with_invalid_event():
-    """Tests given a page_close event the get_model method should raise UnknownEventException."""
-
-    with pytest.raises(UnknownEventException):
-        ModelSelector(module="ralph.models.edx").get_model({"invalid": "event"})

--- a/tests/models/edx/test_navigational.py
+++ b/tests/models/edx/test_navigational.py
@@ -1,0 +1,173 @@
+"""Tests for the navigational event models"""
+
+import json
+import re
+
+import pytest
+from hypothesis import given, provisional, settings
+from hypothesis import strategies as st
+from pydantic.error_wrappers import ValidationError
+
+from ralph.models.edx.base import BaseContextField
+from ralph.models.edx.navigational import (
+    NavigationalEventField,
+    UIPageClose,
+    UISeqGoto,
+    UISeqNext,
+    UISeqPrev,
+)
+from ralph.models.selector import ModelSelector
+
+
+@settings(max_examples=1)
+@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+def test_models_edx_ui_page_close_selector_with_valid_event(event):
+    """Tests given a page_close event the get_model method should return UIPageClose model."""
+
+    event = json.loads(event.json())
+    assert ModelSelector(module="ralph.models.edx").get_model(event) is UIPageClose
+
+
+@settings(max_examples=1)
+@given(st.builds(NavigationalEventField))
+def test_fields_edx_navigational_events_event_field_with_valid_content(field):
+    """Tests that a valid NavigationalEventField field does not raise a ValidationError."""
+
+    assert re.match(
+        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@sequential\+block@[a-f0-9]{32}$",
+        field.id,
+    )
+
+
+@pytest.mark.parametrize(
+    "id",
+    [
+        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        "block-v1:orgX=CS111=20_T1+",
+        "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
+        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
+        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+    ],  # pylint: disable=invalid-name
+)
+@settings(max_examples=1)
+@given(st.builds(NavigationalEventField))
+def test_fields_edx_navigational_events_event_field_with_invalid_content(
+    id, event  # pylint: disable=redefined-builtin
+):
+    """Tests that an invalid NavigationalEventField field raises a ValidationError."""
+
+    invalid_event = json.loads(event.json())
+    invalid_event["id"] = id
+
+    with pytest.raises(ValidationError, match="id\n  string does not match regex"):
+        NavigationalEventField(**invalid_event)
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        UISeqGoto,
+        context=st.builds(BaseContextField),
+        referer=provisional.urls(),
+        page=provisional.urls(),
+        event=st.builds(NavigationalEventField),
+    )
+)
+def test_models_edx_ui_seq_goto_selector_with_valid_event(event):
+    """Tests given a seq_goto event the get_model method should return UISeqGoto model."""
+
+    event = json.loads(event.json())
+    assert ModelSelector(module="ralph.models.edx").get_model(event) is UISeqGoto
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        UISeqNext,
+        context=st.builds(BaseContextField),
+        referer=provisional.urls(),
+        page=provisional.urls(),
+        event=st.builds(
+            NavigationalEventField, old=st.integers(0, 0), new=st.integers(1, 1)
+        ),
+    )
+)
+def test_models_edx_ui_seq_next_selector_with_valid_event(event):
+    """Tests given a seq_next event the get_model method should return UISeqNext model."""
+
+    event = json.loads(event.json())
+    assert ModelSelector(module="ralph.models.edx").get_model(event) is UISeqNext
+
+
+@pytest.mark.parametrize("old,new", [("0", "10"), ("10", "0")])
+@settings(max_examples=1)
+@given(
+    st.builds(
+        UISeqNext,
+        context=st.builds(BaseContextField),
+        referer=provisional.urls(),
+        page=provisional.urls(),
+        event=st.builds(
+            NavigationalEventField, old=st.integers(0, 0), new=st.integers(1, 1)
+        ),
+    )
+)
+def test_models_edx_ui_seq_next_event_with_invalid_content(old, new, event):
+    """Tests that an invalid seq_next event raises a ValidationError."""
+
+    invalid_event = json.loads(event.json())
+    invalid_event["event"]["old"] = old
+    invalid_event["event"]["new"] = new
+
+    with pytest.raises(
+        ValidationError,
+        match="event\n  event.new - event.old should be equal to 1",
+    ):
+        UISeqNext(**invalid_event)
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        UISeqPrev,
+        context=st.builds(BaseContextField),
+        referer=provisional.urls(),
+        page=provisional.urls(),
+        event=st.builds(
+            NavigationalEventField, old=st.integers(1, 1), new=st.integers(0, 0)
+        ),
+    )
+)
+def test_models_edx_ui_seq_prev_selector_with_valid_event(event):
+    """Tests given a seq_prev event the get_model method should return UISeqPrev model."""
+
+    event = json.loads(event.json())
+    assert ModelSelector(module="ralph.models.edx").get_model(event) is UISeqPrev
+
+
+@pytest.mark.parametrize("old,new", [("0", "10"), ("10", "0")])
+@settings(max_examples=1)
+@given(
+    st.builds(
+        UISeqPrev,
+        context=st.builds(BaseContextField),
+        referer=provisional.urls(),
+        page=provisional.urls(),
+        event=st.builds(
+            NavigationalEventField, old=st.integers(1, 1), new=st.integers(0, 0)
+        ),
+    )
+)
+def test_models_edx_ui_seq_prev_event_with_invalid_content(old, new, event):
+    """Tests that an invalid seq_prev event raises a ValidationError."""
+
+    invalid_event = json.loads(event.json())
+    invalid_event["event"]["old"] = old
+    invalid_event["event"]["new"] = new
+
+    with pytest.raises(
+        ValidationError, match="event\n  event.old - event.new should be equal to 1"
+    ):
+        UISeqPrev(**invalid_event)

--- a/tests/models/test_validator.py
+++ b/tests/models/test_validator.py
@@ -9,7 +9,7 @@ from hypothesis import HealthCheck, given, provisional, settings
 from hypothesis import strategies as st
 
 from ralph.exceptions import BadFormatException, UnknownEventException
-from ralph.models.edx.browser import PageClose
+from ralph.models.edx.navigational import UIPageClose
 from ralph.models.edx.server import ServerEvent, ServerEventField
 from ralph.models.selector import ModelSelector
 from ralph.models.validator import Validator
@@ -116,7 +116,7 @@ def test_models_validator_validate_with_an_invalid_page_close_event_writes_an_er
     )
     with caplog.at_level(logging.ERROR):
         assert list(result) == []
-    errors = ["Input event is not a valid PageClose event."]
+    errors = ["Input event is not a valid UIPageClose event."]
     assert errors == [message for _, _, message in caplog.record_tuples]
 
 
@@ -140,7 +140,7 @@ def test_models_validator_validate_with_invalid_page_close_event_raises_an_excep
 @settings(max_examples=1)
 @pytest.mark.parametrize("ignore_errors", [True, False])
 @pytest.mark.parametrize("fail_on_unknown", [True, False])
-@given(st.builds(PageClose, referer=provisional.urls(), page=provisional.urls()))
+@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
 def test_models_validator_validate_with_valid_events(
     ignore_errors, fail_on_unknown, event
 ):
@@ -154,7 +154,7 @@ def test_models_validator_validate_with_valid_events(
 
 
 @settings(max_examples=1, suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(st.builds(PageClose, referer=provisional.urls(), page=provisional.urls()))
+@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
 def test_models_validator_validate_counter(caplog, event):
     """Tests given multiple events the validate method
     should log the total and invalid events."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from ralph.backends.storage.fs import FSStorage
 from ralph.backends.storage.ldp import LDPStorage
 from ralph.cli import CommaSeparatedKeyValueParamType, cli
 from ralph.defaults import APP_DIR, FS_STORAGE_DEFAULT_PATH
-from ralph.models.edx.browser import PageClose
+from ralph.models.edx.navigational import UIPageClose
 
 from tests.fixtures.backends import ES_TEST_HOSTS, ES_TEST_INDEX
 
@@ -152,7 +152,7 @@ def test_validate_command_usage():
 
 @settings(max_examples=1)
 @given(
-    st.builds(PageClose, referer=provisional.urls(), page=provisional.urls()),
+    st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()),
 )
 def test_validate_command_with_edx_format(event):
     """Tests the validate command using the edx format."""


### PR DESCRIPTION
## Purpose

With the `validate` and `select` command newly implemented, it is now possible to implement edx tracking logs events pydantic models to validate incoming events in ralph. 

## Proposal

The first events implemented are the easiest (navigation).

- [x] event models
- [x] event fixtures
- [x] event tests

