### PR TITLE
⚡️(tray) adjust probes configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrate model tests from factories to hypothesis strategies
 - Upgrade `python-swiftclient` to `3.11.1`
 - Tray: switch from openshift to k8s (BC)
+- Tray: remove useless deployment probes
 
 ### Fixed
 

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -44,17 +44,6 @@ spec:
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "while true; do echo -n '.'; sleep 3600; done"]
-          livenessProbe:
-            exec:
-              command: ["ralph", "--help"]
-            initialDelaySeconds: 3
-            # ralph can be slow to boot
-            timeoutSeconds: 10
-          readinessProbe:
-            exec:
-              command: ["ralph", "--help"]
-            # ralph can be slow to boot
-            timeoutSeconds: 10
           env:
             - name: RALPH_APP_DIR
               value: "/app/.ralph"


### PR DESCRIPTION
## Purpose

A readiness probe for a pod that is not a server is useless. ~Moreover, ralph CLI's boot is too greedy, we need to reduce the liveness probe frequency to reduce useless CPU usage.~

Edit: as stated by @madmatah the same remark applies to the liveness probe.

## Proposal

- [x] remove deploy `readinessProbe`
- [x] ~increase `livenessProbe` `periodSeconds` to 1 minute~
- [x] remove deploy `livenessProbe`

Edit: we've decided to completely remove probes as they seems useless for a CLI.