### PR TITLE
📝(project) change documentation primary color

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,9 @@ copyright: 2020-present GIP FUN MOOC
 
 theme:
     name: material
-    highlightjs: true
-
+    palette:
+        primary: deep purple
+        
 markdown_extensions:
     - attr_list
     - mkdocs_click
@@ -19,6 +20,8 @@ markdown_extensions:
     - toc:
         permalink: True
         separator: "_"
+    - pymdownx.highlight
+    - pymdownx.superfences
 
 nav:
     - 'Getting started':


### PR DESCRIPTION
## Purpose

mk-docs based documentation proposes a color customization. By default, the primary color of the documentation is set to `indigo`.

## Proposal

- [x] set the `ralph` documentation primary color to `deep purple`

![image](https://user-images.githubusercontent.com/56359895/113879076-781fe700-97ba-11eb-9878-2c379efdca81.png)

