### PR TITLE
🔖(major) bump release to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-07-09
+
 ### Added
 
 - xAPI video `interacted` pydantic models
@@ -95,7 +97,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v1.2.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v2.0.0...master
+[2.0.0]: https://github.com/openfun/ralph/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/openfun/ralph/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/openfun/ralph/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/openfun/ralph/compare/3d03d85...v1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 1.2.0
+version = 2.0.0
 description = A learning logs processor to feed your LRS
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module"""
 
-__version__ = "1.2.0"
+__version__ = "2.0.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 0.1.0
+  version: 2.0.0


### PR DESCRIPTION
## [2.0.0] - 2021-07-09

### Added

- xAPI video `interacted` pydantic models
- xAPI video `terminated` pydantic models
- xAPI video `completed` pydantic models
- xAPI video `seeked` pydantic models
- xAPI video `initialized` pydantic models
- xAPI video `paused` pydantic models
- `convert` command to transform edx events to xAPI format
- EdX to xAPI converters for page `viewed` and`page_close` events
- Implement core event format converter
- xAPI video `played` pydantic models
- xAPI page `viewed` and page `terminated` pydantic models
- Implement edx navigational events pydantic models
- Implement edx enrollment events pydantic models
- Install security updates in project Docker images
- Model selector to retrieve associated pydantic model of a given event
- `validate` command to lint edx events using pydantic models
- Support all available bulk operation types for the elasticsearch backend (create, index, update, delete) using the `--es-op-type` option

### Changed

- Upgrade `elasticsearch` to `7.13.2`
- Upgrade `python-swiftclient` to `3.12.0`
- Upgrade `click` to `8.0.1`
- Upgrade `click-option-group` to `0.5.3`
- Upgrade `pydantic` to `1.8.2`
- Upgrade `sentry_sdk` to `1.1.0`
- Rename edx models
- Migrate model tests from factories to hypothesis strategies
- Tray: switch from openshift to k8s (BC)
- Tray: remove useless deployment probes

### Fixed

- Tray: remove `version` immutable field in DC selector
