### PR TITLE
🔧(project) add 'run' Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,11 @@ logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app
 .PHONY: logs
 
+run: ## alias for run-es
+run: \
+	run-es
+.PHONY: run
+
 run-all: ## start all supported local backends
 run-all: \
 	run-es \


### PR DESCRIPTION
## Purpose

All our project have a default `make run` rule to start the development stack. This project seems to be an exception.

## Proposal

Elasticsearch is used by Ralph itself, but also grafana in the potsie project using the potsie network. This service should be targetted by the default `run` Makefile rule.
