### PR TITLE
✨(models) add edx enrollment events pydantic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Implement edx navigational events pydantic models
+- Implement edx enrollment events pydantic models
 - Install security updates in project Docker images
 - Model selector to retrieve associated pydantic model of a given event
 - `validate` command to lint edx events using pydantic models

--- a/src/ralph/models/edx/__init__.py
+++ b/src/ralph/models/edx/__init__.py
@@ -2,5 +2,12 @@
 
 # flake8: noqa
 
+from .enrollment import (
+    EdxCourseEnrollmentActivated,
+    EdxCourseEnrollmentDeactivated,
+    EdxCourseEnrollmentModeChanged,
+    EdxCourseEnrollmentUpgradeSucceeded,
+    UIEdxCourseEnrollmentUpgradeClicked,
+)
 from .navigational import UIPageClose, UISeqGoto, UISeqNext, UISeqPrev
 from .server import ServerEvent

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -112,7 +112,7 @@ class BaseEvent(BaseModelWithConfig):
             Note:
                 Can be an empty string if the header is not present in the request.
                 Contains the default language settings of the user.
-        context (BaseContextModel): see BaseContextModel.
+        context (BaseContextField): see BaseContextField.
         time (datetime): Consists of the UTC time in ISO format at which the event was emitted.
             Retrieved with:
                 `datetime.datetime.utcnow()`

--- a/src/ralph/models/edx/enrollment.py
+++ b/src/ralph/models/edx/enrollment.py
@@ -1,0 +1,172 @@
+"""Enrollment event model definitions"""
+
+from typing import Literal, Union
+
+from pydantic import Json
+
+from ralph.models.selector import selector
+
+from .base import AbstractBaseEventField, BaseContextField
+from .browser import BaseBrowserEvent
+from .server import BaseServerEvent
+
+
+class EnrollmentEventField(AbstractBaseEventField):
+    """Represents the `event` field for enrollment events.
+
+    Note: Only server enrollment events require an `event` field.
+
+    Attributes:
+        course_id (str): Consists in the course in which the student was enrolled or unenrolled.
+        mode (str): Takes either `audit`, `honor`, `professional` or `verified` value.
+            It identifies the student’s enrollment mode.
+        user_id (int): Identifies the student who was enrolled or unenrolled.
+    """
+
+    course_id: str
+    mode: Union[
+        Literal["audit"], Literal["honor"], Literal["professional"], Literal["verified"]
+    ]
+    user_id: Union[int, Literal[""], None]
+
+
+class EdxCourseEnrollmentUpgradeClickedContextField(BaseContextField):
+    """Represents the `context` field of the `edx.course.enrollment.upgrade_clicked` server event.
+
+    In addition to the common context member fields, this event also includes
+    the `mode` context member field.
+
+    Attribute:
+        mode (str): Consists of either the `audit` or `honor` value.
+            It identifies the enrollment mode when the user clicked <kbd>Challenge Yourself</kbd>:
+    """
+
+    mode: Union[Literal["audit"], Literal["honor"]]
+
+
+class EdxCourseEnrollmentUpgradeSucceededContextField(BaseContextField):
+    """Represents the `context` field of the `edx.course.enrollment.upgrade.succeeded` server event.
+
+    In addition to the common context member fields, this event also includes
+    the `mode` context member field.
+
+    Attribute:
+        mode (str): Consists of the `verified` value.
+    """
+
+    mode: Literal["verified"]
+
+
+class EdxCourseEnrollmentActivated(BaseServerEvent):
+    """Represents the `edx.course.enrollment.activated` server event.
+
+    When a student enrolls in a course, the server emits this event.
+
+    Attributes:
+        event (EnrollmentEventField): See EnrollmentEventField.
+        event_type (str): Consists of the value `edx.course.enrollment.activated`.
+        name (str): Consists of the value `edx.course.enrollment.activated`.
+    """
+
+    __selector__ = selector(
+        event_source="server", event_type="edx.course.enrollment.activated"
+    )
+
+    event: Union[
+        Json[EnrollmentEventField],  # pylint: disable=unsubscriptable-object
+        EnrollmentEventField,
+    ]
+    event_type: Literal["edx.course.enrollment.activated"]
+    name: Literal["edx.course.enrollment.activated"]
+
+
+class EdxCourseEnrollmentDeactivated(BaseServerEvent):
+    """Represents the `edx.course.enrollment.deactivated` server event.
+
+    When a student unenrolls from a course, the server emits this event.
+
+    Attributes:
+        event (EnrollmentEventField): See EnrollmentEventField.
+        event_type (str): Consists of the value `edx.course.enrollment.deactivated`.
+        name (str): Consists of the value `edx.course.enrollment.deactivated`.
+    """
+
+    __selector__ = selector(
+        event_source="server", event_type="edx.course.enrollment.deactivated"
+    )
+
+    event: Union[
+        Json[EnrollmentEventField],  # pylint: disable=unsubscriptable-object
+        EnrollmentEventField,
+    ]
+    event_type: Literal["edx.course.enrollment.deactivated"]
+    name: Literal["edx.course.enrollment.deactivated"]
+
+
+class EdxCourseEnrollmentModeChanged(BaseServerEvent):
+    """Represents the `edx.course.enrollment.mode_changed` server event.
+
+    The server emits this event when the process of changing a student’s
+    student_courseenrollment.mode to a different mode is complete.
+
+    Attributes:
+        event (EnrollmentEventField): See EnrollmentEventField.
+        event_type (str): Consists of the value `edx.course.enrollment.mode_changed`.
+        name (str): Consists of the value `edx.course.enrollment.mode_changed`.
+    """
+
+    __selector__ = selector(
+        event_source="server", event_type="edx.course.enrollment.mode_changed"
+    )
+
+    event: Union[
+        Json[EnrollmentEventField],  # pylint: disable=unsubscriptable-object
+        EnrollmentEventField,
+    ]
+    event_type: Literal["edx.course.enrollment.mode_changed"]
+    name: Literal["edx.course.enrollment.mode_changed"]
+
+
+class UIEdxCourseEnrollmentUpgradeClicked(BaseBrowserEvent):
+    """Represents the `edx.course.enrollment.upgrade_clicked` browser event.
+
+    The browser emits this event when a student clicks <kbd>ChallengeYourself</kbd> option,
+    and the process of upgrading the student_courseenrollment.mode for the student
+    to `verified` begins.
+
+    Attributes:
+        context (EdxCourseEnrollmentUpgradeClickedContextField):
+            See EdxCourseEnrollmentUpgradeClickedContextField.
+        event_type (str): Consists of the value `edx.course.enrollment.upgrade_clicked`.
+        name (str): Consists of the value `edx.course.enrollment.upgrade_clicked`.
+    """
+
+    __selector__ = selector(
+        event_source="browser", event_type="edx.course.enrollment.upgrade_clicked"
+    )
+
+    context: EdxCourseEnrollmentUpgradeClickedContextField
+    event_type: Literal["edx.course.enrollment.upgrade_clicked"]
+    name: Literal["edx.course.enrollment.upgrade_clicked"]
+
+
+class EdxCourseEnrollmentUpgradeSucceeded(BaseServerEvent):
+    """Represents the `edx.course.enrollment.upgrade.succeeded` server event.
+
+    The server emits this event when the process of upgrading a student’s
+    student_courseenrollment.mode from `audit` or `honor` to `verified` is complete.
+
+    Attributes:
+        context (EdxCourseEnrollmentUpgradeSucceededContextField):
+            See EdxCourseEnrollmentUpgradeSucceededContextField.
+        event_type (str): Consists of the value `edx.course.enrollment.upgrade.succeeded`.
+        name (str): Consists of the value `edx.course.enrollment.upgrade.succeeded`.
+    """
+
+    __selector__ = selector(
+        event_source="server", event_type="edx.course.enrollment.upgrade.succeeded"
+    )
+
+    context: EdxCourseEnrollmentUpgradeSucceededContextField
+    event_type: Literal["edx.course.enrollment.upgrade.succeeded"]
+    name: Literal["edx.course.enrollment.upgrade.succeeded"]

--- a/tests/models/edx/test_enrollment.py
+++ b/tests/models/edx/test_enrollment.py
@@ -1,0 +1,123 @@
+"""Tests for the enrollment event models"""
+
+import json
+
+from hypothesis import given, provisional, settings
+from hypothesis import strategies as st
+
+from ralph.models.edx.enrollment import (
+    EdxCourseEnrollmentActivated,
+    EdxCourseEnrollmentDeactivated,
+    EdxCourseEnrollmentModeChanged,
+    EdxCourseEnrollmentUpgradeClickedContextField,
+    EdxCourseEnrollmentUpgradeSucceeded,
+    EdxCourseEnrollmentUpgradeSucceededContextField,
+    EnrollmentEventField,
+    UIEdxCourseEnrollmentUpgradeClicked,
+)
+from ralph.models.selector import ModelSelector
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        EdxCourseEnrollmentActivated,
+        referer=provisional.urls(),
+        event=st.builds(EnrollmentEventField),
+    )
+)
+def test_models_edx_edx_course_enrollment_activated_selector_with_valid_event(event):
+    """Tests given an edx.course.enrollment.activated event
+    the get_model method should return EdxCourseEnrollmentActivated model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event)
+        is EdxCourseEnrollmentActivated
+    )
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        EdxCourseEnrollmentDeactivated,
+        referer=provisional.urls(),
+        event=st.builds(EnrollmentEventField),
+    )
+)
+def test_models_edx_edx_course_enrollment_deactivated_selector_with_valid_event(event):
+    """Tests given an edx.course.enrollment.deactivated event
+    the get_model method should return EdxCourseEnrollmentDeactivated model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event)
+        is EdxCourseEnrollmentDeactivated
+    )
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        EdxCourseEnrollmentModeChanged,
+        referer=provisional.urls(),
+        event=st.builds(EnrollmentEventField),
+    )
+)
+def test_models_edx_edx_course_enrollment_mode_changed_selector_with_valid_event(event):
+    """Tests given an edx.course.enrollment.mode_changed event
+    the get_model method should return EdxCourseEnrollmentModeChanged model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event)
+        is EdxCourseEnrollmentModeChanged
+    )
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        UIEdxCourseEnrollmentUpgradeClicked,
+        referer=provisional.urls(),
+        page=provisional.urls(),
+        context=st.builds(EdxCourseEnrollmentUpgradeClickedContextField),
+    )
+)
+def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_selector_with_valid_event(
+    event,
+):
+    """Tests given an edx.course.enrollment.upgrade_clicked event
+    the get_model method should return UIEdxCourseEnrollmentUpgradeClicked model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event)
+        is UIEdxCourseEnrollmentUpgradeClicked
+    )
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        EdxCourseEnrollmentUpgradeSucceeded,
+        referer=provisional.urls(),
+        context=st.builds(EdxCourseEnrollmentUpgradeSucceededContextField),
+    )
+)
+def test_models_edx_edx_course_enrollment_upgrade_succeeded_selector_with_valid_event(
+    event,
+):
+    """Tests given an edx.course.enrollment.upgrade.succeeded event
+    the get_model method should return EdxCourseEnrollmentUpgradeSucceeded model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event)
+        is EdxCourseEnrollmentUpgradeSucceeded
+    )


### PR DESCRIPTION
## Purpose

edx enrollment events are common events in tracking logs and easy to represent. For the validation and selection commands of ralph, they are one of the easiest to modelise.

## Proposal

- [x] `pydantic` models
- [x] edge case tests
- [x] `selector` tests

