### PR TITLE
🔒(project) add system package upgrades in docker image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Install security updates in project Docker images
 - Model selector to retrieve associated pydantic model of a given event
 - `validate` command to lint edx events using pydantic models
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.9-slim as base
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN pip install --upgrade pip
 
+# Upgrade system packages to install security updates
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    rm -rf /var/lib/apt/lists/*
+    
+
 # -- Builder --
 FROM base as builder
 


### PR DESCRIPTION
## Purpose

In Docker images, the upgrades of system packages is not run when building. It represents a security failure, as we let failures of
previous packages versions in the images. 

## Proposal

We have added the `apt-get upgrade` command to ensure that packages are up-to-date with their latest version and security failures have been removed.


