### PR TITLE
Add websocket backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `ws` websocket stream backend (compatible with the `fetch` command)
+
 ### Changed
 
 - Upgrade `requests` to `2.26.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - `ws` websocket stream backend (compatible with the `fetch` command)
 - bundle `jq` in the `fundocker/ralph` Docker image
+- Tray: enable ralph app deployment command configuration
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - `ws` websocket stream backend (compatible with the `fetch` command)
+- bundle `jq` in the `fundocker/ralph` Docker image
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --upgrade pip
 RUN apt-get update && \
     apt-get -y upgrade && \
     rm -rf /var/lib/apt/lists/*
-    
+
 
 # -- Builder --
 FROM base as builder
@@ -20,12 +20,16 @@ COPY . /build/
 RUN apt-get update && \
     apt-get install -y gcc libc6-dev && \
     rm -rf /var/lib/apt/lists/*
-    
+
 RUN python setup.py install
 
 
 # -- Core --
 FROM base as core
+
+RUN apt-get update && \
+    apt-get install -y jq && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local /usr/local
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     pyyaml==5.4.1
     requests==2.26.0
     sentry_sdk==1.3.0
+    websockets==9.1
 package_dir =
     =src
 packages = find:

--- a/src/ralph/backends/__init__.py
+++ b/src/ralph/backends/__init__.py
@@ -8,3 +8,4 @@ class BackendTypes(Enum):
 
     DATABASE = auto()
     STORAGE = auto()
+    STREAM = auto()

--- a/src/ralph/backends/stream/__init__.py
+++ b/src/ralph/backends/stream/__init__.py
@@ -1,0 +1,4 @@
+"""Stream backends for Ralph"""
+
+from .base import BaseStream  # noqa: F401
+from .ws import WSStream  # noqa: F401

--- a/src/ralph/backends/stream/base.py
+++ b/src/ralph/backends/stream/base.py
@@ -1,0 +1,13 @@
+"""Base Stream backend for Ralph"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseStream(ABC):
+    """Base stream backend interface."""
+
+    name = "base"
+
+    @abstractmethod
+    def stream(self):
+        """Read records and stream them to stdout."""

--- a/src/ralph/backends/stream/ws.py
+++ b/src/ralph/backends/stream/ws.py
@@ -1,0 +1,38 @@
+"""Websocket stream backend for Ralph"""
+
+import asyncio
+import logging
+import sys
+
+import websockets
+
+from .base import BaseStream
+
+logger = logging.getLogger(__name__)
+
+
+class WSStream(BaseStream):
+    """Websocket stream backend."""
+
+    name = "ws"
+
+    def __init__(self, uri: str):
+        """Instantiate the websocket client.
+
+        uri: the URI to connect to
+        """
+
+        self.uri = uri
+
+    def stream(self):
+        """Stream websocket content to stdout."""
+        # pylint: disable=no-member
+
+        logger.debug("Streaming from websocket uri: %s", self.uri)
+
+        async def _stream():
+            async with websockets.connect(self.uri) as websocket:
+                while event := await websocket.recv():
+                    sys.stdout.buffer.write(bytes(f"{event}" + "\n", encoding="utf-8"))
+
+        asyncio.get_event_loop().run_until_complete(_stream())

--- a/src/ralph/defaults.py
+++ b/src/ralph/defaults.py
@@ -39,6 +39,15 @@ class StorageBackends(Enum):
     SWIFT = "ralph.backends.storage.swift.SwiftStorage"
 
 
+class StreamBackends(Enum):
+    """Enumerate streaming backend modules.
+
+    Adding an entry to this enum will make it available to the CLI.
+    """
+
+    WS = "ralph.backends.stream.ws.WSStream"
+
+
 def load_config(config_file_path):
     """Return a dictionary representing Ralph's configuration."""
 

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from ralph.backends import BackendTypes
 from ralph.backends.database.base import BaseDatabase as BaseDatabaseBackend
 from ralph.backends.storage.base import BaseStorage as BaseStorageBackend
+from ralph.backends.stream.base import BaseStream as BaseStreamBackend
 
 
 # Taken from Django utilities
@@ -41,6 +42,8 @@ def get_backend_type(backend_class):
         return BackendTypes.STORAGE
     if BaseDatabaseBackend in backend_class.__mro__:
         return BackendTypes.DATABASE
+    if BaseStreamBackend in backend_class.__mro__:
+        return BackendTypes.STREAM
     return None
 
 

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -42,8 +42,7 @@ spec:
         - name: ralph
           image: "{{ ralph_image_name }}:{{ ralph_image_tag }}"
           imagePullPolicy: Always
-          command: ["/bin/sh"]
-          args: ["-c", "while true; do echo -n '.'; sleep 3600; done"]
+          command: {{ ralph_app_command }}
           env:
             - name: RALPH_APP_DIR
               value: "/app/.ralph"

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -2,6 +2,10 @@
 ralph_image_name: "fundocker/ralph"
 ralph_image_tag: "latest"
 ralph_app_replicas: 0
+ralph_app_command:
+  - bash
+  - "-c"
+  - while true; do echo -n '.'; sleep 3600; done
 ralph_history_volume_size: 2Gi
 ralph_secret_name: "ralph-backends-{{ ralph_vault_checksum | default('undefined_ralph_vault_checksum') }}"
 ralph_es_ca_secret_name: "ralph-es-ca-{{ ralph_vault_checksum | default('undefined_ralph_vault_checksum') }}"

--- a/tests/backends/stream/test_base.py
+++ b/tests/backends/stream/test_base.py
@@ -1,0 +1,19 @@
+"""Tests for Ralph base stream backend"""
+
+from ralph.backends.stream.base import BaseStream
+
+
+def test_backends_stream_base_abstract_interface_with_implemented_abstract_method():
+    """Tests the interface mechanism with properly implemented abstract methods."""
+
+    class GoodStream(BaseStream):
+        """Correct implementation with required abstract methods."""
+
+        name = "good"
+
+        def stream(self):
+            """Fakes the stream method."""
+
+    GoodStream()
+
+    assert GoodStream.name == "good"

--- a/tests/backends/stream/test_ws.py
+++ b/tests/backends/stream/test_ws.py
@@ -1,0 +1,77 @@
+"""Tests for Ralph ws stream backend"""
+
+import json
+import sys
+from io import BytesIO
+
+import pytest
+import websockets
+
+from ralph.backends.stream.ws import WSStream
+
+from tests.fixtures.backends import WS_TEST_HOST, WS_TEST_PORT
+
+
+def test_backends_stream_ws_stream_instantiation(ws):
+    """Tests the WSStream backend instantiation."""
+    # pylint: disable=invalid-name,unused-argument
+
+    assert WSStream.name == "ws"
+
+    error = "missing 1 required positional argument: 'uri'"
+    with pytest.raises(TypeError, match=error):
+        WSStream()  # pylint: disable=no-value-for-parameter
+
+    uri = f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}"
+    client = WSStream(uri)
+    assert client.uri == uri
+
+
+def test_backends_stream_ws_stream_stream(ws, monkeypatch, events):
+    """Tests the WSStream backend stream method."""
+    # pylint: disable=invalid-name,unused-argument
+
+    client = WSStream(f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}")
+
+    # Mock stdout stream
+    class MockStdout:
+        """A simple mock for sys.stdout.buffer."""
+
+        buffer = BytesIO()
+
+    mock_stdout = MockStdout()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    try:
+        client.stream()
+    except websockets.exceptions.ConnectionClosedOK:
+        pass
+
+    mock_stdout.buffer.seek(0)
+    streamed_events = [json.loads(line) for line in mock_stdout.buffer.readlines()]
+    assert streamed_events == events
+
+
+def test_backends_stream_ws_stream_stream_when_server_stops(ws, monkeypatch, events):
+    """Tests the WSStream backend stream method when the websocket server stops."""
+    # pylint: disable=invalid-name,unused-argument
+
+    client = WSStream(f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}")
+
+    # Mock stdout stream
+    class MockStdout:
+        """A simple mock for sys.stdout.buffer."""
+
+        buffer = BytesIO()
+
+    mock_stdout = MockStdout()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    try:
+        client.stream()
+    except websockets.exceptions.ConnectionClosedOK:
+        pass
+
+    mock_stdout.buffer.seek(0)
+    streamed_events = [json.loads(line) for line in mock_stdout.buffer.readlines()]
+    assert streamed_events == events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,5 @@ Module py.test fixtures
 """
 # pylint: disable=unused-import
 
-from .fixtures.backends import es, es_data_stream, swift  # noqa: F401
+from .fixtures.backends import es, es_data_stream, events, swift, ws  # noqa: F401
 from .fixtures.logs import gelf_logger  # noqa: F401


### PR DESCRIPTION
## Purpose

Some logging tools provide websockets for real-time processing. This is a great added-value for Ralph to support consuming such streams.

## Proposal

- [x] add `ws` stream backend
- [x] install `jq` in ralph Docker image
- [x] allow to run a custom command in app deployment
- [x] add tests for the `ws` stream backend
