### PR TITLE
⚠️ [DO NOT MERGE] genson JSON Schema generator

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     click==7.1.2
     click-option-group==0.5.2
     elasticsearch==7.11.0
+    genson==1.2.2 
     ovh==0.5.0
     pydantic==1.8.1
     python-keystoneclient==4.2.0

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -19,6 +19,7 @@ from ralph.defaults import (
 )
 from ralph.exceptions import UnsupportedBackendException
 from ralph.logger import configure_logging
+from ralph.models.generator import generate_json_schemas
 from ralph.models.selector import ModelSelector
 from ralph.models.validator import Validator
 from ralph.utils import (
@@ -163,6 +164,26 @@ def extract(parser):
 
     for event in parser.parse(sys.stdin):
         click.echo(event)
+
+
+@cli.command()
+@click.option(
+    "-f",
+    "--format",
+    "format_",
+    type=click.Choice(["edx"]),
+    required=True,
+    help="Input events format to validate",
+)
+def genson(format_):
+    """Generates JSON schemas from input events that are not covered by validate."""
+
+    logger.info("Generating %s JSON schemas using genson", format_)
+
+    model_selector = ModelSelector(f"ralph.models.{format_}")
+
+    for schema in generate_json_schemas(sys.stdin, model_selector):
+        click.echo(schema)
 
 
 @cli.command()

--- a/src/ralph/models/generator.py
+++ b/src/ralph/models/generator.py
@@ -1,0 +1,68 @@
+"""generate_json_schemas definition"""
+
+import json
+import logging
+import re
+from typing import TextIO
+
+from genson import SchemaBuilder
+
+from ralph.exceptions import UnknownEventException
+from ralph.models.selector import ModelSelector
+
+logger = logging.getLogger(__name__)
+
+
+def replace_pattern_properties(event):
+    """Replaces pattern properties matching regex with a single pattern.
+
+    This reduces the JSON schema size, genson treats each pattern property as an optional property.
+
+    Example:
+        Replaces `cc2a00e69f7a4dd8b560f4e48911206f_3_1` with `MD5HASH_int_int_0`.
+    """
+
+    count = 0
+    result = {}
+    for key, item in event.items():
+        if re.match(r"^[a-f0-9]{32}_[0-9]+_[0-9]+$", key):
+            key = f"MD5HASH_int_int_{count}"
+            count += 1
+        if isinstance(item, dict):
+            result[key] = replace_pattern_properties(item)
+            continue
+        result[key] = item
+    return result
+
+
+def generate_json_schemas(input_file: TextIO, model_selector: ModelSelector):
+    """Generates JSON schemas reading from input file line by line."""
+
+    json_schemas = {}
+    for event_str in input_file:
+        try:
+            # Parse the event and check if it's Unknown.
+            event = json.loads(event_str)
+            model_selector.get_model(event)
+        except (json.JSONDecodeError, TypeError):
+            message = "Input event is not a valid JSON string"
+            logger.error(message)
+        except UnknownEventException:
+            # Event is unknown.
+            if "event_source" not in event or "event_type" not in event:
+                continue
+            event = replace_pattern_properties(event)
+            # The title of browser event `seq_goto` should be `SeqGotoBrowserEventModel`.
+            title = f"{event['event_type']}.{event['event_source']}.event.model"
+            title = "".join(x.capitalize() for x in title.replace("_", ".").split("."))
+            builder = SchemaBuilder()
+            # Retrieve the schema by title, if we have already defined it before or use a new one.
+            new_schema = {"title": title, "type": "object", "properties": {}}
+            builder.add_schema(json_schemas.get(title, new_schema))
+            # Update the schema with the current event.
+            builder.add_object(event)
+            # Store the updated schema in json_schemas.
+            json_schemas[title] = builder.to_schema()
+
+    for schema in json_schemas.values():
+        yield json.dumps(schema)


### PR DESCRIPTION
## Purpose

Generating JSON schemas from existing data could help us define relevant pydantic models.

## Proposal

Maybe we could run this version of ralph on one log file (in test environment?) to get a first look at the edX event schemas ?

I have run it on my logs in local and got the following results:  https://pastebin.com/SFrc4RNU
By [parsing the nested JSONs](https://github.com/openfun/ralph/pull/81/commits/d62f7ca40c591ae1530951f5aec874051fadde60) in the events it's possible to get their schema too: https://pastebin.com/Cpb2jBd0 
The `datamodel-codegen` generated pydantic models are [here](https://github.com/SergioSim/ralph/commit/b66add20d5060971ecafcf734be5f11256359563).