### PR TITLE
✨(backends) add custom op_type support for es backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 - Install security updates in project Docker images
 - Model selector to retrieve associated pydantic model of a given event
 - `validate` command to lint edx events using pydantic models
+- Support all available bulk operation types for the elasticsearch backend
+  (create, index, update, delete) using the `--es-op-type` option
 
 ### Changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -299,6 +299,7 @@ def test_cli_fetch_command_usage():
         "    --ldp-application-key TEXT\n"
         "    --ldp-endpoint TEXT\n"
         "  es backend: \n"
+        "    --es-op-type TEXT\n"
         "    --es-client-options KEY=VALUE,KEY=VALUE\n"
         "    --es-index TEXT\n"
         "    --es-hosts TEXT\n"


### PR DESCRIPTION
## Purpose

Elasticsearch supports multiple operation types (aka `op_type`s) for bulk action requests: create, index, delete and update.

Using Elasticsearch new index templates requires that you perform "create" operations instead of the default "index" operation. We need more flexibility in Ralph.

## Proposal

We now support all operation types that can be specified as a backend option in the CLI commands that allow the usage of the elasticsearch backend:

```
--es-op-type [create|index|update|delete]
```
