### PR TITLE
🔧(project) add potsie bridged network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       discovery.type: single-node
     ports:
       - "9200:9200"
+    networks:
+      potsie:
+        aliases:
+          - elasticsearch
+      default:
 
   swift:
     image: kklopfenstein/openstack-swift-keystone-docker
@@ -35,3 +40,8 @@ services:
   # -- tools
   dockerize:
     image: jwilder/dockerize
+
+networks:
+  potsie:
+    name: potsie
+    external: true


### PR DESCRIPTION
## Purpose

To integrate the elasticsearch service with other data-related tools, we use a dedicated bridged network called "potsie".

## Proposal

- [x] add the `potsie` network to docker-compose configuration
