### PR TITLE
🔖(patch) bump release to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.0.1] - 2021-07-15
+
 ### Changed
 
 - Upgrade `elasticsearch` to `7.13.3`
@@ -105,7 +107,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v2.0.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v2.0.1...master
+[2.0.1]: https://github.com/openfun/ralph/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/openfun/ralph/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/openfun/ralph/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/openfun/ralph/compare/v1.0.0...v1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 2.0.0
+version = 2.0.1
 description = A learning logs processor to feed your LRS
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 2.0.0
+  version: 2.0.1


### PR DESCRIPTION
### Changed

- Upgrade `elasticsearch` to `7.13.3`

### Fixed

- Restore elasticsearch backend datastream compatibility for bulk operations
