### PR TITLE
Convert problem interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,6 @@ venv.bak/
 .pylint.d
 .pytest_cache
 
-# Test fixtures
-data/
-
 # Documentation site
 site/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Edx to xAPI converter for `openassessmentblock.save_submission` event
 - EdX to xAPI converters for page `viewed` and`page_close` events
 - Implement core event format converter
 - xAPI video `played` pydantic models

--- a/src/ralph/models/edx/__init__.py
+++ b/src/ralph/models/edx/__init__.py
@@ -11,4 +11,5 @@ from .enrollment import (
 )
 from .navigational import UIPageClose, UISeqGoto, UISeqNext, UISeqPrev
 from .open_response_assessment import ORASaveSubmission
+from .problem import DemandhintDisplayed
 from .server import ServerEvent

--- a/src/ralph/models/edx/__init__.py
+++ b/src/ralph/models/edx/__init__.py
@@ -10,4 +10,5 @@ from .enrollment import (
     UIEdxCourseEnrollmentUpgradeClicked,
 )
 from .navigational import UIPageClose, UISeqGoto, UISeqNext, UISeqPrev
+from .open_response_assessment import ORASaveSubmission
 from .server import ServerEvent

--- a/src/ralph/models/edx/__init__.py
+++ b/src/ralph/models/edx/__init__.py
@@ -11,5 +11,5 @@ from .enrollment import (
 )
 from .navigational import UIPageClose, UISeqGoto, UISeqNext, UISeqPrev
 from .open_response_assessment import ORASaveSubmission
-from .problem import DemandhintDisplayed
+from .problem import DemandhintDisplayed, Showanswer
 from .server import ServerEvent

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -5,7 +5,7 @@ from ipaddress import IPv4Address
 from pathlib import Path
 from typing import Dict, Literal, Optional, Union
 
-from pydantic import BaseModel, HttpUrl, constr
+from pydantic import AnyHttpUrl, BaseModel, constr
 
 
 class BaseModelWithConfig(BaseModel):
@@ -125,7 +125,7 @@ class BaseEvent(BaseModelWithConfig):
     ip: Union[IPv4Address, Literal[""]]
     agent: str
     host: str
-    referer: Union[HttpUrl, Literal[""]]
+    referer: Union[AnyHttpUrl, Literal[""]]
     accept_language: str
     context: BaseContextField
     time: datetime

--- a/src/ralph/models/edx/converters/xapi/__init__.py
+++ b/src/ralph/models/edx/converters/xapi/__init__.py
@@ -4,5 +4,8 @@
 
 from .navigational import UIPageCloseToPageTerminated
 from .open_response_assessment import ORASaveSubmissionToQuestionSaved
-from .problem import DemandhintDisplayedToInteractionInteracted
+from .problem import (
+    DemandhintDisplayedToInteractionInteracted,
+    ShowanswerToInteractionAsked,
+)
 from .server import ServerEventToPageViewed

--- a/src/ralph/models/edx/converters/xapi/__init__.py
+++ b/src/ralph/models/edx/converters/xapi/__init__.py
@@ -4,4 +4,5 @@
 
 from .navigational import UIPageCloseToPageTerminated
 from .open_response_assessment import ORASaveSubmissionToQuestionSaved
+from .problem import DemandhintDisplayedToInteractionInteracted
 from .server import ServerEventToPageViewed

--- a/src/ralph/models/edx/converters/xapi/__init__.py
+++ b/src/ralph/models/edx/converters/xapi/__init__.py
@@ -3,4 +3,5 @@
 # flake8: noqa
 
 from .navigational import UIPageCloseToPageTerminated
+from .open_response_assessment import ORASaveSubmissionToQuestionSaved
 from .server import ServerEventToPageViewed

--- a/src/ralph/models/edx/converters/xapi/open_response_assessment.py
+++ b/src/ralph/models/edx/converters/xapi/open_response_assessment.py
@@ -1,0 +1,37 @@
+"""Open Response Assessment xAPI Converters"""
+
+from ralph.models.converter import ConversionItem
+from ralph.models.edx.open_response_assessment import ORASaveSubmission
+from ralph.models.xapi.constants import EXTENSION_RESPONSES_ID
+from ralph.models.xapi.open_response_assessment.statements import QuestionSaved
+
+from .base import BaseXapiConverter
+
+
+class ORASaveSubmissionToQuestionSaved(BaseXapiConverter):
+    """Converts an edX `openassessmentblock.save_submission` event to xAPI.
+
+    Example: John saved his answer to the Open Response Assessment question.
+    """
+
+    __src__ = ORASaveSubmission
+    __dest__ = QuestionSaved
+
+    def _get_conversion_items(self):
+        """Returns a set of ConversionItems used for conversion."""
+
+        conversion_items = super()._get_conversion_items()
+        return conversion_items.union(
+            {
+                ConversionItem(
+                    "object__id",
+                    "context__module__usage_key",
+                    lambda usage_key: f"{self.home_page}/{usage_key}",
+                ),
+                ConversionItem(
+                    "result__extensions__" + EXTENSION_RESPONSES_ID,
+                    "event__saved_response__parts",
+                    lambda parts: [part["text"] for part in parts],
+                ),
+            }
+        )

--- a/src/ralph/models/edx/converters/xapi/problem.py
+++ b/src/ralph/models/edx/converters/xapi/problem.py
@@ -1,0 +1,44 @@
+"""Problem interaction event xAPI Converter"""
+
+from ralph.models.converter import ConversionItem
+from ralph.models.edx.problem import DemandhintDisplayed
+from ralph.models.xapi.problem.constants import (
+    EXTENSION_SUPPLEMENTAL_INFO_ID,
+    EXTENSION_TOTAL_ITEMS_ID,
+)
+from ralph.models.xapi.problem.statements import InteractionInteracted
+
+from .base import BaseXapiConverter
+
+
+class DemandhintDisplayedToInteractionInteracted(BaseXapiConverter):
+    """Converts an `edx.problem.hint.demandhint_displayed` event to xAPI.
+
+    Example Statement: John interacted with the question interaction.
+    """
+
+    __src__ = DemandhintDisplayed
+    __dest__ = InteractionInteracted
+
+    def _get_conversion_items(self):
+        """Returns a set of ConversionItems used for conversion."""
+
+        conversion_items = super()._get_conversion_items()
+        return conversion_items.union(
+            {
+                ConversionItem(
+                    "object__id",
+                    "context__module__usage_key",
+                    lambda usage_key: f"{self.home_page}/{usage_key}",
+                ),
+                ConversionItem(
+                    "object__definition__extensions__" + EXTENSION_SUPPLEMENTAL_INFO_ID,
+                    "event__hint_index",
+                ),
+                ConversionItem(
+                    "object__definition__extensions__" + EXTENSION_TOTAL_ITEMS_ID,
+                    "event__hint_len",
+                ),
+                ConversionItem("result__response", "event__hint_text"),
+            }
+        )

--- a/src/ralph/models/edx/converters/xapi/problem.py
+++ b/src/ralph/models/edx/converters/xapi/problem.py
@@ -1,12 +1,12 @@
 """Problem interaction event xAPI Converter"""
 
 from ralph.models.converter import ConversionItem
-from ralph.models.edx.problem import DemandhintDisplayed
+from ralph.models.edx.problem import DemandhintDisplayed, Showanswer
 from ralph.models.xapi.problem.constants import (
     EXTENSION_SUPPLEMENTAL_INFO_ID,
     EXTENSION_TOTAL_ITEMS_ID,
 )
-from ralph.models.xapi.problem.statements import InteractionInteracted
+from ralph.models.xapi.problem.statements import InteractionAsked, InteractionInteracted
 
 from .base import BaseXapiConverter
 
@@ -40,5 +40,29 @@ class DemandhintDisplayedToInteractionInteracted(BaseXapiConverter):
                     "event__hint_len",
                 ),
                 ConversionItem("result__response", "event__hint_text"),
+            }
+        )
+
+
+class ShowanswerToInteractionAsked(BaseXapiConverter):
+    """Converts a `showanswer` event to xAPI.
+
+    Example: John asked for the response of an interaction.
+    """
+
+    __src__ = Showanswer
+    __dest__ = InteractionAsked
+
+    def _get_conversion_items(self):
+        """Returns a set of ConversionItems used for conversion."""
+
+        conversion_items = super()._get_conversion_items()
+        return conversion_items.union(
+            {
+                ConversionItem(
+                    "object__id",
+                    "context__module__usage_key",
+                    lambda usage_key: f"{self.home_page}/{usage_key}",
+                )
             }
         )

--- a/src/ralph/models/edx/open_response_assessment.py
+++ b/src/ralph/models/edx/open_response_assessment.py
@@ -1,0 +1,57 @@
+"""Open Response Assessment event model definitions"""
+
+from typing import Literal, Union
+
+from pydantic.types import Json
+
+from ralph.models.edx.base import AbstractBaseEventField, BaseModelWithConfig
+from ralph.models.edx.x_block import BaseXBlockEvent
+from ralph.models.selector import selector
+
+
+class ORASaveSubmissionEventSavedResponseField(BaseModelWithConfig):
+    """Represents the `openassessmentblock.save_submission` event saved_response field.
+
+    Attributes:
+        parts: Consists of a list of dictionaries with a `text` key holding the response value.
+    """
+
+    parts: list[dict[Literal["text"], str]]
+
+
+class ORASaveSubmissionEventField(AbstractBaseEventField):
+    """Represents the `openassessmentblock.save_submission` event field.
+
+    Attributes:
+        saved_response (str): Consist of a JSON string holding the users saved responses.
+            Note:
+                Responses have a length limit of 100000 in the front-end but not in the back-end.
+                Events are truncated at `TRACK_MAX_EVENT` length which is 50000 by default.
+                Also the `eventtracking.backends.logger.LoggerBackend` silently drops events when
+                they exceed `TRACK_MAX_EVENT`.
+    """
+
+    # pylint: disable=unsubscriptable-object
+    saved_response: Union[
+        Json[ORASaveSubmissionEventSavedResponseField],
+        ORASaveSubmissionEventSavedResponseField,
+    ]
+
+
+class ORASaveSubmission(BaseXBlockEvent):
+    """Represents the `openassessmentblock.save_submission` event.
+
+    This event is triggered when the user clicks on the `Save you progress` button
+    to save the current state of his response to an open assessment question.
+
+    Attributes:
+        event_type (str): Consists of the value `openassessmentblock.save_submission`.
+        event (str): See ORASaveSubmissionEventField.
+    """
+
+    __selector__ = selector(
+        event_source="server", event_type="openassessmentblock.save_submission"
+    )
+
+    event_type: Literal["openassessmentblock.save_submission"]
+    event: ORASaveSubmissionEventField

--- a/src/ralph/models/edx/problem.py
+++ b/src/ralph/models/edx/problem.py
@@ -2,6 +2,8 @@
 
 from typing import Literal
 
+from pydantic import constr
+
 from ralph.models.edx.base import AbstractBaseEventField
 from ralph.models.edx.x_block import BaseXBlockEvent
 from ralph.models.selector import selector
@@ -44,3 +46,24 @@ class DemandhintDisplayed(BaseXBlockEvent):
 
     event_type: Literal["edx.problem.hint.demandhint_displayed"]
     event: DemandhintDisplayedEventField
+
+
+class Showanswer(BaseXBlockEvent):
+    """Represents the `showanswer` event.
+
+    This event is triggered when the user requests the answer for a problem.
+
+    Attributes:
+        event_type (str): Consists of the value `showanswer`.
+        event (dict): Consists of a dictionary holding the block ID of the current problem.
+            Note:
+                The `problem_id` is equal to the `context.module.usage_key` of the event.
+    """
+
+    __selector__ = selector(event_source="server", event_type="showanswer")
+
+    event_type: Literal["showanswer"]
+    event: dict[
+        Literal["problem_id"],
+        constr(regex=r"^block-v1:.+\+.+\+.+type@.+@[a-f0-9]{32}$"),  # noqa:F722
+    ]

--- a/src/ralph/models/edx/problem.py
+++ b/src/ralph/models/edx/problem.py
@@ -1,0 +1,46 @@
+"""Problem interaction event model definitions"""
+
+from typing import Literal
+
+from ralph.models.edx.base import AbstractBaseEventField
+from ralph.models.edx.x_block import BaseXBlockEvent
+from ralph.models.selector import selector
+
+
+class DemandhintDisplayedEventField(AbstractBaseEventField):
+    """Represents the `edx.problem.hint.demandhint_displayed` event field.
+
+    Attributes:
+        hint_index (int): Consists of the identifier for the hint that was displayed to the user.
+            Note:
+                The first hint defined for a problem is identified with hint_index: 0.
+        hint_len (int): Consists of the total number of hints defined for this problem.
+        hint_text (str): Consists of the text of the hint that was displayed to the user.
+        module_id (str): Consists of the identifier for the problem component for which the user
+            requested the hint.
+            Note:
+                The `module_id` is equal to the `context.module.usage_key` of the event.
+    """
+
+    hint_index: int
+    hint_len: int
+    hint_text: str
+    module_id: str
+
+
+class DemandhintDisplayed(BaseXBlockEvent):
+    """Represents the `edx.problem.hint.demandhint_displayed` event.
+
+    This event is triggered when the user requests a hint for a problem.
+
+    Attributes:
+        event_type (str): Consists of the value `edx.problem.hint.demandhint_displayed`.
+        event (dict): See DemandhintDisplayedEventField.
+    """
+
+    __selector__ = selector(
+        event_source="server", event_type="edx.problem.hint.demandhint_displayed"
+    )
+
+    event_type: Literal["edx.problem.hint.demandhint_displayed"]
+    event: DemandhintDisplayedEventField

--- a/src/ralph/models/edx/x_block.py
+++ b/src/ralph/models/edx/x_block.py
@@ -1,0 +1,44 @@
+"""Base XBlock event model definition"""
+
+from typing import Literal
+
+from pydantic import constr
+
+from ralph.models.edx.base import BaseContextField, BaseModelWithConfig
+from ralph.models.edx.server import BaseServerEvent
+
+
+class ContextModuleField(BaseModelWithConfig):
+    """Represents the context `module` field.
+
+    Attributes:
+        usage_key (str): Consists of a block ID of the current component.
+        display_name (str): Consists of a short description or title of the component.
+    """
+
+    usage_key: constr(regex=r"^block-v1:.+\+.+\+.+type@.+@[a-f0-9]{32}$")  # noqa:F722
+    display_name: str
+
+
+class ContextField(BaseContextField):
+    """Represents the context field.
+
+    Attributes:
+        module (dict): see ContextModuleField.
+    """
+
+    module: ContextModuleField
+
+
+class BaseXBlockEvent(BaseServerEvent):
+    """Represents the base event model all events issued from XBlocks inherit from.
+
+    Attributes:
+        context (str): See ContextField.
+        username (str): Consists of the unique username identifying the logged in user.
+        page (str): Consists of the value `x_module`.
+    """
+
+    context: ContextField
+    username: constr(min_length=2, max_length=30)
+    page: Literal["x_module"]

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -14,12 +14,14 @@ ACTIVITY_PAGE_DISPLAY = "page"
 ACTIVITY_QUESTION_DISPLAY = "question"
 
 # xAPI verb IDs
+VERB_ASKED_ID = "http://adlnet.gov/expapi/verbs/asked"
 VERB_INTERACTED_ID = "http://adlnet.gov/expapi/verbs/interacted"
 VERB_SAVED_ID = "https://w3id.org/xapi/dod-isd/verbs/saved"
 VERB_TERMINATED_ID = "http://adlnet.gov/expapi/verbs/terminated"
 VERB_VIEWED_ID = "http://id.tincanapi.com/verb/viewed"
 
 # xAPI verb display names
+VERB_ASKED_DISPLAY = "asked"
 VERB_INTERACTED_DISPLAY = "interacted"
 VERB_SAVED_DISPLAY = "saved"
 VERB_TERMINATED_DISPLAY = "terminated"

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -4,19 +4,23 @@
 LANG_EN_US_DISPLAY = "en-US"
 
 # xAPI activity IDs
+ACTIVITY_INTERACTION_ID = "http://adlnet.gov/expapi/activities/interaction"
 ACTIVITY_PAGE_ID = "http://activitystrea.ms/schema/1.0/page"
 ACTIVITY_QUESTION_ID = "http://adlnet.gov/expapi/activities/question"
 
 # xAPI activity display names
+ACTIVITY_INTERACTION_DISPLAY = "interaction"
 ACTIVITY_PAGE_DISPLAY = "page"
 ACTIVITY_QUESTION_DISPLAY = "question"
 
 # xAPI verb IDs
+VERB_INTERACTED_ID = "http://adlnet.gov/expapi/verbs/interacted"
 VERB_SAVED_ID = "https://w3id.org/xapi/dod-isd/verbs/saved"
 VERB_TERMINATED_ID = "http://adlnet.gov/expapi/verbs/terminated"
 VERB_VIEWED_ID = "http://id.tincanapi.com/verb/viewed"
 
 # xAPI verb display names
+VERB_INTERACTED_DISPLAY = "interacted"
 VERB_SAVED_DISPLAY = "saved"
 VERB_TERMINATED_DISPLAY = "terminated"
 VERB_VIEWED_DISPLAY = "viewed"

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -5,6 +5,7 @@ LANG_EN_US_DISPLAY = "en-US"
 
 # xAPI activity IDs
 ACTIVITY_PAGE_ID = "http://activitystrea.ms/schema/1.0/page"
+ACTIVITY_QUESTION_ID = "http://adlnet.gov/expapi/activities/question"
 
 # xAPI activity display names
 ACTIVITY_PAGE_DISPLAY = "page"
@@ -25,3 +26,4 @@ VERB_PLAYED_DISPLAY = "played"
 EXTENSION_SCHOOL_ID = "https://w3id.org/xapi/acrossx/extensions/school"
 EXTENSION_COURSE_ID = "http://adlnet.gov/expapi/activities/course"
 EXTENSION_MODULE_ID = "http://adlnet.gov/expapi/activities/module"
+EXTENSION_RESPONSES_ID = "http://vocab.xapi.fr/extensions/responses"

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -1,28 +1,25 @@
 """Constants for xAPI specifications"""
 
-from typing import Literal
-
 # Languages
-LANG_EN_DISPLAY = Literal["en"]  # pylint:disable=invalid-name
-LANG_EN_US_DISPLAY = Literal["en-US"]  # pylint:disable=invalid-name
+LANG_EN_US_DISPLAY = "en-US"
 
-# xAPI activities
-ACTIVITY_PAGE_DISPLAY = Literal["page"]  # pylint:disable=invalid-name
-ACTIVITY_PAGE_ID = Literal[  # pylint:disable=invalid-name
-    "http://activitystrea.ms/schema/1.0/page"
-]
+# xAPI activity IDs
+ACTIVITY_PAGE_ID = "http://activitystrea.ms/schema/1.0/page"
 
-# xAPI verbs
-VERB_TERMINATED_DISPLAY = Literal["terminated"]  # pylint:disable=invalid-name
-VERB_TERMINATED_ID = Literal[  # pylint:disable=invalid-name
-    "http://adlnet.gov/expapi/verbs/terminated"
-]
-VERB_VIEWED_DISPLAY = Literal["viewed"]  # pylint:disable=invalid-name
-VERB_VIEWED_ID = Literal[  # pylint:disable=invalid-name
-    "http://id.tincanapi.com/verb/viewed"
-]
+# xAPI activity display names
+ACTIVITY_PAGE_DISPLAY = "page"
+ACTIVITY_QUESTION_DISPLAY = "question"
 
-VERB_PLAYED_DISPLAY = Literal["played"]  # pylint:disable=invalid-name
+# xAPI verb IDs
+VERB_SAVED_ID = "https://w3id.org/xapi/dod-isd/verbs/saved"
+VERB_TERMINATED_ID = "http://adlnet.gov/expapi/verbs/terminated"
+VERB_VIEWED_ID = "http://id.tincanapi.com/verb/viewed"
+
+# xAPI verb display names
+VERB_SAVED_DISPLAY = "saved"
+VERB_TERMINATED_DISPLAY = "terminated"
+VERB_VIEWED_DISPLAY = "viewed"
+VERB_PLAYED_DISPLAY = "played"
 
 # xAPI extensions
 EXTENSION_SCHOOL_ID = "https://w3id.org/xapi/acrossx/extensions/school"

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -1,8 +1,10 @@
 """Common xAPI verb field definitions"""
 
+from typing import Literal
+
 from ..config import BaseModelWithConfig
 from ..constants import (
-    LANG_EN_DISPLAY,
+    LANG_EN_US_DISPLAY,
     VERB_TERMINATED_DISPLAY,
     VERB_TERMINATED_ID,
     VERB_VIEWED_DISPLAY,
@@ -11,28 +13,28 @@ from ..constants import (
 
 
 class ViewedVerbField(BaseModelWithConfig):
-    """Represents the `verb` xAPI Field for page viewed xAPI statement.
+    """Represents the `verb` xAPI Field for the action `viewed`.
 
     Attributes:
        id (str): Consists of the value `http://id.tincanapi.com/verb/viewed`.
        display (dict): Consists of the dictionary `{"en": "viewed"}`.
     """
 
-    id: VERB_VIEWED_ID = VERB_VIEWED_ID.__args__[0]
-    display: dict[LANG_EN_DISPLAY, VERB_VIEWED_DISPLAY] = {
-        LANG_EN_DISPLAY.__args__[0]: VERB_VIEWED_DISPLAY.__args__[0]
+    id: Literal[VERB_VIEWED_ID] = VERB_VIEWED_ID
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_VIEWED_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: VERB_VIEWED_DISPLAY
     }
 
 
 class TerminatedVerbField(BaseModelWithConfig):
-    """Represents the `verb` xAPI Field for page terminated xAPI statement.
+    """Represents the `verb` xAPI Field for the action `terminated`.
 
     Attributes:
        id (str): Consists of the value `http://adlnet.gov/expapi/verbs/terminated`.
        display (dict): Consists of the dictionary `{"en": "terminated"}`.
     """
 
-    id: VERB_TERMINATED_ID = VERB_TERMINATED_ID.__args__[0]
-    display: dict[LANG_EN_DISPLAY, VERB_TERMINATED_DISPLAY] = {
-        LANG_EN_DISPLAY.__args__[0]: VERB_TERMINATED_DISPLAY.__args__[0]
+    id: Literal[VERB_TERMINATED_ID] = VERB_TERMINATED_ID
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_TERMINATED_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: VERB_TERMINATED_DISPLAY
     }

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -5,6 +5,8 @@ from typing import Literal
 from ..config import BaseModelWithConfig
 from ..constants import (
     LANG_EN_US_DISPLAY,
+    VERB_SAVED_DISPLAY,
+    VERB_SAVED_ID,
     VERB_TERMINATED_DISPLAY,
     VERB_TERMINATED_ID,
     VERB_VIEWED_DISPLAY,
@@ -37,4 +39,18 @@ class TerminatedVerbField(BaseModelWithConfig):
     id: Literal[VERB_TERMINATED_ID] = VERB_TERMINATED_ID
     display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_TERMINATED_DISPLAY]] = {
         LANG_EN_US_DISPLAY: VERB_TERMINATED_DISPLAY
+    }
+
+
+class SavedVerbField(BaseModelWithConfig):
+    """Represents the `verb` xAPI Field for the action `saved`.
+
+    Attributes:
+       id (str): Consists of the value `http://activitystrea.ms/schema/1.0/save`.
+       display (dict): Consists of the dictionary `{"en": "saved"}`.
+    """
+
+    id: Literal[VERB_SAVED_ID] = VERB_SAVED_ID
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_SAVED_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: VERB_SAVED_DISPLAY
     }

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -5,6 +5,8 @@ from typing import Literal
 from ..config import BaseModelWithConfig
 from ..constants import (
     LANG_EN_US_DISPLAY,
+    VERB_ASKED_DISPLAY,
+    VERB_ASKED_ID,
     VERB_INTERACTED_DISPLAY,
     VERB_INTERACTED_ID,
     VERB_SAVED_DISPLAY,
@@ -69,4 +71,18 @@ class InteractedVerbField(BaseModelWithConfig):
     id: Literal[VERB_INTERACTED_ID] = VERB_INTERACTED_ID
     display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_INTERACTED_DISPLAY]] = {
         LANG_EN_US_DISPLAY: VERB_INTERACTED_DISPLAY
+    }
+
+
+class AskedVerbField(BaseModelWithConfig):
+    """Represents the `verb` xAPI Field for the action `asked`.
+
+    Attributes:
+       id (str): Consists of the value `http://adlnet.gov/expapi/verbs/asked`.
+       display (dict): Consists of the dictionary `{"en-US": "asked"}`.
+    """
+
+    id: Literal[VERB_ASKED_ID] = VERB_ASKED_ID
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_ASKED_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: VERB_ASKED_DISPLAY
     }

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -5,6 +5,8 @@ from typing import Literal
 from ..config import BaseModelWithConfig
 from ..constants import (
     LANG_EN_US_DISPLAY,
+    VERB_INTERACTED_DISPLAY,
+    VERB_INTERACTED_ID,
     VERB_SAVED_DISPLAY,
     VERB_SAVED_ID,
     VERB_TERMINATED_DISPLAY,
@@ -53,4 +55,18 @@ class SavedVerbField(BaseModelWithConfig):
     id: Literal[VERB_SAVED_ID] = VERB_SAVED_ID
     display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_SAVED_DISPLAY]] = {
         LANG_EN_US_DISPLAY: VERB_SAVED_DISPLAY
+    }
+
+
+class InteractedVerbField(BaseModelWithConfig):
+    """Represents the `verb` xAPI Field for the action `interacted`.
+
+    Attributes:
+       id (str): Consists of the value `http://adlnet.gov/expapi/verbs/interacted`.
+       display (dict): Consists of the dictionary `{"en-US": "interacted"}`.
+    """
+
+    id: Literal[VERB_INTERACTED_ID] = VERB_INTERACTED_ID
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_INTERACTED_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: VERB_INTERACTED_DISPLAY
     }

--- a/src/ralph/models/xapi/navigation/fields/objects.py
+++ b/src/ralph/models/xapi/navigation/fields/objects.py
@@ -1,9 +1,9 @@
 """Navigation xAPI events object fields definitions"""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from ...base import BaseModelWithConfig
-from ...constants import ACTIVITY_PAGE_DISPLAY, ACTIVITY_PAGE_ID, LANG_EN_DISPLAY
+from ...constants import ACTIVITY_PAGE_DISPLAY, ACTIVITY_PAGE_ID, LANG_EN_US_DISPLAY
 from ...fields.objects import ObjectDefinitionExtensionsField, ObjectField
 
 
@@ -15,14 +15,14 @@ class PageObjectDefinitionField(BaseModelWithConfig):
 
     Attributes:
        type (str): Consists of the value `http://activitystrea.ms/schema/1.0/page`.
-       name (dict): Consists of the dictionary `{"en": "page"}`.
+       name (dict): Consists of the dictionary `{"en-US": "page"}`.
        extensions (dict): See ObjectDefinitionExtensionsField.
     """
 
-    name: dict[LANG_EN_DISPLAY, ACTIVITY_PAGE_DISPLAY] = {
-        LANG_EN_DISPLAY.__args__[0]: ACTIVITY_PAGE_DISPLAY.__args__[0]
+    name: dict[Literal[LANG_EN_US_DISPLAY], Literal[ACTIVITY_PAGE_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: ACTIVITY_PAGE_DISPLAY
     }
-    type: ACTIVITY_PAGE_ID = ACTIVITY_PAGE_ID.__args__[0]
+    type: Literal[ACTIVITY_PAGE_ID] = ACTIVITY_PAGE_ID
     extensions: Optional[ObjectDefinitionExtensionsField]
 
 

--- a/src/ralph/models/xapi/open_response_assessment/fields/objects.py
+++ b/src/ralph/models/xapi/open_response_assessment/fields/objects.py
@@ -1,0 +1,42 @@
+"""Open Response Assessment xAPI object field definitions"""
+
+from typing import Literal, Optional
+
+from ...base import BaseModelWithConfig
+from ...constants import (
+    ACTIVITY_QUESTION_DISPLAY,
+    ACTIVITY_QUESTION_ID,
+    LANG_EN_US_DISPLAY,
+)
+from ...fields.objects import ObjectDefinitionExtensionsField, ObjectField
+
+
+class QuestionObjectDefinitionField(BaseModelWithConfig):
+    """Represents the `object.definition` xAPI field for question saved xAPI statement.
+
+    WARNING: It doesn't include the recommended `description` field nor the optional `moreInfo`,
+    `Interaction properties` and `extensions` fields.
+
+    Attributes:
+       name (dict): Consists of the dictionary `{"en-US": "question"}`.
+       type (str): Consists of the value `http://adlnet.gov/expapi/activities/question`.
+       extensions (dict): See ObjectDefinitionExtensionsField.
+    """
+
+    name: dict[Literal[LANG_EN_US_DISPLAY], Literal[ACTIVITY_QUESTION_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: ACTIVITY_QUESTION_DISPLAY
+    }
+    type: Literal[ACTIVITY_QUESTION_ID] = ACTIVITY_QUESTION_ID
+    extensions: Optional[ObjectDefinitionExtensionsField]
+
+
+class QuestionObjectField(ObjectField):
+    """Represents the `object` xAPI field for question saved xAPI statement.
+
+    WARNING: It doesn't include the optional `objectType` field.
+
+    Attributes:
+        definition (QuestionObjectDefinitionField): See PageObjectDefinitionField.
+    """
+
+    definition: QuestionObjectDefinitionField = QuestionObjectDefinitionField()

--- a/src/ralph/models/xapi/open_response_assessment/fields/results.py
+++ b/src/ralph/models/xapi/open_response_assessment/fields/results.py
@@ -1,0 +1,26 @@
+"""Open Response Assessment xAPI events result fields definitions"""
+
+from pydantic import Field
+
+from ralph.models.xapi.config import BaseModelWithConfig
+from ralph.models.xapi.constants import EXTENSION_RESPONSES_ID
+
+
+class QuestionSavedResultExtensionsField(BaseModelWithConfig):
+    """Represents the `result.extensions` xAPI field for question saved xAPI statement.
+
+    Attributes:
+        responses (list of str): A list of saved responses for the question.
+    """
+
+    responses: list[str] = Field(alias=EXTENSION_RESPONSES_ID)
+
+
+class QuestionSavedResultField(BaseModelWithConfig):
+    """Represents the `result` xAPI field for question saved xAPI statement.
+
+    Attributes:
+        extensions (dict): see QuestionSavedResultExtensionsField.
+    """
+
+    extensions: QuestionSavedResultExtensionsField

--- a/src/ralph/models/xapi/open_response_assessment/statements.py
+++ b/src/ralph/models/xapi/open_response_assessment/statements.py
@@ -1,0 +1,22 @@
+"""Open Response Assessment xAPI statement definitions"""
+
+from ..base import BaseXapiModel
+from ..fields.verbs import SavedVerbField
+from .fields.objects import QuestionObjectField
+from .fields.results import QuestionSavedResultField
+
+
+class QuestionSaved(BaseXapiModel):
+    """Represents a question saved xAPI statement.
+
+    Example: John saved his answer to the Open Response Assessment question.
+
+    Attributes:
+       object (PageObjectField): See PageObjectField.
+       result (QuestionSavedResultField): See QuestionSavedResultField
+       verb (SavedVerbField): See SavedVerbField.
+    """
+
+    object: QuestionObjectField
+    result: QuestionSavedResultField
+    verb: SavedVerbField = SavedVerbField()

--- a/src/ralph/models/xapi/problem/constants.py
+++ b/src/ralph/models/xapi/problem/constants.py
@@ -1,0 +1,11 @@
+"""Constants for xAPI specifications"""
+
+# QUESTION supplemental-info should be a string but we use an integer.
+# May be we should coin a new extension? Example: "https://www.edx.org/extension/hint_index"
+EXTENSION_SUPPLEMENTAL_INFO_ID = (
+    "https://w3id.org/xapi/acrossx/extensions/supplemental-info"
+)
+
+# QUESTION total-items should be a string but we use an integer.
+# May be we should coin a new extension? Example: "https://www.edx.org/extension/hint_len"
+EXTENSION_TOTAL_ITEMS_ID = "https://w3id.org/xapi/acrossx/extensions/total-items"

--- a/src/ralph/models/xapi/problem/fields/objects.py
+++ b/src/ralph/models/xapi/problem/fields/objects.py
@@ -1,0 +1,63 @@
+"""Problem interaction xAPI object field definitions"""
+
+from typing import Literal, Optional
+
+from pydantic import Field
+
+from ralph.models.xapi.config import BaseModelWithConfig
+from ralph.models.xapi.constants import (
+    ACTIVITY_INTERACTION_DISPLAY,
+    ACTIVITY_INTERACTION_ID,
+    LANG_EN_US_DISPLAY,
+)
+from ralph.models.xapi.fields.objects import (
+    ObjectDefinitionExtensionsField,
+    ObjectField,
+)
+from ralph.models.xapi.problem.constants import (
+    EXTENSION_SUPPLEMENTAL_INFO_ID,
+    EXTENSION_TOTAL_ITEMS_ID,
+)
+
+
+class InteractionObjectDefinitionExtensionsField(ObjectDefinitionExtensionsField):
+    """Represents the `object.definition.extensions` xAPI field.
+
+    Attributes:
+        supplemental_info (int): Consists of the the index of the hint the user received.
+        total_items (int): Consists of the total number of available hints.
+    """
+
+    supplemental_info: Optional[int] = Field(alias=EXTENSION_SUPPLEMENTAL_INFO_ID)
+    total_items: Optional[int] = Field(alias=EXTENSION_TOTAL_ITEMS_ID)
+
+
+class InteractionObjectDefinitionField(BaseModelWithConfig):
+    """Represents the `object.definition` xAPI field of an interaction.
+
+    WARNING: It doesn't include the recommended `description` field nor the optional `moreInfo`
+    and `Interaction properties` fields.
+
+    Attributes:
+       name (dict): Consists of the dictionary `{"en-US": "interaction"}`.
+       type (str): Consists of the value `http://adlnet.gov/expapi/activities/interaction`.
+       extensions (dict): See ObjectDefinitionExtensionsField.
+    """
+
+    name: dict[Literal[LANG_EN_US_DISPLAY], Literal[ACTIVITY_INTERACTION_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: ACTIVITY_INTERACTION_DISPLAY
+    }
+    type: Literal[ACTIVITY_INTERACTION_ID] = ACTIVITY_INTERACTION_ID
+    extensions: Optional[InteractionObjectDefinitionExtensionsField]
+
+
+class InteractionObjectField(ObjectField):
+    """Represents the `object` xAPI field of an interaction.
+
+    WARNING: It doesn't include the optional `objectType` field.
+
+    Attributes:
+        definition (InteractionObjectDefinitionField): See InteractionObjectDefinitionField.
+    """
+
+    definition: InteractionObjectDefinitionField

--- a/src/ralph/models/xapi/problem/fields/objects.py
+++ b/src/ralph/models/xapi/problem/fields/objects.py
@@ -60,4 +60,4 @@ class InteractionObjectField(ObjectField):
         definition (InteractionObjectDefinitionField): See InteractionObjectDefinitionField.
     """
 
-    definition: InteractionObjectDefinitionField
+    definition: InteractionObjectDefinitionField = InteractionObjectDefinitionField()

--- a/src/ralph/models/xapi/problem/fields/results.py
+++ b/src/ralph/models/xapi/problem/fields/results.py
@@ -1,0 +1,13 @@
+"""Problem interaction xAPI events result fields definitions"""
+
+from ralph.models.xapi.config import BaseModelWithConfig
+
+
+class InteractionInteractedResultField(BaseModelWithConfig):
+    """Represents the `result` xAPI field for the interaction interacted xAPI statement.
+
+    Attributes:
+        response (str): Consists of the text of the hint that was displayed to the user.
+    """
+
+    response: str

--- a/src/ralph/models/xapi/problem/statements.py
+++ b/src/ralph/models/xapi/problem/statements.py
@@ -1,0 +1,22 @@
+"""Problem interaction xAPI statement definitions"""
+
+from ralph.models.xapi.base import BaseXapiModel
+from ralph.models.xapi.fields.verbs import InteractedVerbField
+from ralph.models.xapi.problem.fields.objects import InteractionObjectField
+from ralph.models.xapi.problem.fields.results import InteractionInteractedResultField
+
+
+class InteractionInteracted(BaseXapiModel):
+    """Represents an interaction interacted xAPI statement.
+
+    Example: John interacted with the question interaction.
+
+    Attributes:
+        object (InteractionObjectField): See InteractionObjectField.
+        result (InteractionInteractedResultField): See InteractionInteractedResultField
+        verb (InteractedVerbField): See InteractedVerbField.
+    """
+
+    object: InteractionObjectField
+    result: InteractionInteractedResultField
+    verb: InteractedVerbField = InteractedVerbField()

--- a/src/ralph/models/xapi/problem/statements.py
+++ b/src/ralph/models/xapi/problem/statements.py
@@ -1,7 +1,7 @@
 """Problem interaction xAPI statement definitions"""
 
 from ralph.models.xapi.base import BaseXapiModel
-from ralph.models.xapi.fields.verbs import InteractedVerbField
+from ralph.models.xapi.fields.verbs import AskedVerbField, InteractedVerbField
 from ralph.models.xapi.problem.fields.objects import InteractionObjectField
 from ralph.models.xapi.problem.fields.results import InteractionInteractedResultField
 
@@ -20,3 +20,17 @@ class InteractionInteracted(BaseXapiModel):
     object: InteractionObjectField
     result: InteractionInteractedResultField
     verb: InteractedVerbField = InteractedVerbField()
+
+
+class InteractionAsked(BaseXapiModel):
+    """Represents an interaction asked xAPI statement.
+
+    Example: John asked for the response of an interaction.
+
+    Attributes:
+        object (InteractionObjectField): See InteractionObjectField.
+        verb (AskedVerbField): See AskedVerbField.
+    """
+
+    object: InteractionObjectField
+    verb: AskedVerbField = AskedVerbField()

--- a/src/ralph/models/xapi/video/constants.py
+++ b/src/ralph/models/xapi/video/constants.py
@@ -1,23 +1,15 @@
 """Constants for xAPI video specifications"""
 
-from typing import Literal
-
 # xAPI video extensions
 VIDEO_EXTENSION_SESSION_ID = "https://w3id.org/xapi/video/extensions/session-id"
 VIDEO_EXTENSION_TIME = "https://w3id.org/xapi/video/extensions/time"
 
 
 # xAPI video ID
-VERB_VIDEO_PLAYED_ID = Literal[  # pylint:disable=invalid-name
-    "https://w3id.org/xapi/video/verbs/played"
-]
+VERB_VIDEO_PLAYED_ID = "https://w3id.org/xapi/video/verbs/played"
 
 # xAPI video object definition type
-VIDEO_OBJECT_DEFINITION_TYPE = Literal[  # pylint:disable=invalid-name
-    "https://w3id.org/xapi/video/activity-type/video"
-]
+VIDEO_OBJECT_DEFINITION_TYPE = "https://w3id.org/xapi/video/activity-type/video"
 
 # Video context category
-VIDEO_CONTEXT_CATEGORY = Literal[  # pylint:disable=invalid-name
-    "https://w3id.org/xapi/video"
-]
+VIDEO_CONTEXT_CATEGORY = "https://w3id.org/xapi/video"

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -25,8 +25,8 @@ class VideoPlayedContextActivitiesField(BaseModelWithConfig):
         category(dict): Consists of the dictionary {"id": "https://w3id.org/xapi/video"}.
     """
 
-    category: List[dict[Literal["id"], VIDEO_CONTEXT_CATEGORY]] = [
-        {Literal["id"]: VIDEO_CONTEXT_CATEGORY.__args__[0]}
+    category: List[dict[Literal["id"], Literal[VIDEO_CONTEXT_CATEGORY]]] = [
+        {"id": VIDEO_CONTEXT_CATEGORY}
     ]
 
 

--- a/src/ralph/models/xapi/video/fields/objects.py
+++ b/src/ralph/models/xapi/video/fields/objects.py
@@ -20,10 +20,10 @@ class VideoObjectDefinitionField(BaseModelWithConfig):
        type (str): Consists of the value `https://w3id.org/xapi/video/activity-type/video`.
     """
 
-    name: dict[LANG_EN_US_DISPLAY, ACTIVITY_PAGE_DISPLAY] = {
-        LANG_EN_US_DISPLAY.__args__[0]: ACTIVITY_PAGE_DISPLAY.__args__[0]
+    name: dict[Literal[LANG_EN_US_DISPLAY], Literal[ACTIVITY_PAGE_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: ACTIVITY_PAGE_DISPLAY
     }
-    type: VIDEO_OBJECT_DEFINITION_TYPE = VIDEO_OBJECT_DEFINITION_TYPE.__args__[0]
+    type: Literal[VIDEO_OBJECT_DEFINITION_TYPE] = VIDEO_OBJECT_DEFINITION_TYPE
 
 
 class VideoObjectField(ObjectField):

--- a/src/ralph/models/xapi/video/fields/verbs.py
+++ b/src/ralph/models/xapi/video/fields/verbs.py
@@ -1,5 +1,7 @@
 """Video xAPI events verb fields definitions"""
 
+from typing import Literal
+
 from ...base import BaseModelWithConfig
 from ...constants import LANG_EN_US_DISPLAY, VERB_PLAYED_DISPLAY
 from ..constants import VERB_VIDEO_PLAYED_ID
@@ -13,7 +15,7 @@ class VideoPlayedVerbField(BaseModelWithConfig):
         display (dict): Consists of the dictionary `{"en-US": "played"}`.
     """
 
-    id: VERB_VIDEO_PLAYED_ID = VERB_VIDEO_PLAYED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_PLAYED_DISPLAY] = {
-        LANG_EN_US_DISPLAY.__args__[0]: VERB_PLAYED_DISPLAY.__args__[0]
+    id: Literal[VERB_VIDEO_PLAYED_ID] = VERB_VIDEO_PLAYED_ID
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal[VERB_PLAYED_DISPLAY]] = {
+        LANG_EN_US_DISPLAY: VERB_PLAYED_DISPLAY
     }

--- a/tests/models/data/edx/navigational.json
+++ b/tests/models/data/edx/navigational.json
@@ -1,0 +1,112 @@
+[
+    {
+        "__comment__": "page_close event with logged-in user",
+        "username": "user",
+        "event_source": "browser",
+        "name": "page_close",
+        "accept_language": "en-US,en;q=0.5",
+        "time": "2020-04-18T13:23:04.198240+00:00",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "page": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "host": "7a4a1c08e030",
+        "session": "cc7ee04f8e4eb7e84f8c4c441cc78f40",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "context": {
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/event"
+        },
+        "ip": "172.20.0.1",
+        "event": "{}",
+        "event_type": "page_close"
+    },
+    {
+        "__comment__": "page_close event with anonymous user",
+        "username": "",
+        "event_source": "browser",
+        "name": "page_close",
+        "accept_language": "en-US,en;q=0.5",
+        "time": "2020-04-20T11:38:52.037467+00:00",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "page": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "host": "7a4a1c08e030",
+        "session": "694d2b38c5a017822b25e3a671ac4615",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "context": {
+            "user_id": null,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/event"
+        },
+        "ip": "172.20.0.1",
+        "event": "{}",
+        "event_type": "page_close"
+    },
+    {
+        "__comment__": "seq_goto event",
+        "username": "user",
+        "event_source": "browser",
+        "name": "seq_goto",
+        "accept_language": "en-US,en;q=0.5",
+        "time": "2020-05-06T20:40:19.866511+00:00",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "page": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "host": "7a4a1c08e030",
+        "session": "12303cedee495a1be10f399ac3ccf66b",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "context": {
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/event"
+        },
+        "ip": "172.20.0.1",
+        "event": "{\"new\": 1, \"old\": 1, \"id\": \"block-v1:organisationCourse+numeroCours+sessiondCours+type@sequential+block@e2fa42fa1ca645389ee4618c86e982ff\"}",
+        "event_type": "seq_goto"
+    },
+    {
+        "__comment__": "seq_next event",
+        "username": "sergios",
+        "event_source": "browser",
+        "name": "seq_next",
+        "accept_language": "en-US,en;q=0.5",
+        "time": "2020-05-06T20:41:52.622072+00:00",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "page": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "host": "7a4a1c08e030",
+        "session": "2c154864575c527ad87863148f05072e",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "context": {
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/event"
+        },
+        "ip": "172.20.0.1",
+        "event": "{\"new\": 2, \"old\": 1, \"id\": \"block-v1:organisationCourse+numeroCours+sessiondCours+type@sequential+block@e2fa42fa1ca645389ee4618c86e982ff\"}",
+        "event_type": "seq_next"
+    },
+    {
+        "__comment__": "seq_prev event",
+        "username": "sergios",
+        "event_source": "browser",
+        "name": "seq_prev",
+        "accept_language": "en-US,en;q=0.5",
+        "time": "2020-05-06T20:41:53.986326+00:00",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "page": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "host": "7a4a1c08e030",
+        "session": "2c154864575c527ad87863148f05072e",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "context": {
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/event"
+        },
+        "ip": "172.20.0.1",
+        "event": "{\"new\": 1, \"old\": 2, \"id\": \"block-v1:organisationCourse+numeroCours+sessiondCours+type@sequential+block@e2fa42fa1ca645389ee4618c86e982ff\"}",
+        "event_type": "seq_prev"
+    }
+]

--- a/tests/models/data/edx/open_response_assessment.json
+++ b/tests/models/data/edx/open_response_assessment.json
@@ -1,0 +1,83 @@
+[
+    {
+        "__comment__": "ORA save_submission event with 2 filled saved responses",
+        "username": "hello",
+        "event_type": "openassessmentblock.save_submission",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
+        "host": "9ae7771bd190",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e4b9180ab3304a4497dd379887370705/",
+        "accept_language": "",
+        "event": {
+            "saved_response": "{\"parts\": [{\"text\": \"This is my reponse\"}, {\"text\": \"une autre reponse\"}]}"
+        },
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 6,
+            "org_id": "organisationCourse",
+            "module": {
+                "usage_key": "block-v1:organisationCourse+numeroCours+sessiondCours+type@openassessment+block@b34a9cf1611c4dd09a9dcbdc556c6d90",
+                "display_name": "Open Response Assessment"
+            },
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@openassessment+block@b34a9cf1611c4dd09a9dcbdc556c6d90/handler/save_submission"
+        },
+        "time": "2020-07-30T05:22:36.045544+00:00",
+        "page": "x_module"
+    },
+    {
+        "__comment__": "ORA save_submission event with 1 filled and 1 emtpy saved response",
+        "username": "John",
+        "event_type": "openassessmentblock.save_submission",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
+        "host": "9ae7771bd190",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e4b9180ab3304a4497dd379887370705/",
+        "accept_language": "",
+        "event": {
+            "saved_response": "{\"parts\": [{\"text\": \"This is some other reponse!\"}, {\"text\": \"\"}]}"
+        },
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 4,
+            "org_id": "organisationCourse",
+            "module": {
+                "usage_key": "block-v1:organisationCourse+numeroCours+sessiondCours+type@openassessment+block@b34a9cf1611c4dd09a9dcbdc556c6d90",
+                "display_name": "Open Response Assessment"
+            },
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@openassessment+block@b34a9cf1611c4dd09a9dcbdc556c6d90/handler/save_submission"
+        },
+        "time": "2020-07-30T05:32:55.475978+00:00",
+        "page": "x_module"
+    },
+    {
+        "__comment__": "ORA save_submission event with 1 filled saved response",
+        "username": "jdupont",
+        "event_type": "openassessmentblock.save_submission",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
+        "host": "9ae7771bd190",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e4b9180ab3304a4497dd379887370705/",
+        "accept_language": "",
+        "event": {
+            "saved_response": "{\"parts\": [{\"text\": \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}, {\"text\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}"
+        },
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 5,
+            "org_id": "organisationCourse",
+            "module": {
+                "usage_key": "block-v1:organisationCourse+numeroCours+sessiondCours+type@openassessment+block@b34a9cf1611c4dd09a9dcbdc556c6d90",
+                "display_name": "Open Response Assessment"
+            },
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@openassessment+block@b34a9cf1611c4dd09a9dcbdc556c6d90/handler/save_submission"
+        },
+        "time": "2020-07-30T05:35:25.357747+00:00",
+        "page": "x_module"
+    }
+]

--- a/tests/models/data/edx/problem.json
+++ b/tests/models/data/edx/problem.json
@@ -1,0 +1,32 @@
+[
+    {
+        "__comment__": "demandhint_displayed event of a dropdown problem",
+        "username": "somebody",
+        "event_type": "edx.problem.hint.demandhint_displayed",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "host": "7a4a1c08e030",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/83b079f4f3844c2d9150a984d8248f2f/",
+        "accept_language": "",
+        "event": {
+            "hint_index": 0,
+            "module_id": "block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@113962f0bf80437c9c29ef081291dcad",
+            "hint_text": "A fruit is the fertilized ovary from a flower.",
+            "hint_len": 2
+        },
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "module": {
+                "usage_key": "block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@113962f0bf80437c9c29ef081291dcad",
+                "display_name": "Dropdown with Hints and Feedback"
+            },
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@113962f0bf80437c9c29ef081291dcad/handler/xmodule_handler/hint_button"
+        },
+        "time": "2020-05-14T12:56:15.813912+00:00",
+        "page": "x_module"
+    }
+]

--- a/tests/models/data/edx/problem.json
+++ b/tests/models/data/edx/problem.json
@@ -28,5 +28,32 @@
         },
         "time": "2020-05-14T12:56:15.813912+00:00",
         "page": "x_module"
+    },
+    {
+        "__comment__": "showanswer server event of a Checkbox problem",
+        "username": "admin",
+        "event_type": "showanswer",
+        "ip": "172.19.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0",
+        "host": "fcf907156c2f",
+        "referer": "http://localhost:8072/courses/course-v1:FUN+Demo+course/courseware/3dab5213382241f1954cbc9d193a0098/72bc587d439d4a53aac65286fbc21209/",
+        "accept_language": "",
+        "event": {
+            "problem_id": "block-v1:FUN+Demo+course+type@problem+block@28cf090c941a44a2b41f01e30320c0c2"
+        },
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 3,
+            "org_id": "FUN",
+            "module": {
+                "usage_key": "block-v1:FUN+Demo+course+type@problem+block@28cf090c941a44a2b41f01e30320c0c2",
+                "display_name": "Checkboxes with Hints and Feedback"
+            },
+            "course_id": "course-v1:FUN+Demo+course",
+            "path": "/courses/course-v1:FUN+Demo+course/xblock/block-v1:FUN+Demo+course+type@problem+block@28cf090c941a44a2b41f01e30320c0c2/handler/xmodule_handler/problem_show"
+        },
+        "time": "2021-06-12T11:48:21.501348+00:00",
+        "page": "x_module"
     }
 ]

--- a/tests/models/data/edx/server.json
+++ b/tests/models/data/edx/server.json
@@ -1,0 +1,85 @@
+[
+    {
+        "__comment__": "server event of a course page visit",
+        "username": "someUsername",
+        "event_type": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "host": "7a4a1c08e030",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "accept_language": "en-US,en;q=0.5",
+        "event": "{\"POST\": {}, \"GET\": {}}",
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/"
+        },
+        "time": "2020-04-18T13:23:03.357329+00:00",
+        "page": null
+    },
+    {
+        "__comment__": "server event of a problem retieval",
+        "username": "someUsername",
+        "event_type": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@e8bc718966e9441abc3ccf1a6429ee8b/handler/xmodule_handler/problem_get",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "host": "7a4a1c08e030",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "accept_language": "en-US,en;q=0.5",
+        "event": "{\"POST\": {}, \"GET\": {}}",
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@e8bc718966e9441abc3ccf1a6429ee8b/handler/xmodule_handler/problem_get"
+        },
+        "time": "2020-04-18T14:34:04.419315+00:00",
+        "page": null
+    },
+    {
+        "__comment__": "server event of an anonymous user",
+        "username": "",
+        "event_type": "/",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "host": "7a4a1c08e030",
+        "referer": "",
+        "accept_language": "en-US,en;q=0.5",
+        "event": "{\"POST\": {}, \"GET\": {}}",
+        "event_source": "server",
+        "context": {
+            "user_id": null,
+            "org_id": "",
+            "course_id": "",
+            "path": "/"
+        },
+        "time": "2020-04-20T09:44:18.884213+00:00",
+        "page": null
+    },
+    {
+        "__comment__": "server event with POST data",
+        "username": "someUsername",
+        "event_type": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@d9fd0115d0be4fe08281f2eaf361744c/handler/xmodule_handler/problem_check",
+        "ip": "172.20.0.1",
+        "agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0",
+        "host": "7a4a1c08e030",
+        "referer": "http://localhost:8072/courses/course-v1:organisationCourse+numeroCours+sessiondCours/courseware/b5722732abed4eb7ba823f0b4239d50d/e2fa42fa1ca645389ee4618c86e982ff/",
+        "accept_language": "en-US,en;q=0.5",
+        "event": "{\"POST\": {\"input_d9fd0115d0be4fe08281f2eaf361744c_2_1\": [\"China\"]}, \"GET\": {}}",
+        "event_source": "server",
+        "context": {
+            "course_user_tags": {},
+            "user_id": 2,
+            "org_id": "organisationCourse",
+            "course_id": "course-v1:organisationCourse+numeroCours+sessiondCours",
+            "path": "/courses/course-v1:organisationCourse+numeroCours+sessiondCours/xblock/block-v1:organisationCourse+numeroCours+sessiondCours+type@problem+block@d9fd0115d0be4fe08281f2eaf361744c/handler/xmodule_handler/problem_check"
+        },
+        "time": "2020-04-19T09:45:42.961458+00:00",
+        "page": null
+    }
+]

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -44,14 +44,14 @@ def test_navigational_ui_page_close_to_page_terminated(
         },
         "object": {
             "definition": {
-                "name": {"en": "page"},
+                "name": {"en-US": "page"},
                 "type": "http://activitystrea.ms/schema/1.0/page",
             },
             "id": event["page"],
         },
         "timestamp": event["time"],
         "verb": {
-            "display": {"en": "terminated"},
+            "display": {"en-US": "terminated"},
             "id": "http://adlnet.gov/expapi/verbs/terminated",
         },
     }

--- a/tests/models/edx/converters/xapi/test_open_response_assessment.py
+++ b/tests/models/edx/converters/xapi/test_open_response_assessment.py
@@ -1,0 +1,77 @@
+"""Tests for the open response assessment xAPI converters"""
+
+import json
+from uuid import UUID, uuid5
+
+import pytest
+from hypothesis import given, provisional, settings
+from hypothesis import strategies as st
+
+from ralph.models.converter import convert_dict_event
+from ralph.models.edx.converters.xapi.open_response_assessment import (
+    ORASaveSubmissionToQuestionSaved,
+)
+from ralph.models.edx.open_response_assessment import (
+    ORASaveSubmission,
+    ORASaveSubmissionEventField,
+    ORASaveSubmissionEventSavedResponseField,
+)
+from ralph.models.edx.x_block import ContextField, ContextModuleField
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        ORASaveSubmission,
+        referer=provisional.urls(),
+        context=st.builds(
+            ContextField,
+            user_id=st.just("1"),
+            path=st.just("https://fun-mooc.fr/"),
+            module=st.builds(ContextModuleField),
+        ),
+        event=st.builds(
+            ORASaveSubmissionEventField,
+            saved_response=st.builds(
+                ORASaveSubmissionEventSavedResponseField,
+                parts=st.just([{"text": "first"}, {"text": "second"}]),
+            ),
+        ),
+    ),
+    provisional.urls(),
+)
+@pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
+def test_open_response_assessment_ora_save_submission_to_quesiont_saved_conversion(
+    uuid_namespace, event, home_page
+):
+    """Tests that converting with `ORASaveSubmissionToQuestionSaved` returns the expected value."""
+
+    event_str = event.json()
+    event = json.loads(event_str)
+    xapi_event = convert_dict_event(
+        event, event_str, ORASaveSubmissionToQuestionSaved(uuid_namespace, home_page)
+    )
+    xapi_event_dict = json.loads(xapi_event.json(exclude_none=True, by_alias=True))
+    assert xapi_event_dict == {
+        "id": str(uuid5(UUID(uuid_namespace), event_str)),
+        "actor": {
+            "account": {"homePage": home_page, "name": "1"},
+        },
+        "object": {
+            "definition": {
+                "name": {"en-US": "question"},
+                "type": "http://adlnet.gov/expapi/activities/question",
+            },
+            "id": home_page + "/" + event["context"]["module"]["usage_key"],
+        },
+        "result": {
+            "extensions": {
+                "http://vocab.xapi.fr/extensions/responses": ["first", "second"]
+            }
+        },
+        "timestamp": event["time"],
+        "verb": {
+            "display": {"en-US": "saved"},
+            "id": "https://w3id.org/xapi/dod-isd/verbs/saved",
+        },
+    }

--- a/tests/models/edx/converters/xapi/test_problem.py
+++ b/tests/models/edx/converters/xapi/test_problem.py
@@ -1,0 +1,75 @@
+"""Tests for the problem interaction xAPI converters"""
+
+import json
+from uuid import UUID, uuid5
+
+import pytest
+from hypothesis import given, provisional, settings
+from hypothesis import strategies as st
+
+from ralph.models.converter import convert_dict_event
+from ralph.models.edx.converters.xapi.problem import (
+    DemandhintDisplayedToInteractionInteracted,
+)
+from ralph.models.edx.problem import DemandhintDisplayed, DemandhintDisplayedEventField
+from ralph.models.edx.x_block import ContextField, ContextModuleField
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        DemandhintDisplayed,
+        referer=provisional.urls(),
+        context=st.builds(
+            ContextField,
+            user_id=st.just("1"),
+            path=st.just("https://fun-mooc.fr/"),
+            module=st.builds(ContextModuleField),
+        ),
+        event=st.builds(DemandhintDisplayedEventField, hint_text=st.just("Hint text")),
+    ),
+    provisional.urls(),
+)
+@pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
+def test_demandhint_displayed_to_interaction_interacted_conversion(
+    uuid_namespace, event, home_page
+):
+    """Tests that converting with `DemandhintDisplayedToInteractionInteracted`
+    returns the expected value.
+    """
+
+    event_str = event.json()
+    event = json.loads(event_str)
+    xapi_event = convert_dict_event(
+        event,
+        event_str,
+        DemandhintDisplayedToInteractionInteracted(uuid_namespace, home_page),
+    )
+    xapi_event_dict = json.loads(xapi_event.json(exclude_none=True, by_alias=True))
+    assert xapi_event_dict == {
+        "id": str(uuid5(UUID(uuid_namespace), event_str)),
+        "actor": {
+            "account": {"homePage": home_page, "name": "1"},
+        },
+        "object": {
+            "definition": {
+                "name": {"en-US": "interaction"},
+                "type": "http://adlnet.gov/expapi/activities/interaction",
+                "extensions": {
+                    "https://w3id.org/xapi/acrossx/extensions/supplemental-info": event[
+                        "event"
+                    ]["hint_index"],
+                    "https://w3id.org/xapi/acrossx/extensions/total-items": event[
+                        "event"
+                    ]["hint_len"],
+                },
+            },
+            "id": home_page + "/" + event["context"]["module"]["usage_key"],
+        },
+        "result": {"response": event["event"]["hint_text"]},
+        "timestamp": event["time"],
+        "verb": {
+            "display": {"en-US": "interacted"},
+            "id": "http://adlnet.gov/expapi/verbs/interacted",
+        },
+    }

--- a/tests/models/edx/converters/xapi/test_problem.py
+++ b/tests/models/edx/converters/xapi/test_problem.py
@@ -10,8 +10,13 @@ from hypothesis import strategies as st
 from ralph.models.converter import convert_dict_event
 from ralph.models.edx.converters.xapi.problem import (
     DemandhintDisplayedToInteractionInteracted,
+    ShowanswerToInteractionAsked,
 )
-from ralph.models.edx.problem import DemandhintDisplayed, DemandhintDisplayedEventField
+from ralph.models.edx.problem import (
+    DemandhintDisplayed,
+    DemandhintDisplayedEventField,
+    Showanswer,
+)
 from ralph.models.edx.x_block import ContextField, ContextModuleField
 
 
@@ -71,5 +76,51 @@ def test_demandhint_displayed_to_interaction_interacted_conversion(
         "verb": {
             "display": {"en-US": "interacted"},
             "id": "http://adlnet.gov/expapi/verbs/interacted",
+        },
+    }
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        Showanswer,
+        referer=provisional.urls(),
+        context=st.builds(
+            ContextField,
+            user_id=st.just("1"),
+            path=st.just("https://fun-mooc.fr/"),
+            module=st.builds(ContextModuleField),
+        ),
+    ),
+    provisional.urls(),
+)
+@pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
+def test_showanswer_to_interaction_asked_conversion(uuid_namespace, event, home_page):
+    """Tests that converting with `ShowanswerToInteractionAsked` returns the expected value."""
+
+    event_str = event.json()
+    event = json.loads(event_str)
+    xapi_event = convert_dict_event(
+        event,
+        event_str,
+        ShowanswerToInteractionAsked(uuid_namespace, home_page),
+    )
+    xapi_event_dict = json.loads(xapi_event.json(exclude_none=True, by_alias=True))
+    assert xapi_event_dict == {
+        "id": str(uuid5(UUID(uuid_namespace), event_str)),
+        "actor": {
+            "account": {"homePage": home_page, "name": "1"},
+        },
+        "object": {
+            "definition": {
+                "name": {"en-US": "interaction"},
+                "type": "http://adlnet.gov/expapi/activities/interaction",
+            },
+            "id": home_page + "/" + event["context"]["module"]["usage_key"],
+        },
+        "timestamp": event["time"],
+        "verb": {
+            "display": {"en-US": "asked"},
+            "id": "http://adlnet.gov/expapi/verbs/asked",
         },
     }

--- a/tests/models/edx/converters/xapi/test_server.py
+++ b/tests/models/edx/converters/xapi/test_server.py
@@ -69,14 +69,14 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_val
         },
         "object": {
             "definition": {
-                "name": {"en": "page"},
+                "name": {"en-US": "page"},
                 "type": "http://activitystrea.ms/schema/1.0/page",
             },
             "id": home_page + "/main/blog",
         },
         "timestamp": event["time"],
         "verb": {
-            "display": {"en": "viewed"},
+            "display": {"en-US": "viewed"},
             "id": "http://id.tincanapi.com/verb/viewed",
         },
     }

--- a/tests/models/edx/test_open_response_assessment.py
+++ b/tests/models/edx/test_open_response_assessment.py
@@ -1,0 +1,37 @@
+"""Tests for the open response assessment event models"""
+
+import json
+
+from hypothesis import given, provisional, settings
+from hypothesis import strategies as st
+
+from ralph.models.edx.open_response_assessment import (
+    ORASaveSubmission,
+    ORASaveSubmissionEventField,
+    ORASaveSubmissionEventSavedResponseField,
+)
+from ralph.models.edx.x_block import ContextField
+from ralph.models.selector import ModelSelector
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        ORASaveSubmission,
+        context=st.builds(ContextField),
+        referer=provisional.urls(),
+        event=st.builds(
+            ORASaveSubmissionEventField,
+            saved_response=st.builds(ORASaveSubmissionEventSavedResponseField),
+        ),
+    )
+)
+def test_models_edx_ora_save_submission_with_valid_event(event):
+    """Tests given an `openassessmentblock.save_submission` event the get_model method
+    should return an ORASaveSubmission model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event) is ORASaveSubmission
+    )

--- a/tests/models/edx/test_problem.py
+++ b/tests/models/edx/test_problem.py
@@ -5,7 +5,11 @@ import json
 from hypothesis import given, provisional, settings
 from hypothesis import strategies as st
 
-from ralph.models.edx.problem import DemandhintDisplayed, DemandhintDisplayedEventField
+from ralph.models.edx.problem import (
+    DemandhintDisplayed,
+    DemandhintDisplayedEventField,
+    Showanswer,
+)
 from ralph.models.edx.x_block import ContextField
 from ralph.models.selector import ModelSelector
 
@@ -28,3 +32,18 @@ def test_models_edx_demandhint_displayed_with_valid_event(event):
     assert (
         ModelSelector(module="ralph.models.edx").get_model(event) is DemandhintDisplayed
     )
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        Showanswer,
+        context=st.builds(ContextField),
+        referer=provisional.urls(),
+    )
+)
+def test_models_edx_showanswer_with_valid_event(event):
+    """Tests given an `showanswer` event the get_model method should return a Showanswer model."""
+
+    event = json.loads(event.json())
+    assert ModelSelector(module="ralph.models.edx").get_model(event) is Showanswer

--- a/tests/models/edx/test_problem.py
+++ b/tests/models/edx/test_problem.py
@@ -1,0 +1,30 @@
+"""Tests for the open response assessment event models"""
+
+import json
+
+from hypothesis import given, provisional, settings
+from hypothesis import strategies as st
+
+from ralph.models.edx.problem import DemandhintDisplayed, DemandhintDisplayedEventField
+from ralph.models.edx.x_block import ContextField
+from ralph.models.selector import ModelSelector
+
+
+@settings(max_examples=1)
+@given(
+    st.builds(
+        DemandhintDisplayed,
+        context=st.builds(ContextField),
+        referer=provisional.urls(),
+        event=st.builds(DemandhintDisplayedEventField),
+    )
+)
+def test_models_edx_demandhint_displayed_with_valid_event(event):
+    """Tests given an `edx.problem.hint.demandhint_displayed` event the get_model method
+    should return an DemandhintDisplayed model.
+    """
+
+    event = json.loads(event.json())
+    assert (
+        ModelSelector(module="ralph.models.edx").get_model(event) is DemandhintDisplayed
+    )

--- a/tests/models/test_static_fixtures.py
+++ b/tests/models/test_static_fixtures.py
@@ -1,0 +1,42 @@
+"""Tests for the validate command using static fixtures"""
+
+import json
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from ralph.cli import cli
+from ralph.exceptions import BadFormatException
+
+
+def read_static_events(directory_path):
+    """Yields tuples (file, comment, event) for events found at the directory path."""
+
+    file_names = os.listdir(directory_path)
+    for file_name in file_names:
+        full_file_name = f"{directory_path}/{file_name}"
+        with open(full_file_name, "r") as file:
+            raw_static_events = file.read()
+        try:
+            parsed_static_events = json.loads(raw_static_events)
+        except (TypeError, json.JSONDecodeError) as err:
+            raise BadFormatException(
+                f"File `{full_file_name}` contains invalid JSON"
+            ) from err
+        for event in parsed_static_events:
+            comment = event.get("__comment__")
+            del event["__comment__"]
+            yield (file_name.replace(".json", ""), comment, event)
+
+
+@pytest.mark.parametrize("_,__,event", read_static_events("./tests/models/data/edx"))
+def test_static_edx_events(_, __, event):
+    """Tests the validate command using the static events from the data directory."""
+
+    event_str = json.dumps(event)
+    runner = CliRunner()
+    cli_args = ["-v", "DEBUG", "validate", "-f", "edx", "--fail-on-unknown"]
+    result = runner.invoke(cli, cli_args, input=event_str)
+    assert result.exception is None
+    assert result.exit_code == 0

--- a/tests/models/xapi/fields/test_objects.py
+++ b/tests/models/xapi/fields/test_objects.py
@@ -12,4 +12,4 @@ def test_models_xapi_fields_object_page_object_field(field):
     """Tests that a page object field contains a definition with the expected values."""
 
     assert field.definition.type == "http://activitystrea.ms/schema/1.0/page"
-    assert field.definition.name == {"en": "page"}
+    assert field.definition.name == {"en-US": "page"}

--- a/tests/models/xapi/fields/test_verbs.py
+++ b/tests/models/xapi/fields/test_verbs.py
@@ -10,7 +10,7 @@ def test_models_xapi_fields_verb_page_viewed_verb_field():
 
     assert json.loads(ViewedVerbField().json()) == {
         "id": "http://id.tincanapi.com/verb/viewed",
-        "display": {"en": "viewed"},
+        "display": {"en-US": "viewed"},
     }
 
 
@@ -19,5 +19,5 @@ def test_models_xapi_fields_verb_page_terminated_verb_field():
 
     assert json.loads(TerminatedVerbField().json()) == {
         "id": "http://adlnet.gov/expapi/verbs/terminated",
-        "display": {"en": "terminated"},
+        "display": {"en-US": "terminated"},
     }


### PR DESCRIPTION
## Purpose

`edx.problem.hint.demandhint_displayed`, `showanswer` and `problem_check` are common problem interaction related edX events which conversion to xAPI format is already documented by edX in [this google sheets](https://docs.google.com/spreadsheets/d/1Qx-1NkpCHXkWh8AagwHD5vzyBCdRXQVof10Ent_EDms/edit#gid=52329066).
We want to convert them to xAPI format.

## Proposal

Add `DemandhintDisplayedToInteractionInteracted`, `ShowanswerToInteractionAsked` and `ProblemCheckToInteractionAnswered` conversion sets.

- [x] edx.problem.hint.demandhint_displayed
- [x] showanswer
- [ ] problem_check

This PR is continuing the changes of  #103 and is blocked until #103 is merged.