### PR TITLE
🐛(fixture) fix context management for gelf logger fixture

### DIFF
--- a/src/ralph/models/xapi/base.py
+++ b/src/ralph/models/xapi/base.py
@@ -14,7 +14,7 @@ class BaseXapiModel(BaseModelWithConfig):
     `context`, `result`, `stored`, `authority`, `version` and `attachments` fields.
 
     Attributes:
-        id (UUID): Consists of a generated UUID4 from the source event string.
+        id (UUID): Consists of a generated UUID string from the source event string.
         actor (ActorField): See ActorField.
         timestamp (datetime): Consists of the UTC time in ISO format when the event was emitted.
     """

--- a/tests/fixtures/logs.py
+++ b/tests/fixtures/logs.py
@@ -12,15 +12,15 @@ from logging_gelf.formatters import GELFFormatter
 def gelf_logger():
     """Generate a GELF logger to generate wrapped tracking log fixtures."""
 
-    # pylint: disable=consider-using-with
-    handler = logging.StreamHandler(NamedTemporaryFile(mode="w+", delete=False))
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(GELFFormatter(null_character=False))
+    with NamedTemporaryFile(mode="w+", delete=False) as temp_file:
+        handler = logging.StreamHandler(temp_file)
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(GELFFormatter(null_character=False))
 
-    # Generate a unique logger per test function to avoid stacking handlers on
-    # the same one
-    logger = logging.getLogger(f"test_logger_{token_hex(8)}")
-    logger.setLevel(logging.INFO)
-    logger.addHandler(handler)
+        # Generate a unique logger per test function to avoid stacking handlers on
+        # the same one
+        logger = logging.getLogger(f"test_logger_{token_hex(8)}")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
 
-    return logger
+        yield logger


### PR DESCRIPTION
## Purpose

With the upgrade of pylint package, the stream handler requires to use a context.

## Proposal

It was ignored in the pull request #112 concerning the upgrade, and fix here, additionnally with yielding the logger.

