### PR TITLE
Fix elasticsearch datastream support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Upgrade `elasticsearch` to `7.13.3`
 
+### Fixed
+
+- Restore elasticsearch backend datastream compatibility for bulk operations
+
 ## [2.0.0] - 2021-07-09
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # -- backends
   elasticsearch:
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.13.3
     environment:
       discovery.type: single-node
     ports:

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -78,7 +78,6 @@ class ESDatabase(BaseDatabase):
                 "_index": self.index,
                 "_id": get_id(item),
                 "_op_type": self.op_type,
-                "_type": "document",
             }
             if self.op_type == "update":
                 action.update(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,5 @@ Module py.test fixtures
 """
 # pylint: disable=unused-import
 
-from .fixtures.backends import es, swift  # noqa: F401
+from .fixtures.backends import es, es_data_stream, swift  # noqa: F401
 from .fixtures.logs import gelf_logger  # noqa: F401

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -9,7 +9,9 @@ from elasticsearch import Elasticsearch
 from ralph.backends.storage.swift import SwiftStorage
 
 # Elasticsearch backend defaults
-ES_TEST_INDEX = os.environ.get("RALPH_ES_TEST_INDEX", "test-index")
+ES_TEST_INDEX = os.environ.get("RALPH_ES_TEST_INDEX", "test-index-foo")
+ES_TEST_INDEX_TEMPLATE = os.environ.get("RALPH_ES_TEST_INDEX_TEMPLATE", "test-index")
+ES_TEST_INDEX_PATTERN = os.environ.get("RALPH_ES_TEST_INDEX_PATTERN", "test-index-*")
 ES_TEST_HOSTS = os.environ.get("RALPH_ES_TEST_HOSTS", "http://localhost:9200").split(
     ","
 )
@@ -43,6 +45,50 @@ def es():
     client.indices.create(index=ES_TEST_INDEX)
     yield client
     client.indices.delete(index=ES_TEST_INDEX)
+
+
+@pytest.fixture
+def es_data_stream():
+    """Creates / deletes an ElasticSearch test datastream and yields an instantiated client."""
+
+    client = Elasticsearch(ES_TEST_HOSTS)
+
+    # Create statements index template with enabled data stream
+    index_template = {
+        "index_patterns": [ES_TEST_INDEX_PATTERN],
+        "data_stream": {},
+        "template": {
+            "mappings": {
+                "dynamic": True,
+                "dynamic_date_formats": [
+                    "strict_date_optional_time",
+                    "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z",
+                ],
+                "dynamic_templates": [],
+                "date_detection": True,
+                "numeric_detection": True,
+            },
+            "settings": {
+                "index": {
+                    "number_of_shards": "1",
+                    "number_of_replicas": "1",
+                }
+            },
+        },
+    }
+    client.transport.perform_request(
+        "PUT", f"/_index_template/{ES_TEST_INDEX_TEMPLATE}", body=index_template
+    )
+
+    # Create a datastream matching the index template
+    client.indices.create_data_stream(ES_TEST_INDEX)
+
+    yield client
+
+    client.indices.delete_data_stream(ES_TEST_INDEX)
+    client.transport.perform_request(
+        "DELETE", f"/_index_template/{ES_TEST_INDEX_TEMPLATE}"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Purpose

Pushing statements to an elasticsearch data stream fails due to index mapping inconsistency.

## Proposal

Removing the `"_type": "document"` to bulk actions seems to fix the issue.

Note that statements send to an elasticsearch data stream requires to name your timestamp field `@timestamp`.
