### PR TITLE
Update arnold image tag for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,9 +256,7 @@ jobs:
             echo "export K8S_DOMAIN=$(hostname -I | awk '{print $1}')" >> $BASH_ENV
             echo 'export ARNOLD_DEFAULT_VAULT_PASSWORD="arnold"' >> $BASH_ENV
             echo 'export ANSIBLE_VAULT_PASSWORD="${ARNOLD_DEFAULT_VAULT_PASSWORD}"' >> $BASH_ENV
-            # FIXME
-            # arnold image tag should point to the default value (the following line should be removed)
-            echo "export ARNOLD_IMAGE_TAG=migration-to-k8s" >> $BASH_ENV
+            echo "export ARNOLD_IMAGE_TAG=master" >> $BASH_ENV
             echo "export K3D_REGISTRY_NAME=k3d-registry.127.0.0.1.nip.io" >> $BASH_ENV
             echo "export K3D_REGISTRY_PORT=5000" >> $BASH_ENV
             source $BASH_ENV


### PR DESCRIPTION
## Purpose

The arnold image used for the CI is outdated. It was not updated in the pull request related to this update (see #127)

## Proposal

change arnold image tag from `migration-to-k8s` to `master`
