### PR TITLE
🔧(project) better integrate Black code formatter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -128,6 +128,7 @@ disable=print-statement,
         dict-keys-not-iterating,
         dict-values-not-iterating,
         bad-continuation
+        bad-whitespace
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -303,7 +304,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=88
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -13,9 +13,10 @@ from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
 
 class GitmojiTitle(LineRule):
     """
-    This rule will enforce that each commit title is of the form "<gitmoji>(<scope>) <subject>"
-    where gitmoji is an emoji from the list defined in https://gitmoji.carloscuesta.me and
-    subject should be all lowercase
+    This rule will enforce that each commit title is of the form
+    "<gitmoji>(<scope>) <subject>" where gitmoji is an emoji from the list
+    defined in https://gitmoji.carloscuesta.me and subject should be all
+    lowercase
     """
 
     id = "UC1"
@@ -24,11 +25,11 @@ class GitmojiTitle(LineRule):
 
     def validate(self, title, _commit):
         """
-        Download the list possible gitmojis from the project's github repository and check that
-        title contains one of them.
+        Download the list possible gitmojis from the project's github
+        repository and check that title contains one of them.
         """
         gitmojis = requests.get(
-            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json"
+            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json"  # noqa
         ).json()["gitmojis"]
         emojis = [item["emoji"] for item in gitmojis]
         pattern = r"^({:s})\(.*\)\s[a-z].*$".format("|".join(emojis))

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ python_requires = >= 3.9
 [options.extras_require]
 dev =
     bandit==1.7.0
-    black==21.7b0
+    black==21.10b0
     factory-boy==3.2.1
     Faker==9.8.0
     flake8==4.0.1
@@ -79,7 +79,8 @@ universal = 1
 ;; Third-party packages configuration
 ;;
 [flake8]
-max-line-length = 99
+max-line-length = 88
+extend-ignore = E203
 exclude =
     .git,
     .venv,
@@ -91,11 +92,9 @@ exclude =
 
 [isort]
 known_ralph=ralph
-include_trailing_comma=True
-line_length=88
-multi_line_output=3
 sections=FUTURE,STDLIB,THIRDPARTY,RALPH,FIRSTPARTY,LOCALFOLDER
 skip_glob=venv
+profile=black
 
 [tool:pytest]
 addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=src/ralph --hypothesis-show-statistics

--- a/src/ralph/backends/storage/fs.py
+++ b/src/ralph/backends/storage/fs.py
@@ -30,7 +30,9 @@ class FSStorage(HistoryMixin, BaseStorage):
         logger.debug("File system storage path: %s", self._path)
 
     def _get_filepath(self, name, strict=False):
-        """Return path of the archive in the FS storage, or throws an exception if not found"""
+        """Return path of the archive in the FS storage, or throws an exception if
+        not found.
+        """
 
         file_path = self._path / Path(name)
         if strict and not file_path.exists():

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -48,10 +48,16 @@ class LDPStorage(HistoryMixin, BaseStorage):
     @property
     def _archive_endpoint(self):
         if None in (self.service_name, self.stream_id):
-            msg = "LDPStorage backend instance requires to set both service_name and stream_id"
+            msg = (
+                "LDPStorage backend instance requires to set both "
+                "service_name and stream_id"
+            )
             logger.error(msg)
             raise BackendParameterException(msg)
-        return f"/dbaas/logs/{self.service_name}/output/graylog/stream/{self.stream_id}/archive"
+        return (
+            f"/dbaas/logs/{self.service_name}/"
+            f"output/graylog/stream/{self.stream_id}/archive"
+        )
 
     def _details(self, name):
         """Get name archive details
@@ -65,7 +71,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
                 "md5": "01585b394be0495e38dbb60b20cb40a9",
                 "retrievalDelay": 0,
                 "retrievalState": "sealed",
-                "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+                "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
                 "size": 67906662,
             }
         """

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -49,14 +49,19 @@ class CommaSeparatedKeyValueParamType(click.ParamType):
     name = "key=value,key=value"
 
     def convert(self, value, param, ctx):
-        """Split value by comma and equal sign to return a dict build with key/value pairs."""
+        """Split value by comma and equal sign to return a dict build with key/value
+        pairs.
+        """
 
         # Parse options string
         try:
             options = dict(option.split("=") for option in value.split(","))
         except ValueError:
             self.fail(
-                "You should provide key=value pairs separated by commas, e.g. foo=bar,bar=2",
+                (
+                    "You should provide key=value pairs separated by commas, "
+                    "e.g. foo=bar,bar=2"
+                ),
                 param,
                 ctx,
             )

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -40,4 +40,6 @@ class UnsupportedBackendException(Exception):
 
 
 class ModelRulesException(Exception):
-    """Raised when a model rules list is a subset or superset of another model rules list"""
+    """Raised when a model rules list is a subset or superset of another model rules
+    list.
+    """

--- a/src/ralph/models/converter.py
+++ b/src/ralph/models/converter.py
@@ -43,10 +43,10 @@ class ConversionItem:
                 - When `src` is a path (ex. `context__user_id`) - the value is the item
                     of the event at the path.
                 - When `src` is `None` - the value is the whole event.
-            transformers (function or tuple of functions): The function(s) to apply on the source
-                value.
-            raw_input (bool): Flag indicating whether `get_value` will receive a raw event string
-                or a parsed event dictionary.
+            transformers (function or tuple of functions): The function(s) to apply on
+                the source value.
+            raw_input (bool): Flag indicating whether `get_value` will receive a raw
+                event string or a parsed event dictionary.
         """
 
         object.__setattr__(self, "dest", tuple(dest.split(MODEL_PATH_SEPARATOR)))
@@ -102,7 +102,8 @@ class BaseConversionSet(ABC):
 def convert_dict_event(
     event: dict, event_str: str, conversion_set: BaseConversionSet
 ) -> BaseModel:
-    """Converts the event dictionary using the provided original event string and conversion_set.
+    """Converts the event dictionary using the provided original event string and
+    conversion_set.
 
     Args:
         event (dict): The event to convert.
@@ -222,7 +223,8 @@ class Converter:
             TypeError: When the event_str is not of type string.
             JSONDecodeError: When the event_str is not a valid JSON string.
             UnknownEventException: When no matching model is found for the event.
-            MissingConversionSetException: When no matching conversion set is found for the event.
+            MissingConversionSetException: When no matching conversion set is found for
+                the event.
             ConversionException: When a field transformation fails.
             ValidationError: When the final converted event is invalid.
         """

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -46,8 +46,8 @@ class BaseContextField(BaseModelWithConfig):
                 )`
             Note:
                 Is only present when a course page is requested.
-                Is an empty dictionary when the user is not logged in or not found in the
-                `user_api_usercoursetag` table.
+                Is an empty dictionary when the user is not logged in or not found in
+                the `user_api_usercoursetag` table.
         user_id (int or str or None): Consists of the ID of the authenticated user.
             Retrieved with:
                 `request.user.pk` querying the `auth_user` table.
@@ -57,8 +57,9 @@ class BaseContextField(BaseModelWithConfig):
                 Is `None` when the user is not logged in.
         org_id (str): Consists of the organization name that lists the course.
             Retrieved with:
-                `course_id.org` where `course_id` is an `opaque_keys.edx.locator.CourseLocator`
-                which is created using the URL of the requested page.
+                `course_id.org` where `course_id` is an
+                `opaque_keys.edx.locator.CourseLocator` which is created using the URL
+                of the requested page.
             Note:
                 Is an empty string when the requested page is not a course page.
         course_id (str): Consists of the unique identifier for the visited course page.
@@ -68,7 +69,8 @@ class BaseContextField(BaseModelWithConfig):
                 of the requested page.
             Note:
                 Is an empty string when the requested page is not a course page.
-        path (Path): Consist of the relative URL (without the hostname) of the requested page.
+        path (Path): Consist of the relative URL (without the hostname) of the
+            requested page.
             Retrieved with:
                 `request.META['PATH_INFO']`
     """
@@ -84,7 +86,8 @@ class BaseContextField(BaseModelWithConfig):
 class AbstractBaseEventField(BaseModelWithConfig):
     """Represents the base model inherited by all `event` fields.
 
-    The base model does not have any attributes as event field does not have common sub-fields.
+    The base model does not have any attributes as event field does not have common
+    sub-fields.
     """
 
 
@@ -99,9 +102,10 @@ class BaseEdxModel(BaseModelWithConfig):
                 `request.user.username` querying the `auth_user` table.
             Note:
                 Is an empty string when the user is not logged in.
-                If an exception is raised when retrieving the username from the table then
-                the value is `anonymous`.
-                Usernames are made of 2-30 ASCII letters / numbers / underscores (_) / hyphens (-)
+                If an exception is raised when retrieving the username from the table
+                then the value is `anonymous`.
+                Usernames are made of 2-30 ASCII letters / numbers / underscores (_) /
+                hyphens (-)
         ip (IPv4Address or str): Consists of the public IPv4 address of the user.
             Retrieved with:
                 `get_ip(request)` cf. https://github.com/un33k/django-ipware/tree/1.1.0
@@ -132,7 +136,8 @@ class BaseEdxModel(BaseModelWithConfig):
                 Can be an empty string if the header is not present in the request.
                 Contains the default language settings of the user.
         context (BaseContextField): see BaseContextField.
-        time (datetime): Consists of the UTC time in ISO format at which the event was emitted.
+        time (datetime): Consists of the UTC time in ISO format at which the event was
+            emitted.
             Retrieved with:
                 `datetime.datetime.utcnow()`
         page (None): Consists of the value `None`

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -18,7 +18,8 @@ class BaseBrowserModel(BaseEdxModel):
         page (Path): Consists of the URL (with hostname) of the visited page.
             Retrieved with:
                 `window.location.href` from the JavaScript front-end.
-        session (str): Consists of the md5 encrypted Django session key or an empty string.
+        session (str): Consists of the md5 encrypted Django session key or an empty
+            string.
     """
 
     event_source: Literal["browser"]

--- a/src/ralph/models/edx/converters/xapi/base.py
+++ b/src/ralph/models/edx/converters/xapi/base.py
@@ -71,7 +71,9 @@ class BaseXapiConverter(BaseConversionSet):
 
     @staticmethod
     def parse_course_id(course_id: str):
-        """Returns a dictionary with `course` and `module` of edX event's `context.course_id`."""
+        """Returns a dictionary with `course` and `module` of edX event's
+        `context.course_id`.
+        """
 
         match = re.match(r"^course-v1:.+\+(.+)\+(.+)$", course_id)
         if not match:

--- a/src/ralph/models/edx/enrollment/fields/contexts.py
+++ b/src/ralph/models/edx/enrollment/fields/contexts.py
@@ -6,26 +6,26 @@ from ...base import BaseContextField
 
 
 class EdxCourseEnrollmentUpgradeClickedContextField(BaseContextField):
-    """Represents the `context` field of the `edx.course.enrollment.upgrade_clicked` server
-    statement.
+    """Represents the `context` field of the `edx.course.enrollment.upgrade_clicked`
+    server statement.
 
-    In addition to the common context member fields, this statement also comprises the `mode`
-    context member field.
+    In addition to the common context member fields, this statement also comprises the
+    `mode` context member field.
 
     Attributes:
-        mode (str): Consists of either the `audit` or `honor` value. It identifies the enrollment
-        mode when the user clicked <kbd>Challenge Yourself</kbd>.
+        mode (str): Consists of either the `audit` or `honor` value. It identifies the
+        enrollment mode when the user clicked <kbd>Challenge Yourself</kbd>.
     """
 
     mode: Union[Literal["audit"], Literal["honor"]]
 
 
 class EdxCourseEnrollmentUpgradeSucceededContextField(BaseContextField):
-    """Represents the `context` field of the `edx.course.enrollment.upgrade.succeeded` server
-    statement.
+    """Represents the `context` field of the `edx.course.enrollment.upgrade.succeeded`
+    server statement.
 
-    In addition to the common context member fields, this statement also comprises the `mode`
-    context member field.
+    In addition to the common context member fields, this statement also comprises the
+    `mode` context member field.
 
     Attributes:
         mode (str): Consists of the `verified` value.

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -11,7 +11,8 @@ class EnrollmentEventField(AbstractBaseEventField):
     Note: Only server enrollment statements require an `event` field.
 
     Attributes:
-        course_id (str): Consists in the course in which the student was enrolled or unenrolled.
+        course_id (str): Consists in the course in which the student was enrolled or
+            unenrolled.
         mode (str): Takes either `audit`, `honor`, `professional` or `verified` value.
             It identifies the student’s enrollment mode.
         user_id (int): Identifies the student who was enrolled or unenrolled.

--- a/src/ralph/models/edx/enrollment/statements.py
+++ b/src/ralph/models/edx/enrollment/statements.py
@@ -117,7 +117,8 @@ class EdxCourseEnrollmentUpgradeSucceeded(BaseServerModel):
     Attributes:
         context (EdxCourseEnrollmentUpgradeSucceededContextField):
             See EdxCourseEnrollmentUpgradeSucceededContextField.
-        event_type (str): Consists of the value `edx.course.enrollment.upgrade.succeeded`.
+        event_type (str): Consists of the value
+            `edx.course.enrollment.upgrade.succeeded`.
         name (str): Consists of the value `edx.course.enrollment.upgrade.succeeded`.
     """
 

--- a/src/ralph/models/edx/navigational/fields/events.py
+++ b/src/ralph/models/edx/navigational/fields/events.py
@@ -13,10 +13,11 @@ class NavigationalEventField(AbstractBaseEventField):
     Attributes:
         id (str): Consists of the edX ID of the sequence.
         old (int): For `seq_goto`, it consists of the index of the unit being jumped to.
-            For `seq_next` and `seq_prev`, it consists of the index of the unit being navigated to.
-        new (int): For `seq_goto`, it consists of the index of the unit being jumped from.
-            For `seq_next` and `seq_prev`, it consists of the index of the unit being navigated
-            away from.
+            For `seq_next` and `seq_prev`, it consists of the index of the unit being
+            navigated to.
+        new (int): For `seq_goto`, it consists of the index of the unit being jumped
+            from. For `seq_next` and `seq_prev`, it consists of the index of the unit
+            being navigated away from.
     """
 
     id: constr(

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -13,7 +13,8 @@ class QueueState(BaseModelWithConfig):
 
     Attributes:
         key (str): Consists of a secret string.
-        time (str): Consists of a string dump of a DateTime object in the format '%Y%m%d%H%M%S'.
+        time (str): Consists of a string dump of a DateTime object in the format
+            '%Y%m%d%H%M%S'.
     """
 
     key: str
@@ -68,14 +69,15 @@ class SubmissionAnswerField(BaseModelWithConfig):
     """Represents the information in a problem of `submission` field.
 
     Attributes:
-        answer (str, list): Consists of the answer string or a list of the answer strings if
-            multiple choices are allorwed.
+        answer (str, list): Consists of the answer string or a list of the answer
+            strings if multiple choices are allorwed.
         correct (bool): `True` if the `answer` value is correct, else `False`.
-        input_type (str): Consists of the type of value that the student supplies for the
-            `response_type`.
+        input_type (str): Consists of the type of value that the student supplies for
+            the `response_type`.
         question (str): Consists of the question text.
         response_type (str): Consists of the type of problem.
-        variant (str): Consists of the unique ID of the variant that was presented to this user.
+        variant (str): Consists of the unique ID of the variant that was presented to
+            this user.
     """
 
     answer: Union[str, List[str]]
@@ -90,11 +92,13 @@ class EdxProblemHintDemandhintDisplayedEventField(AbstractBaseEventField):
     """Represents the `event` field of `EdxProblemHintDemandhintDisplayed` model.
 
     Attributes:
-        hint_index (int): Consists of the identifier for the hint that was displayed to the user.
+        hint_index (int): Consists of the identifier for the hint that was displayed to
+            the user.
         hint_len (int): Consists of the total number of hints defined for this problem.
-        hint_text (str): Consists of the text of the hint that was displayed to the user.
-        module_id (str): Consists of the identifier for the problem component for which the user
-            requested the hint.
+        hint_text (str): Consists of the text of the hint that was displayed to the
+            user.
+        module_id (str): Consists of the identifier for the problem component for which
+            the user requested the hint.
     """
 
     hint_index: int
@@ -107,19 +111,22 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
     """Represents the `event` field of `EdxProblemHintFeedbackDisplayed` model.
 
     Attributes:
-        choice_all (list): Lists all of the answer choices for problems with multiple possible
-            answers defined.
-        correctness (bool): `True` if the `student_answer` value is correct, else `False`.
-        hint_label (str): Consists of the feedback message given for the answer correctness.
+        choice_all (list): Lists all of the answer choices for problems with multiple
+            possible answers defined.
+        correctness (bool): `True` if the `student_answer` value is correct, else
+            `False`.
+        hint_label (str): Consists of the feedback message given for the answer
+            correctness.
         hints (list): Consists of a text member field with the given feedback string.
-        module_id (str): Consists of the identifier for the problem component for which the user
-            received the feedback.
-        problem_part_id (str): Consists of the specific problem for which the user received
-            feedback.
+        module_id (str): Consists of the identifier for the problem component for which
+            the user received the feedback.
+        problem_part_id (str): Consists of the specific problem for which the user
+            received feedback.
         question_type (str): Consists of the XML tag that identifies the problem type.
-        student_answer (list): Consists of the answer value(s) selected or supplied by the user.
-        trigger_type (str): Identifies the type of feedback obtained by the `student_answer`
-            response. Consists either of `single` or `compound` value.
+        student_answer (list): Consists of the answer value(s) selected or supplied by
+            the user.
+        trigger_type (str): Identifies the type of feedback obtained by the
+            `student_answer` response. Consists either of `single` or `compound` value.
     """
 
     choice_all: Optional[List[str]]
@@ -143,9 +150,10 @@ class ProblemCheckEventField(AbstractBaseEventField):
     """Represents the `event` field of `ProblemCheck` model.
 
     Attributes:
-        answers (dict): Consists of a dictionary of problem ID and the corresponding internal
-            answer identifier for each problem.
-        attempts (int): Consists of the number of times the user attempted to answer the problem.
+        answers (dict): Consists of a dictionary of problem ID and the corresponding
+            internal answer identifier for each problem.
+        attempts (int): Consists of the number of times the user attempted to answer
+            the problem.
         correct_map (dict): Consists of the evaluation data for each answer.
         grade (int): Consists of the current grade value.
         max_grade (int): Consists of the maximum possible grade value.
@@ -182,8 +190,8 @@ class ProblemCheckFailEventField(AbstractBaseEventField):
     """Represents the `event` field of `ProblemCheckFail` model.
 
     Attributes:
-        answers (dict): Consists of a dictionary of problem ID and the internal answer identifier
-            for each problem.
+        answers (dict): Consists of a dictionary of problem ID and the internal answer
+            identifier for each problem.
         failure (str): Consists either of the `closed` or `unreset` value.
         problem_id (str): Consists of the ID of the problem that was checked.
         state (dict): Consists of the current problem state.
@@ -251,8 +259,8 @@ class UIProblemResetEventField(AbstractBaseEventField):
     """Represents the `event` field of `ProblemReset` model.
 
     Attributes:
-        answers (str, list): Consists of the answer string or a list of the answer strings if
-            multiple choices are allowed.
+        answers (str, list): Consists of the answer string or a list of the answer
+            strings if multiple choices are allowed.
     """
 
     answers: Union[str, List[str]]
@@ -262,8 +270,8 @@ class UIProblemShowEventField(AbstractBaseEventField):
     """Represents the `event` field of `ProblemShow` model.
 
     Attributes:
-        problem (str): Consists of the optional name value that the course creators supply or
-            the system-generated hash code for the problem being shown.
+        problem (str): Consists of the optional name value that the course creators
+            supply or the system-generated hash code for the problem being shown.
     """
 
     problem: str
@@ -307,8 +315,8 @@ class SaveProblemFailEventField(AbstractBaseEventField):
     """Represents the `event` field of `SaveProblemFail` model.
 
     Attributes:
-        answers (dict): Consists of a dict of the answer string or a list or a dict of the answer
-            strings if multiple choices are allowed.
+        answers (dict): Consists of a dict of the answer string or a list or a dict of
+            the answer strings if multiple choices are allowed.
         failure (str): Consists either of `closed` or `done` value.
         problem_id (str): Consists of the ID of the problem being saved.
         state (json): see StateField.
@@ -327,8 +335,8 @@ class SaveProblemSuccessEventField(AbstractBaseEventField):
     """Represents the `event` field of `SaveProblemSuccess` model.
 
     Attributes:
-        answers (dict): Consists of a dict of the answer string or a list or a dict of the answer
-            strings if multiple choices are allowed.
+        answers (dict): Consists of a dict of the answer string or a list or a dict of
+            the answer strings if multiple choices are allowed.
         problem_id (str): Consists of the ID of the problem being saved.
         state (json): see StateField.
     """

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -71,7 +71,8 @@ class UIProblemCheck(BaseBrowserModel):
     The browser emits this event when a user checks a problem.
 
     Attributes:
-        event (str): Consists of values of problem being checked, styled as `GET` parameters.
+        event (str): Consists of values of problem being checked, styled as `GET`
+        parameters.
         event_type (str): Consists of the value `problem_check`.
         name (str): Consists of the value `problem_check`.
     """
@@ -104,8 +105,8 @@ class ProblemCheck(BaseServerModel):
 class ProblemCheckFail(BaseServerModel):
     """Represents the `problem_check_fail` server event.
 
-    This event is triggered when a user checks a problem and a failure prevents the problem
-    from being checked successfully.
+    This event is triggered when a user checks a problem and a failure prevents the
+    problem from being checked successfully.
 
     Attributes:
         event (dict): See ProblemCheckFailEventField.

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -26,20 +26,29 @@ class ServerEventField(AbstractBaseEventField):
 class Server(BaseServerModel):
     """Represents a common server statement.
 
-    This type of event is triggered from the django middleware on each request excluding:
-    `/event`, `login`, `heartbeat`, `/segmentio/event` and `/performance`.
+    This type of event is triggered from the django middleware on each request
+    excluding: `/event`, `login`, `heartbeat`, `/segmentio/event` and `/performance`.
 
     Attributes:
-        event_type (str): Consist of the relative URL (without the hostname) of the requested page.
+        event_type (str): Consist of the relative URL (without the hostname) of the
+            requested page.
             Retrieved with:
                 `request.META['PATH_INFO']`
-        event (str): Consist of a JSON string holding the content of the GET or POST request.
+        event (str): Consist of a JSON string holding the content of the GET or POST
+            request.
             Retrieved with:
-                `json.dumps({'GET': dict(request.GET), 'POST': dict(request.POST)})[:512]`
+                ```json.dumps(
+                    {
+                        'GET': dict(request.GET),
+                        'POST': dict(request.POST)
+                    }
+                )[:512]```
             Note:
                 Values for ['password', 'newpassword', 'new_password', 'oldpassword',
-                'old_password', 'new_password1', 'new_password2'] are replaced by `********`.
-                The JSON string is truncated at 512 characters resulting in invalid JSON.
+                'old_password', 'new_password1', 'new_password2'] are replaced by
+                `********`.
+                The JSON string is truncated at 512 characters resulting in invalid
+                JSON.
     """
 
     __selector__ = selector(

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -7,6 +7,7 @@ from pydantic import Field, constr
 from ...base import AbstractBaseEventField
 
 
+# pylint: disable=line-too-long
 class TextbookInteractionBaseEventField(AbstractBaseEventField):
     """Represents the event field which attributes are common to most of the textbook
     interaction events.
@@ -20,7 +21,7 @@ class TextbookInteractionBaseEventField(AbstractBaseEventField):
     page: int
     chapter: constr(
         regex=(
-            r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa: F722
+            r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa
         )
     )
 
@@ -57,6 +58,7 @@ class TextbookPdfOutlineToggledEventField(TextbookInteractionBaseEventField):
     name: Literal["textbook.pdf.outline.toggled"]
 
 
+# pylint: disable=line-too-long
 class TextbookPdfChapterNavigatedEventField(AbstractBaseEventField):
     """Represents the `textbook.pdf.chapter.navigated` event field.
 
@@ -69,7 +71,7 @@ class TextbookPdfChapterNavigatedEventField(AbstractBaseEventField):
     name: Literal["textbook.pdf.chapter.navigated"]
     chapter: constr(
         regex=(
-            r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa: F722
+            r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa
         )
     )
     chapter_title: str
@@ -102,8 +104,8 @@ class TextbookPdfZoomMenuChangedEventField(TextbookInteractionBaseEventField):
 
     Attributes:
         name (str): Consists of the value `textbook.pdf.zoom.menu.changed`.
-        amount (str): Consists either of the `0.5`, `0.75`, `1`, `1.25`, `1.5`, `2`, `3`, `4`,
-            `auto`, `custom`, `page-actual`, `page-fit`, `page-width` value.
+        amount (str): Consists either of the `0.5`, `0.75`, `1`, `1.25`, `1.5`, `2`,
+            `3`, `4`, `auto`, `custom`, `page-actual`, `page-fit`, `page-width` value.
     """
 
     name: Literal["textbook.pdf.zoom.menu.changed"]
@@ -153,13 +155,13 @@ class TextbookPdfSearchExecutedEventField(TextbookInteractionBaseEventField):
 
     Attributes:
         name (str): Consists of the value `textbook.pdf.search.executed`.
-        caseSensitive (bool): Consists either of the `true` value if the case sensitive option
-            is selected or `false` if this option is not selected.
-        highlightAll (bool): Consists either of the `true` value if the option to highlight
-            all matches is selected or `false` if this option is not selected.
+        caseSensitive (bool): Consists either of the `true` value if the case sensitive
+            option is selected or `false` if this option is not selected.
+        highlightAll (bool): Consists either of the `true` value if the option to
+            highlight all matches is selected or `false` if this option is not selected.
         query (str): Consists of the value in the search field.
-        status (str): Consists either of the value `not found` for a search string that is
-            unsuccessful or blank for successful search strings.
+        status (str): Consists either of the value `not found` for a search string that
+            is unsuccessful or blank for successful search strings.
     """
 
     name: Literal["textbook.pdf.search.executed"]
@@ -174,15 +176,16 @@ class TextbookPdfSearchNavigatedNextEventField(TextbookInteractionBaseEventField
 
     Attributes:
         name (str): Consists of the value `textbook.pdf.search.navigatednext`.
-        caseSensitive (bool): Consists either of the `true` value if the case sensitive option
-            is selected or `false` if this option is not selected.
+        caseSensitive (bool): Consists either of the `true` value if the case sensitive
+            option is selected or `false` if this option is not selected.
         findPrevious(bool): Consists either of the ‘true’ value if the user clicks the
-            Find Previous icon or ‘false’ if the user clicks the <kbd>Find Next</kbd> icon.
-        highlightAll (bool): Consists either of the `true` value if the option to highlight
-            all matches is selected or `false` if this option is not selected.
+            Find Previous icon or ‘false’ if the user clicks the <kbd>Find Next</kbd>
+            icon.
+        highlightAll (bool): Consists either of the `true` value if the option to
+            highlight all matches is selected or `false` if this option is not selected.
         query (str): Consists of the value in the search field.
-        status (str): Consists either of the value `not found` for a search string that is
-            unsuccessful or blank for successful search strings.
+        status (str): Consists either of the value `not found` for a search string that
+            is unsuccessful or blank for successful search strings.
     """
 
     name: Literal["textbook.pdf.search.navigatednext"]
@@ -200,11 +203,11 @@ class TextbookPdfSearchHighlightToggledEventField(TextbookInteractionBaseEventFi
         name (str): Consists of the value `textbook.pdf.search.highlight.toggled`.
         caseSensitive (bool): Consists either of the `true` value if the case sensitive
             option is selected or `false` if this option is not selected.
-        highlightAll (bool): Consists either of the `true` value if the option to highlight
-            all matches is selected or `false` if this option is not selected.
+        highlightAll (bool): Consists either of the `true` value if the option to
+            highlight all matches is selected or `false` if this option is not selected.
         query (str): Consists of the value in the search field.
-        status (str): Consists either of the value `not found` for a search string that is
-            unsuccessful or blank for successful search strings.
+        status (str): Consists either of the value `not found` for a search string that
+            is unsuccessful or blank for successful search strings.
     """
 
     name: Literal["textbook.pdf.search.highlight.toggled"]
@@ -223,11 +226,11 @@ class TextbookPdfSearchCaseSensitivityToggledEventField(
         name (str): Consists of the value `textbook.pdf.searchcasesensitivity.toggled`.
         caseSensitive (bool): Consists either of the `true` value if the case sensitive
             option is selected or `false` if this option is not selected.
-        highlightAll (bool): Consists either of the `true` value if the option to highlight
-            all matches is selected or `false` if this option is not selected.
+        highlightAll (bool): Consists either of the `true` value if the option to
+            highlight all matches is selected or `false` if this option is not selected.
         query (str): Consists of the value in the search field.
-        status (str): Consists either of the value `not found` for a search string that is
-            unsuccessful or blank for successful search strings.
+        status (str): Consists either of the value `not found` for a search string that
+            is unsuccessful or blank for successful search strings.
     """
 
     name: Literal["textbook.pdf.searchcasesensitivity.toggled"]
@@ -237,24 +240,27 @@ class TextbookPdfSearchCaseSensitivityToggledEventField(
     status: str
 
 
+# pylint: disable=line-too-long
 class BookEventField(AbstractBaseEventField):
     """Represents the `book` event field.
 
     Attributes:
         chapter (str): Consists of the name of the PDF file.
-        name (str): Consists of `textbook.pdf.page.loaded` if type is set to `gotopage`,
+        name (str): Consists of `textbook.pdf.page.loaded` if type is set to
+            `gotopage`,
             `textbook.pdf.page.navigatednext` if type is set to `prevpage`,
             `textbook.pdf.page.navigatednext` if type is set to `nextpage`.
         new (int): Consists of the destination page number.
-        old (int): Consists of the original page number. It applies to `gotopage` event types only.
-        type (str): Consists of `gotopage` value when a page loads after the student manually
-            enters its number, `prevpage` value when the next page button is clicked or `nextpage`
-            value when the previous page button is clicked.
+        old (int): Consists of the original page number. It applies to `gotopage` event
+            types only.
+        type (str): Consists of `gotopage` value when a page loads after the student
+            manually enters its number, `prevpage` value when the next page button is
+            clicked or `nextpage` value when the previous page button is clicked.
     """
 
     chapter: constr(
         regex=(
-            r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa: F722
+            r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa
         )
     )
     name: Union[

--- a/src/ralph/models/edx/textbook_interaction/statements.py
+++ b/src/ralph/models/edx/textbook_interaction/statements.py
@@ -28,7 +28,8 @@ from .fields.events import (
 class UIBook(BaseBrowserModel):
     """Represents the `book` browser event model.
 
-    The browser emits this event when a user navigates within the PDF Viewer or the PNG Viewer.
+    The browser emits this event when a user navigates within the PDF Viewer or the
+    PNG Viewer.
 
     Attributes:
         event (BookEventField): See BookEventField.
@@ -48,7 +49,8 @@ class UIBook(BaseBrowserModel):
 class UITextbookPdfThumbnailsToggled(BaseBrowserModel):
     """Represents the `textbook.pdf.thumbnails.toggled` browser event model.
 
-    The browser emits this event when a user clicks on the icon to show or hide page thumbnails.
+    The browser emits this event when a user clicks on the icon to show or hide page
+    thumbnails.
 
     Attributes:
         event (json): See TextbookPdfThumbnailsToggledEventField.
@@ -73,7 +75,8 @@ class UITextbookPdfThumbnailsToggled(BaseBrowserModel):
 class UITextbookPdfThumbnailNavigated(BaseBrowserModel):
     """Represents the `textbook.pdf.thumbnail.navigated` browser event model.
 
-    The browser emits this event when a user clicks on a thumbnail image to navigate to a page.
+    The browser emits this event when a user clicks on a thumbnail image to navigate
+    to a page.
 
     Attributes:
         event (json): See TextbookPdfThumbnailNavigatedEventField.
@@ -226,8 +229,8 @@ class UITextbookPdfZoomMenuChanged(BaseBrowserModel):
 class UITextbookPdfDisplayScaled(BaseBrowserModel):
     """Represents the `textbook.pdf.display.scaled` browser event model.
 
-    The browser emits this event when the display magnification changes or the first page
-    is shown.
+    The browser emits this event when the display magnification changes or the first
+    page is shown.
 
     Attributes:
         event (json): See TextbookPdfDisplayScaledEventField.
@@ -329,7 +332,8 @@ class UITextbookPdfSearchNavigatedNext(BaseBrowserModel):
 class UITextbookPdfSearchHighlightToggled(BaseBrowserModel):
     """Represents the `textbook.pdf.search.highlight.toggled` browser event model.
 
-    The browser emits this event when a user selects or clears the <kbd>Highlight All</kbd> option.
+    The browser emits this event when a user selects or clears the
+    <kbd>Highlight All</kbd> option.
 
     Attributes:
         event (json): See TextbookPdfSearchHighlightToggledEventField.
@@ -354,11 +358,13 @@ class UITextbookPdfSearchHighlightToggled(BaseBrowserModel):
 class UITextbookPdfSearchCaseSensitivityToggled(BaseBrowserModel):
     """Represents the `textbook.pdf.searchcasesensitivity.toggled` browser event model.
 
-    The browser emits this event when a user selects or clears the <kbd>Match Case</kbd> option.
+    The browser emits this event when a user selects or clears the
+    <kbd>Match Case</kbd> option.
 
     Attributes:
         event (json): See TextbookPdfSearchCaseSensitivityToggledEventField.
-        event_type (str): Consists of the value `textbook.pdf.searchcasesensitivity.toggled`.
+        event_type (str): Consists of the value
+            `textbook.pdf.searchcasesensitivity.toggled`.
         name (str): Consists of the value `textbook.pdf.searchcasesensitivity.toggled`.
     """
 

--- a/src/ralph/models/selector.py
+++ b/src/ralph/models/selector.py
@@ -53,7 +53,8 @@ class ModelRules(dict):
         """Inserts a new model with it's associated list of rules.
 
         Raises:
-            ModelRulesException: When new_rules list is a subset or superset of another rules list.
+            ModelRulesException: When new_rules list is a subset or superset of
+            another rules list.
         """
 
         rules_set = set(new_rules)
@@ -95,7 +96,9 @@ class ModelSelector:
 
     @staticmethod
     def build_model_rules(module: ModuleType):
-        """Builds the model_rules dictionary from BaseModel classes defined in the module."""
+        """Builds the model_rules dictionary from BaseModel classes defined
+        in the module.
+        """
 
         model_rules = ModelRules()
         for _, class_ in getmembers(module, isclass):
@@ -104,11 +107,13 @@ class ModelSelector:
         return model_rules
 
     def get_model(self, event: dict, tree=None):
-        """Recursively walks through the decision tree to return the matching model for the event.
+        """Recursively walks through the decision tree to return the matching model
+        for the event.
 
         Args:
             event (dict): Event to retrieve the corresponding model.
-            tree (dict): The (sub) decision tree, `None` stands for the whole decision tree.
+            tree (dict): The (sub) decision tree, `None` stands for the whole decision
+                         tree.
 
         Returns:
             model (BaseModel): When the event matches all rules of the model.
@@ -138,10 +143,12 @@ class ModelSelector:
         if not rule_counter:
             return {}
 
-        # We retrieve the rule with the highest occurrence and use it to split the decision tree
-        # in two subtrees:
-        # 1 - true_subtree: a subtree of models that require the most occurred rule to be true.
-        # 2 - false_subtree: a subtree of models that don't use the most occurred rule.
+        # We retrieve the rule with the highest occurrence and use it to split
+        # the decision tree in two subtrees:
+        # 1 - true_subtree: a subtree of models that require the most occurred
+        #     rule to be true.
+        # 2 - false_subtree: a subtree of models that don't use the most
+        #     occurred rule.
         root_rule = rule_counter.most_common(1)[0][0]
         true_subtree = {}
         false_subtree = {}

--- a/src/ralph/models/xapi/base.py
+++ b/src/ralph/models/xapi/base.py
@@ -16,7 +16,8 @@ class BaseXapiModel(BaseModelWithConfig):
     Attributes:
         id (UUID): Consists of a generated UUID string from the source event string.
         actor (ActorField): See ActorField.
-        timestamp (datetime): Consists of the UTC time in ISO format when the event was emitted.
+        timestamp (datetime): Consists of the UTC time in ISO format when the event was
+            emitted.
     """
 
     id: UUID

--- a/src/ralph/models/xapi/fields/actors.py
+++ b/src/ralph/models/xapi/fields/actors.py
@@ -12,7 +12,8 @@ class ActorAccountField(BaseModelWithConfig):
 
     Attributes:
         name (str): Consists of the unique id or name used to log in to this account.
-        homePage (URL): Consists of the canonical home page for the system the account is on.
+        homePage (URL): Consists of the canonical home page for the system the account
+            is on.
     """
 
     name: str

--- a/src/ralph/models/xapi/navigation/fields/objects.py
+++ b/src/ralph/models/xapi/navigation/fields/objects.py
@@ -10,8 +10,8 @@ from ...fields.objects import ObjectDefinitionExtensionsField, ObjectField
 class PageObjectDefinitionField(BaseModelWithConfig):
     """Represents the `object.definition` xAPI field for page viewed xAPI statement.
 
-    WARNING: It doesn't include the recommended `description` field nor the optional `moreInfo`,
-    `Interaction properties` and `extensions` fields.
+    WARNING: It doesn't include the recommended `description` field nor the optional
+        `moreInfo`, `Interaction properties` and `extensions` fields.
 
     Attributes:
        type (str): Consists of the value `http://activitystrea.ms/schema/1.0/page`.

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -62,22 +62,24 @@ class VideoInitializedContextExtensionsField(VideoContextExtensionsField):
 
     Attributes:
         length (float): Consists of the length of the video.
-        ccSubtitleEnabled (bool): Indicates whether subtitle or closed captioning is enabled.
-        ccSubtitleLanguage (str): Consists of the language of subtitle or closed captioning.
+        ccSubtitleEnabled (bool): Indicates whether subtitle or closed captioning is
+            enabled.
+        ccSubtitleLanguage (str): Consists of the language of subtitle or closed
+            captioning.
         frameRate (float): Consists of the frame rate or frames per second of a video.
         fullScreen (bool): Indicates whether the video is played in full screen mode.
         quality (str): Consists of the video resolution or quality.
-        screenSize (str): Consists of the device playback screen size or the maximum available
-            screen size for Video playback.
-        videoPlaybackSize (str): Consists of the size in Width x Height of the video as viewed
-            by the user.
+        screenSize (str): Consists of the device playback screen size or the maximum
+            available screen size for Video playback.
+        videoPlaybackSize (str): Consists of the size in Width x Height of the video as
+            viewed by the user.
         speed (str): Consists of the play back speed.
         track (str): Consists of the name of the audio track in a media object.
         userAgent (str): Consists of the User Agent string of the browser,
             if the video is launched in browser.
         volume (int): Consists of the volume of the video.
-        completionThreshold (float): Consists of the percentage of media that should be consumed to
-            trigger a completion.
+        completionThreshold (float): Consists of the percentage of media that should be
+            consumed to trigger a completion.
     """
 
     length: Optional[float] = Field(alias=VIDEO_EXTENSION_LENGTH)
@@ -103,8 +105,8 @@ class VideoBrowsingContextExtensionsField(VideoContextExtensionsField):
     Such field is used in `paused`, `completed` and `terminated` events.
 
     Attributes:
-        completionThreshold (float): Consists of the percentage of media that should be consumed to
-            trigger a completion.
+        completionThreshold (float): Consists of the percentage of media that should
+            be consumed to trigger a completion.
         length (float): Consists of the length of the video.
     """
 
@@ -119,13 +121,15 @@ class VideoInteractedContextExtensionsField(VideoContextExtensionsField):
 
     Attributes:
         length (float): Consists of the length of the video.
-        ccSubtitleEnabled (bool): Indicates whether subtitle or closed captioning is enabled.
-        ccSubtitleLanguage (str): Consists of the language of subtitle or closed captioning.
+        ccSubtitleEnabled (bool): Indicates whether subtitle or closed captioning is
+            enabled.
+        ccSubtitleLanguage (str): Consists of the language of subtitle or closed
+            captioning.
         frameRate (float): Consists of the frame rate or frames per second of a video.
         fullScreen (bool): Indicates whether the video is played in full screen mode.
         quality (str): Consists of the video resolution or quality.
-        videoPlaybackSize (str): Consists of the size in Width x Height of the video as viewed
-            by the user.
+        videoPlaybackSize (str): Consists of the size in Width x Height of the video as
+            viewed by the user.
         speed (str): Consists of the play back speed.
         track (str): Consists of the name of the audio track in a media object.
         volume (int): Consists of the volume of the video.

--- a/src/ralph/models/xapi/video/fields/objects.py
+++ b/src/ralph/models/xapi/video/fields/objects.py
@@ -12,12 +12,13 @@ from ..constants import VIDEO_OBJECT_DEFINITION_TYPE
 class VideoObjectDefinitionField(BaseModelWithConfig):
     """Represents the `object.definition` xAPI field for page viewed xAPI statement.
 
-    WARNING: It doesn't include the recommended `description` field nor the optional `moreInfo`,
-    `Interaction properties` and `extensions` fields.
+    WARNING: It doesn't include the recommended `description` field nor the optional
+    `moreInfo`, `Interaction properties` and `extensions` fields.
 
     Attributes:
        name (dict): Consists of the dictionary `{"en-US": <name of the video>}`.
-       type (str): Consists of the value `https://w3id.org/xapi/video/activity-type/video`.
+       type (str): Consists of the value
+        `https://w3id.org/xapi/video/activity-type/video`.
     """
 
     name: Optional[dict[LANG_EN_US_DISPLAY, str]]

--- a/src/ralph/models/xapi/video/fields/results.py
+++ b/src/ralph/models/xapi/video/fields/results.py
@@ -30,8 +30,8 @@ class VideoPausedResultExtensionsField(VideoActionResultExtensionsField):
     """Represents the result.extensions field for video `played` xAPI statement.
 
     Attributes:
-        playedSegments (str): Consists of parts of the video the actor watched during current
-            registration in chronological order (for example,
+        playedSegments (str): Consists of parts of the video the actor watched during
+            current registration in chronological order (for example,
             "0[.]5[,]12[.]22[,]15[.]55[,]55[.]99.33[,]99.33").
         progress (float): Consists of the ratio of media consumed by the actor.
     """
@@ -47,13 +47,13 @@ class VideoSeekedResultExtensionsField(BaseModelWithConfig):
     """Represents the result.extensions field for video `seeked` xAPI statement.
 
     Attributes:
-        timeFrom (float): Consists of the point in time the actor changed from in a media object
-            during a seek operation.
-        timeTo (float): Consists of the point in time the actor changed to in a media object
-            during a seek operation.
+        timeFrom (float): Consists of the point in time the actor changed from in a
+            media object during a seek operation.
+        timeTo (float): Consists of the point in time the actor changed to in a media
+            object during a seek operation.
         length (float): Consists of the actual length of the media in seconds.
-        playedSegments (str): Consists of parts of the video the actor watched during current
-            registration in chronological order.
+        playedSegments (str): Consists of parts of the video the actor watched during
+            current registration in chronological order.
         progress (float): Consists of the percentage of media consumed by the actor.
     """
 
@@ -71,8 +71,8 @@ class VideoCompletedResultExtensionsField(VideoActionResultExtensionsField):
     """Represents the result.extensions field for video `completed` xAPI statement.
 
     Attributes:
-        playedSegments (str): Consists of parts of the video the actor watched during current
-            registration in chronological order.
+        playedSegments (str): Consists of parts of the video the actor watched during
+            current registration in chronological order.
         progress (float): Consists of the percentage of media consumed by the actor.
     """
 
@@ -87,8 +87,8 @@ class VideoTerminatedResultExtensionsField(VideoActionResultExtensionsField):
     """Represents the result.extensions field for video `terminated` xAPI statement.
 
     Attributes:
-        playedSegments (str): Consists of parts of the video the actor watched during current
-            registration in chronological order.
+        playedSegments (str): Consists of parts of the video the actor watched during
+            current registration in chronological order.
         progress (float): Consists of the percentage of media consumed by the actor.
     """
 
@@ -135,8 +135,8 @@ class VideoCompletedResultField(BaseModelWithConfig):
     Attributes:
         extensions (dict): See VideoCompletedResultExtensionsField.
         completion (bool): Consists of the value `True`.
-        duration (str): Consists of the total time spent consuming the video under current
-            registration.
+        duration (str): Consists of the total time spent consuming the video under
+            current registration.
     """
 
     extensions: Optional[VideoCompletedResultExtensionsField]

--- a/src/ralph/models/xapi/video/statements.py
+++ b/src/ralph/models/xapi/video/statements.py
@@ -105,7 +105,8 @@ class VideoPaused(BaseVideoStatement):
 class VideoSeeked(BaseVideoStatement):
     """Represents a video seeked xAPI statement.
 
-    Example: John moved the progress bar forward or backward to a specific time in the video.
+    Example: John moved the progress bar forward or backward to a specific time in the
+        video.
 
     Attributes:
         verb (dict): See VideoSeekedVerbField.
@@ -168,8 +169,8 @@ class VideoTerminated(BaseVideoStatement):
 class VideoInteracted(BaseVideoStatement):
     """Represents a video terminated xAPI statement.
 
-    Example: John interacted with the player (except play, pause, seek). e.g. mute, unmute, change
-        resolution, change player size, etc.
+    Example: John interacted with the player (except play, pause, seek). e.g. mute,
+        unmute, change resolution, change player size, etc.
 
     Attributes:
         verb (dict): See VideoInteractedVerbField.

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -59,7 +59,10 @@ class GELFParser(BaseParser):
                 logger.debug("Raised error was: %s", err)
             except KeyError as err:
                 logger.error(
-                    "Input event '%s' doesn't comply with GELF format! It will be ignored.",
+                    (
+                        "Input event '%s' doesn't comply with GELF format! It will be "
+                        "ignored."
+                    ),
                     event,
                 )
                 logger.debug("Raised error was: %s", err)

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -91,7 +91,9 @@ def now():
 
 
 def get_dict_value_from_path(dict_: dict, path: list[str]):
-    """Gets a nested dictionary value using an array of keys representing the path to the value."""
+    """Gets a nested dictionary value using an array of keys representing the path
+    to the value.
+    """
 
     if path is None:
         return None
@@ -102,7 +104,9 @@ def get_dict_value_from_path(dict_: dict, path: list[str]):
 
 
 def set_dict_value_from_path(dict_: dict, path: list[str], value: any):
-    """Sets a nested dictionary value using an array of keys representing the path to the value."""
+    """Sets a nested dictionary value using an array of keys representing the path
+    to the value.
+    """
 
     for key in path[:-1]:
         dict_ = dict_.setdefault(key, {})

--- a/tests/backends/storage/test_fs.py
+++ b/tests/backends/storage/test_fs.py
@@ -35,7 +35,9 @@ def test_backends_storage_fs_storage_instantiation(fs):
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 def test_backends_storage_fs_getfile(fs):
-    """Tests that an existing path can be returned, and throws an exception otherwise."""
+    """Tests that an existing path can be returned, and throws an exception
+    otherwise.
+    """
     # pylint: disable=protected-access
 
     path = "test_fs/"

--- a/tests/backends/storage/test_ldp.py
+++ b/tests/backends/storage/test_ldp.py
@@ -61,7 +61,10 @@ def test_backends_storage_ldp_archive_endpoint_property():
     storage.service_name = None
     with pytest.raises(
         BackendParameterException,
-        match="LDPStorage backend instance requires to set both service_name and stream_id",
+        match=(
+            "LDPStorage backend instance requires to set "
+            "both service_name and stream_id"
+        ),
     ):
         storage._archive_endpoint
 
@@ -69,14 +72,20 @@ def test_backends_storage_ldp_archive_endpoint_property():
     storage.stream_id = None
     with pytest.raises(
         BackendParameterException,
-        match="LDPStorage backend instance requires to set both service_name and stream_id",
+        match=(
+            "LDPStorage backend instance requires to set "
+            "both service_name and stream_id"
+        ),
     ):
         storage._archive_endpoint
 
     storage.service_name = None
     with pytest.raises(
         BackendParameterException,
-        match="LDPStorage backend instance requires to set both service_name and stream_id",
+        match=(
+            "LDPStorage backend instance requires to set "
+            "both service_name and stream_id"
+        ),
     ):
         storage._archive_endpoint
 
@@ -96,7 +105,7 @@ def test_backends_storage_ldp_details_method(monkeypatch):
             "md5": "01585b394be0495e38dbb60b20cb40a9",
             "retrievalDelay": 0,
             "retrievalState": "sealed",
-            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
             "size": 67906662,
         }
 
@@ -274,7 +283,7 @@ def test_backends_storage_ldp_list_method_with_details(monkeypatch):
             "md5": "01585b394be0495e38dbb60b20cb40a9",
             "retrievalDelay": 0,
             "retrievalState": "sealed",
-            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
             "size": 67906662,
         },
         {
@@ -284,7 +293,7 @@ def test_backends_storage_ldp_list_method_with_details(monkeypatch):
             "md5": "01585b394be0495e38dbb60b20cb40a9",
             "retrievalDelay": 0,
             "retrievalState": "sealed",
-            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
             "size": 67906662,
         },
     ]
@@ -356,7 +365,7 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs):
             "md5": "01585b394be0495e38dbb60b20cb40a9",
             "retrievalDelay": 0,
             "retrievalState": "sealed",
-            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
             "size": 67906662,
         }
 

--- a/tests/backends/storage/test_swift.py
+++ b/tests/backends/storage/test_swift.py
@@ -34,7 +34,9 @@ def test_backends_storage_swift_storage_instantiation_failure_should_raise_excep
 def test_backends_storage_swift_storage_instantiation_should_not_raise_exception(
     monkeypatch, swift
 ):
-    """Checks that SwiftStorage doesn't raise exceptions when the connection is successful."""
+    """Checks that SwiftStorage doesn't raise exceptions when the connection is
+    successful.
+    """
 
     def mock_successful_stat(*args, **kwargs):  # pylint:disable=unused-argument
         return {"success": True}
@@ -50,8 +52,8 @@ def test_backends_storage_swift_storage_instantiation_should_not_raise_exception
 def test_backends_storage_swift_list_should_yield_archive_names(
     pages_count, swift, monkeypatch, fs
 ):  # pylint:disable=invalid-name
-    """Tests that given SwiftService.list method successfully connects to the Swift storage,
-    the SwiftStorage list method should yield the archives.
+    """Tests that given SwiftService.list method successfully connects to the Swift
+    storage, the SwiftStorage list method should yield the archives.
     """
 
     listing = [
@@ -118,8 +120,8 @@ def test_backends_storage_swift_list_with_failed_connection_should_log_the_error
 def test_backends_storage_swift_read_with_valid_name_should_write_to_history(
     swift, monkeypatch, fs
 ):  # pylint:disable=invalid-name
-    """Tests that given SwiftService.download method successfully retrieves from the Swift storage
-    the object with the provided name (the object exists),
+    """Tests that given SwiftService.download method successfully retrieves from the
+    Swift storage the object with the provided name (the object exists),
     the SwiftStorage read method should write the entry to the history.
     """
 
@@ -151,8 +153,8 @@ def test_backends_storage_swift_read_with_valid_name_should_write_to_history(
 def test_backends_storage_swift_read_with_invalid_name_should_log_the_error(
     swift, monkeypatch, fs, caplog
 ):  # pylint:disable=invalid-name
-    """Tests that given SwiftService.download method fails to retrieve from the Swift storage
-    the object with the provided name (the object does not exists on Swift),
+    """Tests that given SwiftService.download method fails to retrieve from the Swift
+    storage the object with the provided name (the object does not exists on Swift),
     the SwiftStorage read method should log the error, not write to history and raise a
     BackendException.
     """
@@ -179,16 +181,17 @@ def test_backends_storage_swift_read_with_invalid_name_should_log_the_error(
     assert swift.history == []
 
 
+# pylint: disable=line-too-long
 @pytest.mark.parametrize("overwrite", [False, True])
 @pytest.mark.parametrize("new_archive", [False, True])
-def test_backends_storage_swift_write_should_write_to_history_new_or_overwriten_archives(
+def test_backends_storage_swift_write_should_write_to_history_new_or_overwriten_archives(  # noqa
     overwrite, new_archive, swift, monkeypatch, fs, caplog
 ):  # pylint:disable=invalid-name, too-many-arguments, too-many-locals
-    """Tests that given SwiftService list/upload method successfully connects to the Swift storage,
-    the SwiftStorage write method should update the history file when overwrite is True
-    or when the name of the archive is not in the history.
-    In case overwrite is False and the archive is in the history, the write method should
-    raise a FileExistsError.
+    """Tests that given SwiftService list/upload method successfully connects to the
+    Swift storage, the SwiftStorage write method should update the history file when
+    overwrite is True or when the name of the archive is not in the history.
+    In case overwrite is False and the archive is in the history, the write method
+    should raise a FileExistsError.
     """
 
     history = [

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -47,7 +47,9 @@ class NamedClassEnum(Enum):
 
 @pytest.fixture
 def es():
-    """Creates / deletes an ElasticSearch test index and yields an instantiated client."""
+    """Creates / deletes an ElasticSearch test index and yields an instantiated
+    client.
+    """
     # pylint: disable=invalid-name
 
     client = Elasticsearch(ES_TEST_HOSTS)
@@ -58,7 +60,9 @@ def es():
 
 @pytest.fixture
 def es_data_stream():
-    """Creates / deletes an ElasticSearch test datastream and yields an instantiated client."""
+    """Creates / deletes an ElasticSearch test datastream and yields an instantiated
+    client.
+    """
 
     client = Elasticsearch(ES_TEST_HOSTS)
 

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -29,7 +29,9 @@ from ralph.models.edx.navigational.statements import UIPageClose
 def test_navigational_ui_page_close_to_page_terminated(
     uuid_namespace, event, platform_url
 ):
-    """Tests that ServerEventToPageViewed.convert returns a JSON string with a constant UUID."""
+    """Tests that ServerEventToPageViewed.convert returns a JSON string with a
+    constant UUID.
+    """
 
     event_str = event.json()
     event = json.loads(event_str)

--- a/tests/models/edx/converters/xapi/test_server.py
+++ b/tests/models/edx/converters/xapi/test_server.py
@@ -22,7 +22,9 @@ from ralph.models.edx.server import Server, ServerEventField
 def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_constant_uuid(
     uuid_namespace, event, platform_url
 ):
-    """Tests that ServerEventToPageViewed.convert returns a JSON string with a constant UUID."""
+    """Tests that ServerEventToPageViewed.convert returns a JSON string with a
+    constant UUID.
+    """
 
     event_str = event.json()
     event = json.loads(event_str)
@@ -35,6 +37,7 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_constant
     assert xapi_event1.id == xapi_event2.id
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -49,10 +52,12 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_constant
     provisional.urls(),
 )
 @pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
-def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_valid_event(
+def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_valid_event(  # noqa
     uuid_namespace, event, platform_url
 ):
-    """Tests that converting with ServerEventToPageViewed returns the expected xAPI statement."""
+    """Tests that converting with ServerEventToPageViewed returns the expected xAPI
+    statement.
+    """
 
     event_str = event.json()
     event = json.loads(event_str)
@@ -80,6 +85,7 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_val
     }
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -91,7 +97,7 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_val
     provisional.urls(),
 )
 @pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
-def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_anonymous_user(
+def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_anonymous_user(  # noqa
     uuid_namespace, event, platform_url
 ):
     """Tests that anonymous usernames are replaced with with `anonymous`."""

--- a/tests/models/edx/problem_interaction/test_events.py
+++ b/tests/models/edx/problem_interaction/test_events.py
@@ -36,7 +36,9 @@ def test_models_edx_correct_map_with_valid_content(subfield):
 @settings(max_examples=1)
 @given(st.builds(CorrectMap))
 def test_models_edx_correct_map_with_invalid_correctness_value(correctness, subfield):
-    """Tests that an invalid `correctness` value in `CorrectMap` raises a `ValidationError`."""
+    """Tests that an invalid `correctness` value in `CorrectMap` raises a
+    `ValidationError`.
+    """
 
     invalid_subfield = json.loads(subfield.json())
     invalid_subfield["correctness"] = correctness
@@ -49,7 +51,9 @@ def test_models_edx_correct_map_with_invalid_correctness_value(correctness, subf
 @settings(max_examples=1)
 @given(st.builds(CorrectMap))
 def test_models_edx_correct_map_with_invalid_hintmode_value(hintmode, subfield):
-    """Tests that an invalid `hintmode` value in `CorrectMap` raises a `ValidationError`."""
+    """Tests that an invalid `hintmode` value in `CorrectMap` raises a
+    `ValidationError`.
+    """
 
     invalid_subfield = json.loads(subfield.json())
     invalid_subfield["hintmode"] = hintmode
@@ -75,6 +79,7 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_valid_field
     assert field.trigger_type in ("single", "compound")
 
 
+# pylint: disable=line-too-long
 @pytest.mark.parametrize(
     "question_type",
     [
@@ -87,11 +92,11 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_valid_field
 )
 @settings(max_examples=1)
 @given(st.builds(EdxProblemHintFeedbackDisplayedEventField))
-def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_question_type_value(
+def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_question_type_value(  # noqa
     question_type, field
 ):
-    """Tests that an invalid `question_type` value in `EdxProblemHintFeedbackDisplayedEventField`
-    raises a `ValidationError`.
+    """Tests that an invalid `question_type` value in
+    `EdxProblemHintFeedbackDisplayedEventField` raises a `ValidationError`.
     """
 
     invalid_field = json.loads(field.json())
@@ -101,14 +106,15 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_que
         EdxProblemHintFeedbackDisplayedEventField(**invalid_field)
 
 
+# pylint: disable=line-too-long
 @pytest.mark.parametrize("trigger_type", ["jingle", "compund"])
 @settings(max_examples=1)
 @given(st.builds(EdxProblemHintFeedbackDisplayedEventField))
-def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_trigger_type_value(
+def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_trigger_type_value(  # noqa
     trigger_type, field
 ):
-    """Tests that an invalid `question_type` value in `EdxProblemHintFeedbackDisplayedEventField`
-    raises a `ValidationError`.
+    """Tests that an invalid `question_type` value in
+    `EdxProblemHintFeedbackDisplayedEventField` raises a `ValidationError`.
     """
 
     invalid_field = json.loads(field.json())
@@ -121,10 +127,15 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_tri
 @settings(max_examples=1)
 @given(st.builds(ProblemCheckEventField, state=st.builds(State)))
 def test_models_edx_problem_check_event_field_with_valid_field(field):
-    """Tests that a valid `ProblemCheckEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `ProblemCheckEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
     assert field.success in ("correct", "incorrect")
@@ -133,13 +144,28 @@ def test_models_edx_problem_check_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -180,10 +206,15 @@ def test_models_edx_problem_check_event_field_with_invalid_success_value(
 @settings(max_examples=1)
 @given(st.builds(ProblemCheckFailEventField, state=st.builds(State)))
 def test_models_edx_problem_check_fail_event_field_with_valid_field(field):
-    """Tests that a valid `ProblemCheckFailEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `ProblemCheckFailEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
     assert field.failure in ("closed", "unreset")
@@ -192,13 +223,28 @@ def test_models_edx_problem_check_fail_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -245,10 +291,15 @@ def test_models_edx_problem_check_fail_event_field_with_invalid_failure_value(
     )
 )
 def test_models_edx_problem_rescore_event_field_with_valid_field(field):
-    """Tests that a valid `ProblemRescoreEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `ProblemRescoreEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
     assert field.success in ("correct", "incorrect")
@@ -257,13 +308,28 @@ def test_models_edx_problem_rescore_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -316,10 +382,15 @@ def test_models_edx_problem_rescore_event_field_with_invalid_success_value(
 @settings(max_examples=1)
 @given(st.builds(ProblemRescoreFailEventField, state=st.builds(State)))
 def test_models_edx_problem_rescore_fail_event_field_with_valid_field(field):
-    """Tests that a valid `ProblemRescoreFailEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `ProblemRescoreFailEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
     assert field.failure in ("closed", "unreset")
@@ -328,13 +399,28 @@ def test_models_edx_problem_rescore_fail_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -342,8 +428,8 @@ def test_models_edx_problem_rescore_fail_event_field_with_valid_field(field):
 def test_models_edx_problem_rescore_fail_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
-    """Tests that an invalid `problem_id` value in `ProblemRescoreFailEventField` raises a
-    `ValidationError`.
+    """Tests that an invalid `problem_id` value in `ProblemRescoreFailEventField` raises
+    a `ValidationError`.
     """
 
     invalid_field = json.loads(field.json())
@@ -379,10 +465,15 @@ def test_models_edx_problem_rescore_fail_event_field_with_invalid_failure_value(
     )
 )
 def test_models_edx_reset_problem_event_field_with_valid_field(field):
-    """Tests that a valid `ResetProblemEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `ResetProblemEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
 
@@ -390,13 +481,28 @@ def test_models_edx_reset_problem_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -424,10 +530,15 @@ def test_models_edx_reset_problem_event_field_with_invalid_problem_id_value(
 @settings(max_examples=1)
 @given(st.builds(ResetProblemFailEventField, old_state=st.builds(State)))
 def test_models_edx_reset_problem_fail_event_field_with_valid_field(field):
-    """Tests that a valid `ResetProblemFailEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `ResetProblemFailEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
     assert field.failure in ("closed", "not_closed")
@@ -436,13 +547,28 @@ def test_models_edx_reset_problem_fail_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -450,8 +576,8 @@ def test_models_edx_reset_problem_fail_event_field_with_valid_field(field):
 def test_models_edx_reset_problem_fail_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
-    """Tests that an invalid `problem_id` value in `ResetProblemFailEventField` raises a
-    `ValidationError`.
+    """Tests that an invalid `problem_id` value in `ResetProblemFailEventField` raises
+    a `ValidationError`.
     """
 
     invalid_field = json.loads(field.json())
@@ -483,10 +609,15 @@ def test_models_edx_reset_problem_fail_event_field_with_invalid_failure_value(
 @settings(max_examples=1)
 @given(st.builds(SaveProblemFailEventField, state=st.builds(State)))
 def test_models_edx_save_problem_fail_event_field_with_valid_field(field):
-    """Tests that a valid `SaveProblemFailEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `SaveProblemFailEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
     assert field.failure in ("closed", "done")
@@ -495,13 +626,28 @@ def test_models_edx_save_problem_fail_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -542,10 +688,15 @@ def test_models_edx_save_problem_fail_event_field_with_invalid_failure_value(
 @settings(max_examples=1)
 @given(st.builds(SaveProblemSuccessEventField, state=st.builds(State)))
 def test_models_edx_save_problem_success_event_field_with_valid_field(field):
-    """Tests that a valid `SaveProblemFailEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `SaveProblemFailEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@problem\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]"
+            r"+type@problem\+block@[a-f0-9]{32}$"
+        ),
         field.problem_id,
     )
 
@@ -553,13 +704,28 @@ def test_models_edx_save_problem_success_event_field_with_valid_field(field):
 @pytest.mark.parametrize(
     "problem_id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],
 )
 @settings(max_examples=1)
@@ -567,8 +733,8 @@ def test_models_edx_save_problem_success_event_field_with_valid_field(field):
 def test_models_edx_save_problem_success_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
-    """Tests that an invalid `problem_id` value in `SaveProblemSuccessEventField` raises a
-    `ValidationError`.
+    """Tests that an invalid `problem_id` value in `SaveProblemSuccessEventField`
+    raises a `ValidationError`.
     """
 
     invalid_field = json.loads(field.json())

--- a/tests/models/edx/problem_interaction/test_statements.py
+++ b/tests/models/edx/problem_interaction/test_statements.py
@@ -54,8 +54,8 @@ from ralph.models.selector import ModelSelector
 def test_models_edx_edx_problem_hint_demandhint_displayed_with_valid_statement(
     statement,
 ):
-    """Tests that a `edx.problem.hint.demandhint_displayed` statement has the expected `event_type`
-    and `page`.
+    """Tests that a `edx.problem.hint.demandhint_displayed` statement has the expected
+    `event_type` and `page`.
     """
 
     assert statement.event_type == "edx.problem.hint.demandhint_displayed"
@@ -73,8 +73,8 @@ def test_models_edx_edx_problem_hint_demandhint_displayed_with_valid_statement(
 def test_models_edx_edx_problem_hint_demandhint_displayed_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `edx.problem.hint.demandhint_displayed` statement the selector `get_model`
-    method should return `EdxProblemHintDemandhintDisplayed` model.
+    """Tests given a `edx.problem.hint.demandhint_displayed` statement the selector
+    `get_model` method should return `EdxProblemHintDemandhintDisplayed` model.
     """
 
     statement = json.loads(statement.json())
@@ -93,8 +93,8 @@ def test_models_edx_edx_problem_hint_demandhint_displayed_selector_with_valid_st
     )
 )
 def test_models_edx_edx_problem_hint_feedback_displayed_with_valid_statement(statement):
-    """Tests that a `edx.problem.hint.feedback_displayed` statement has the expected `event_type`
-    and `page`.
+    """Tests that a `edx.problem.hint.feedback_displayed` statement has the expected
+    `event_type` and `page`.
     """
 
     assert statement.event_type == "edx.problem.hint.feedback_displayed"
@@ -112,8 +112,8 @@ def test_models_edx_edx_problem_hint_feedback_displayed_with_valid_statement(sta
 def test_models_edx_edx_problem_hint_feedback_displayed_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `edx.problem.hint.feedback_displayed` statement the selector `get_model`
-    method should return `EdxProblemHintFeedbackDisplayed` model.
+    """Tests given a `edx.problem.hint.feedback_displayed` statement the selector
+    `get_model` method should return `EdxProblemHintFeedbackDisplayed` model.
     """
 
     statement = json.loads(statement.json())
@@ -132,7 +132,9 @@ def test_models_edx_edx_problem_hint_feedback_displayed_selector_with_valid_stat
     )
 )
 def test_models_edx_ui_problem_check_with_valid_statement(statement):
-    """Tests that a `problem_check` browser statement has the expected `event_type` and `name`."""
+    """Tests that a `problem_check` browser statement has the expected `event_type` and
+    `name`.
+    """
 
     assert statement.event_type == "problem_check"
     assert statement.name == "problem_check"
@@ -169,7 +171,9 @@ def test_models_edx_ui_problem_check_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_check_with_valid_statement(statement):
-    """Tests that a `problem_check` server statement has the expected `event_type` and `page`."""
+    """Tests that a `problem_check` server statement has the expected `event_type` and
+    `page`.
+    """
 
     assert statement.event_type == "problem_check"
     assert statement.page == "x_module"
@@ -187,8 +191,8 @@ def test_models_edx_problem_check_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_check_selector_with_valid_statement(statement):
-    """Tests given a `problem_check` statement the selector `get_model`
-    method should return `ProblemCheck` model.
+    """Tests given a `problem_check` statement the selector `get_model` method should
+    return `ProblemCheck` model.
     """
 
     statement = json.loads(statement.json())
@@ -207,8 +211,8 @@ def test_models_edx_problem_check_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_check_fail_with_valid_statement(statement):
-    """Tests that a `problem_check_fail` server statement has the expected `event_type` and
-    `page`.
+    """Tests that a `problem_check_fail` server statement has the expected `event_type`
+    and `page`.
     """
 
     assert statement.event_type == "problem_check_fail"
@@ -227,8 +231,8 @@ def test_models_edx_problem_check_fail_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_check_fail_selector_with_valid_statement(statement):
-    """Tests given a `problem_check_fail` statement the selector `get_model` method should return
-    `ProblemCheckFail` model.
+    """Tests given a `problem_check_fail` statement the selector `get_model` method
+    should return `ProblemCheckFail` model.
     """
 
     statement = json.loads(statement.json())
@@ -241,7 +245,8 @@ def test_models_edx_problem_check_fail_selector_with_valid_statement(statement):
 @settings(max_examples=1)
 @given(st.builds(UIProblemGraded, referer=provisional.urls(), page=provisional.urls()))
 def test_models_edx_ui_problem_graded_with_valid_statement(statement):
-    """Tests that a `problem_graded` browser statement has the expected `event_type` and `name`."""
+    """Tests that a `problem_graded` browser statement has the expected `event_type` and
+    `name`."""
 
     assert statement.event_type == "problem_graded"
     assert statement.name == "problem_graded"
@@ -273,7 +278,8 @@ def test_models_edx_ui_problem_graded_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_rescore_with_valid_statement(statement):
-    """Tests that a `problem_rescore` server statement has the expected `event_type` and `page`."""
+    """Tests that a `problem_rescore` server statement has the expected `event_type` and
+    `page`."""
 
     assert statement.event_type == "problem_rescore"
     assert statement.page == "x_module"
@@ -292,8 +298,8 @@ def test_models_edx_problem_rescore_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_rescore_selector_with_valid_statement(statement):
-    """Tests given a `problem_rescore` statement the selector `get_model`
-    method should return `ProblemRescore` model.
+    """Tests given a `problem_rescore` statement the selector `get_model` method should
+    return `ProblemRescore` model.
     """
 
     statement = json.loads(statement.json())
@@ -311,7 +317,8 @@ def test_models_edx_problem_rescore_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
-    """Tests that a `problem_rescore` server statement has the expected `event_type` and `page`."""
+    """Tests that a `problem_rescore` server statement has the expected `event_type` and
+    `page`."""
 
     assert statement.event_type == "problem_rescore_fail"
     assert statement.page == "x_module"
@@ -326,8 +333,8 @@ def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
     )
 )
 def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement):
-    """Tests given a `problem_rescore_fail` statement the selector `get_model`
-    method should return `ProblemRescoreFail` model.
+    """Tests given a `problem_rescore_fail` statement the selector `get_model` method
+    should return `ProblemRescoreFail` model.
     """
 
     statement = json.loads(statement.json())
@@ -347,7 +354,8 @@ def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement
     )
 )
 def test_models_edx_ui_problem_reset_with_valid_statement(statement):
-    """Tests that a `problem_reset` browser statement has the expected `event_type` and `name`."""
+    """Tests that a `problem_reset` browser statement has the expected `event_type` and
+    `name`."""
 
     assert statement.event_type == "problem_reset"
     assert statement.name == "problem_reset"
@@ -363,8 +371,8 @@ def test_models_edx_ui_problem_reset_with_valid_statement(statement):
     )
 )
 def test_models_edx_ui_problem_reset_selector_with_valid_statement(statement):
-    """Tests given a `problem_reset` statement the selector `get_model`
-    method should return `ProblemReset` model.
+    """Tests given a `problem_reset` statement the selector `get_model` method should
+    return `ProblemReset` model.
     """
 
     statement = json.loads(statement.json())
@@ -376,7 +384,9 @@ def test_models_edx_ui_problem_reset_selector_with_valid_statement(statement):
 @settings(max_examples=1)
 @given(st.builds(UIProblemSave, referer=provisional.urls(), page=provisional.urls()))
 def test_models_edx_ui_problem_save_with_valid_statement(statement):
-    """Tests that a `problem_save` browser statement has the expected `event_type` and `name`."""
+    """Tests that a `problem_save` browser statement has the expected `event_type` and
+    `name`.
+    """
 
     assert statement.event_type == "problem_save"
     assert statement.name == "problem_save"
@@ -385,8 +395,8 @@ def test_models_edx_ui_problem_save_with_valid_statement(statement):
 @settings(max_examples=1)
 @given(st.builds(UIProblemSave, referer=provisional.urls(), page=provisional.urls()))
 def test_models_edx_ui_problem_save_selector_with_valid_statement(statement):
-    """Tests given a `problem_save` statement the selector `get_model`
-    method should return `ProblemSave` model.
+    """Tests given a `problem_save` statement the selector `get_model` method should
+    return `ProblemSave` model.
     """
 
     statement = json.loads(statement.json())
@@ -405,7 +415,9 @@ def test_models_edx_ui_problem_save_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_ui_problem_show_with_valid_statement(statement):
-    """Tests that a `problem_show` browser statement has the expected `event_type` and `name`."""
+    """Tests that a `problem_show` browser statement has the expected `event_type` and
+    `name`.
+    """
 
     assert statement.event_type == "problem_show"
     assert statement.name == "problem_show"
@@ -421,8 +433,8 @@ def test_models_edx_ui_problem_show_with_valid_statement(statement):
     )
 )
 def test_models_edx_ui_problem_show_selector_with_valid_statement(statement):
-    """Tests given a `problem_show` statement the selector `get_model`
-    method should return `ProblemShow` model.
+    """Tests given a `problem_show` statement the selector `get_model` method should
+    return `ProblemShow` model.
     """
 
     statement = json.loads(statement.json())
@@ -444,7 +456,9 @@ def test_models_edx_ui_problem_show_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_reset_problem_with_valid_statement(statement):
-    """Tests that a `reset_problem` server statement has the expected `event_type` and `page`."""
+    """Tests that a `reset_problem` server statement has the expected `event_type` and
+    `page`.
+    """
 
     assert statement.event_type == "reset_problem"
     assert statement.page == "x_module"
@@ -463,8 +477,8 @@ def test_models_edx_reset_problem_with_valid_statement(statement):
     )
 )
 def test_models_edx_reset_problem_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem` statement the selector `get_model`
-    method should return `ResetProblem` model.
+    """Tests given a `reset_problem` statement the selector `get_model` method should
+    return `ResetProblem` model.
     """
 
     statement = json.loads(statement.json())
@@ -480,8 +494,8 @@ def test_models_edx_reset_problem_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_reset_problem_fail_with_valid_statement(statement):
-    """Tests that a `reset_problem_fail` server statement has the expected `event_type` and
-    `page`.
+    """Tests that a `reset_problem_fail` server statement has the expected `event_type`
+    and `page`.
     """
 
     assert statement.event_type == "reset_problem_fail"
@@ -497,8 +511,8 @@ def test_models_edx_reset_problem_fail_with_valid_statement(statement):
     )
 )
 def test_models_edx_reset_problem_fail_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem_fail` statement the selector `get_model`
-    method should return `ResetProblemFail` model.
+    """Tests given a `reset_problem_fail` statement the selector `get_model` method
+    should return `ResetProblemFail` model.
     """
 
     statement = json.loads(statement.json())
@@ -517,8 +531,8 @@ def test_models_edx_reset_problem_fail_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_save_problem_fail_with_valid_statement(statement):
-    """Tests that a `save_problem_fail` server statement has the expected `event_type` and
-    `page`.
+    """Tests that a `save_problem_fail` server statement has the expected `event_type`
+    and `page`.
     """
 
     assert statement.event_type == "save_problem_fail"
@@ -534,8 +548,8 @@ def test_models_edx_save_problem_fail_with_valid_statement(statement):
     )
 )
 def test_models_edx_save_problem_fail_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem_fail` statement the selector `get_model`
-    method should return `SaveProblemFail` model.
+    """Tests given a `reset_problem_fail` statement the selector `get_model` method
+    should return `SaveProblemFail` model.
     """
 
     statement = json.loads(statement.json())
@@ -553,8 +567,8 @@ def test_models_edx_save_problem_fail_selector_with_valid_statement(statement):
     )
 )
 def test_models_edx_save_problem_success_with_valid_statement(statement):
-    """Tests that a `save_problem_success` server statement has the expected `event_type` and
-    `page`.
+    """Tests that a `save_problem_success` server statement has the expected
+    `event_type` and `page`.
     """
 
     assert statement.event_type == "save_problem_success"
@@ -570,8 +584,8 @@ def test_models_edx_save_problem_success_with_valid_statement(statement):
     )
 )
 def test_models_edx_save_problem_success_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem_success` statement the selector `get_model`
-    method should return `SaveProblemSuccess` model.
+    """Tests given a `reset_problem_success` statement the selector `get_model` method
+    should return `SaveProblemSuccess` model.
     """
 
     statement = json.loads(statement.json())
@@ -588,7 +602,9 @@ def test_models_edx_save_problem_success_selector_with_valid_statement(statement
     )
 )
 def test_models_edx_show_answer_with_valid_statement(statement):
-    """Tests that a `showanswer` server statement has the expected `event_type` and `page`."""
+    """Tests that a `showanswer` server statement has the expected `event_type` and
+    `page`.
+    """
 
     assert statement.event_type == "showanswer"
     assert statement.page == "x_module"
@@ -601,8 +617,8 @@ def test_models_edx_show_answer_with_valid_statement(statement):
     )
 )
 def test_models_edx_show_answer_selector_with_valid_statement(statement):
-    """Tests given a `show_answer` statement the selector `get_model`
-    method should return `ShowAnswer` model.
+    """Tests given a `show_answer` statement the selector `get_model` method should
+    return `ShowAnswer` model.
     """
 
     statement = json.loads(statement.json())

--- a/tests/models/edx/test_enrollment.py
+++ b/tests/models/edx/test_enrollment.py
@@ -31,8 +31,8 @@ from ralph.models.selector import ModelSelector
 def test_models_edx_edx_course_enrollment_activated_with_valid_statement(
     statement,
 ):
-    """Tests that a `edx.course.enrollment.activated` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `edx.course.enrollment.activated` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "edx.course.enrollment.activated"
@@ -50,8 +50,8 @@ def test_models_edx_edx_course_enrollment_activated_with_valid_statement(
 def test_models_edx_edx_course_enrollment_activated_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `edx.course.enrollment.activated` statement the `get_model` selector method
-    should return `EdxCourseEnrollmentActivated` model.
+    """Tests given a `edx.course.enrollment.activated` statement the `get_model`
+    selector method should return `EdxCourseEnrollmentActivated` model.
     """
 
     statement = json.loads(statement.json())
@@ -72,8 +72,8 @@ def test_models_edx_edx_course_enrollment_activated_selector_with_valid_statemen
 def test_models_edx_edx_course_enrollment_deactivated_with_valid_statement(
     statement,
 ):
-    """Tests that a `edx.course.enrollment.deactivated` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `edx.course.enrollment.deactivated` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "edx.course.enrollment.deactivated"
@@ -91,8 +91,8 @@ def test_models_edx_edx_course_enrollment_deactivated_with_valid_statement(
 def test_models_edx_edx_course_enrollment_deactivated_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `edx.course.enrollment.deactivated` statement the `get_model` selector method
-    should return `EdxCourseEnrollmentDeactivated` model.
+    """Tests given a `edx.course.enrollment.deactivated` statement the `get_model`
+    selector method should return `EdxCourseEnrollmentDeactivated` model.
     """
 
     statement = json.loads(statement.json())
@@ -113,8 +113,8 @@ def test_models_edx_edx_course_enrollment_deactivated_selector_with_valid_statem
 def test_models_edx_edx_course_enrollment_mode_changed_with_valid_statement(
     statement,
 ):
-    """Tests that a `edx.course.enrollment.mode_changed` statement has the expected `event_type`
-    and `name`.
+    """Tests that a `edx.course.enrollment.mode_changed` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "edx.course.enrollment.mode_changed"
@@ -132,8 +132,8 @@ def test_models_edx_edx_course_enrollment_mode_changed_with_valid_statement(
 def test_models_edx_edx_course_enrollment_mode_changed_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `edx.course.enrollment.mode_changed` statement the `get_model` selector method
-    should return `EdxCourseEnrollmentModeChanged` model.
+    """Tests given a `edx.course.enrollment.mode_changed` statement the `get_model`
+    selector method should return `EdxCourseEnrollmentModeChanged` model.
     """
 
     statement = json.loads(statement.json())
@@ -155,14 +155,15 @@ def test_models_edx_edx_course_enrollment_mode_changed_selector_with_valid_state
 def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_with_valid_statement(
     statement,
 ):
-    """Tests that a `edx.course.enrollment.upgrade_clicked` statement has the expected `event_type`
-    and `name`.
+    """Tests that a `edx.course.enrollment.upgrade_clicked` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "edx.course.enrollment.upgrade_clicked"
     assert statement.name == "edx.course.enrollment.upgrade_clicked"
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -172,11 +173,11 @@ def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_with_valid_statemen
         context=st.builds(EdxCourseEnrollmentUpgradeClickedContextField),
     )
 )
-def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_selector_with_valid_statement(
+def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_selector_with_valid_statement(  # noqa
     statement,
 ):
-    """Tests given a `edx.course.enrollment.upgrade_clicked` statement the `get_model` selector
-    method should return `UIEdxCourseEnrollmentUpgradeClicked` model.
+    """Tests given a `edx.course.enrollment.upgrade_clicked` statement the `get_model`
+    selector method should return `UIEdxCourseEnrollmentUpgradeClicked` model.
     """
 
     statement = json.loads(statement.json())
@@ -205,6 +206,7 @@ def test_models_edx_edx_course_enrollment_upgrade_succeeded_with_valid_statement
     assert statement.name == "edx.course.enrollment.upgrade.succeeded"
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -213,11 +215,11 @@ def test_models_edx_edx_course_enrollment_upgrade_succeeded_with_valid_statement
         context=st.builds(EdxCourseEnrollmentUpgradeSucceededContextField),
     )
 )
-def test_models_edx_edx_course_enrollment_upgrade_succeeded_selector_with_valid_statement(
+def test_models_edx_edx_course_enrollment_upgrade_succeeded_selector_with_valid_statement(  # noqa
     statement,
 ):
-    """Tests given a `edx.course.enrollment.upgrade.succeeded` statement the `get_model` selector
-    method should return `EdxCourseEnrollmentUpgradeSucceeded` model.
+    """Tests given a `edx.course.enrollment.upgrade.succeeded` statement the `get_model`
+    selector method should return `EdxCourseEnrollmentUpgradeSucceeded` model.
     """
 
     statement = json.loads(statement.json())

--- a/tests/models/edx/test_navigational.py
+++ b/tests/models/edx/test_navigational.py
@@ -22,10 +22,15 @@ from ralph.models.selector import ModelSelector
 @settings(max_examples=1)
 @given(st.builds(NavigationalEventField))
 def test_fields_edx_navigational_events_event_field_with_valid_content(field):
-    """Tests that a valid `NavigationalEventField` does not raise a `ValidationError`."""
+    """Tests that a valid `NavigationalEventField` does not raise a
+    `ValidationError`.
+    """
 
     assert re.match(
-        r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@sequential\+block@[a-f0-9]{32}$",
+        (
+            r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"
+            r"type@sequential\+block@[a-f0-9]{32}$"
+        ),
         field.id,
     )
 
@@ -33,13 +38,28 @@ def test_fields_edx_navigational_events_event_field_with_valid_content(field):
 @pytest.mark.parametrize(
     "id",
     [
-        "block-v2:orgX=CS111+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS11120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1",
+        (
+            "block-v2:orgX=CS111+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS11120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1"
+        ),
         "block-v1:orgX=CS111=20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1",
-        "block-v1:orgX=CS111=20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13",
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1"
+        ),
+        (
+            "block-v1:orgX=CS111=20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13"
+        ),
     ],  # pylint: disable=invalid-name
 )
 @settings(max_examples=1)
@@ -59,7 +79,9 @@ def test_fields_edx_navigational_events_event_field_with_invalid_content(
 @settings(max_examples=1)
 @given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
 def test_models_edx_ui_page_close_with_valid_statement(statement):
-    """Tests that a `page_close` statement has the expected `event`, `event_type` and `name`."""
+    """Tests that a `page_close` statement has the expected `event`, `event_type` and
+    `name`.
+    """
 
     assert statement.event == "{}"
     assert statement.event_type == "page_close"
@@ -69,8 +91,8 @@ def test_models_edx_ui_page_close_with_valid_statement(statement):
 @settings(max_examples=1)
 @given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
 def test_models_edx_ui_page_close_selector_with_valid_statement(statement):
-    """Tests given a `page_close` statement the selector `get_model` method should return
-    `UIPageClose` model.
+    """Tests given a `page_close` statement the selector `get_model` method should
+    return `UIPageClose` model.
     """
 
     statement = json.loads(statement.json())
@@ -105,8 +127,8 @@ def test_models_edx_ui_seq_goto_with_valid_statement(statement):
     )
 )
 def test_models_edx_ui_seq_goto_selector_with_valid_statement(statement):
-    """Tests given a `seq_goto` statement the selector `get_model` method should return `UISeqGoto`
-    model.
+    """Tests given a `seq_goto` statement the selector `get_model` method should return
+    `UISeqGoto` model.
     """
 
     statement = json.loads(statement.json())
@@ -145,8 +167,8 @@ def test_models_edx_ui_seq_next_with_valid_statement(statement):
     )
 )
 def test_models_edx_ui_seq_next_selector_with_valid_statement(statement):
-    """Tests given a `seq_next` event the selector `get_model` method should return `UISeqNext`
-    model.
+    """Tests given a `seq_next` event the selector `get_model` method should return
+    `UISeqNext` model.
     """
 
     statement = json.loads(statement.json())
@@ -238,8 +260,8 @@ def test_models_edx_ui_seq_prev_with_invalid_statement(old, new, event):
     )
 )
 def test_models_edx_ui_seq_prev_selector_with_valid_statement(statement):
-    """Tests given a `seq_prev` statement the selector `get_model` method should return `UISeqPrev`
-    model.
+    """Tests given a `seq_prev` statement the selector `get_model` method should return
+    `UISeqPrev` model.
     """
 
     statement = json.loads(statement.json())

--- a/tests/models/edx/test_server.py
+++ b/tests/models/edx/test_server.py
@@ -14,15 +14,18 @@ from ralph.models.selector import ModelSelector
 @settings(max_examples=1)
 @given(st.builds(Server, referer=provisional.urls(), event=st.builds(ServerEventField)))
 def test_model_selector_server_get_model_with_valid_event(event):
-    """Tests given a server statement, the get_model method should return the corresponding
-    model."""
+    """Tests given a server statement, the get_model method should return the
+    corresponding model.
+    """
 
     event = json.loads(event.json())
     assert ModelSelector(module="ralph.models.edx").get_model(event) is Server
 
 
 def test_model_selector_server_get_model_with_invalid_event():
-    """Tests given a server statement, the get_model method should raise UnknownEventException."""
+    """Tests given a server statement, the get_model method should raise
+    UnknownEventException.
+    """
 
     with pytest.raises(UnknownEventException):
         ModelSelector(module="ralph.models.edx").get_model({"invalid": "event"})

--- a/tests/models/edx/test_textbook_interaction.py
+++ b/tests/models/edx/test_textbook_interaction.py
@@ -60,15 +60,36 @@ def test_fields_edx_textbook_interaction_base_event_field_with_valid_content(fie
 @pytest.mark.parametrize(
     "chapter",
     (
-        "block-v2:orgX=CS11+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
-        "block-v1:orgX=CS1120_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
-        "block-v1:orgX=CS11=20_T1+tipe@sequential+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
+        (
+            "block-v2:orgX=CS11+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf"
+        ),
+        (
+            "block-v1:orgX=CS1120_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf"
+        ),
+        (
+            "block-v1:orgX=CS11=20_T1+tipe@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf"
+        ),
         "block-v1:orgX=CS11+20_T1+",
         "type@sequentialblock@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
-        "block-v1:orgX=CS11+20_T1+type@sequential+block@d0d4a647742943z3951b45d9db8a0ea1file.pdf",
-        "block-v1:orgX=CS11+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea13file.pdf",
-        "block-v1:orgX=CS11+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1file",
-        "block-v1:orgX=CS11+20_T1+type@sequential+block@d0d4a647742943e3951b45d9db8a0ea1file.jpg",
+        (
+            "block-v1:orgX=CS11+20_T1+type@sequential"
+            "+block@d0d4a647742943z3951b45d9db8a0ea1file.pdf"
+        ),
+        (
+            "block-v1:orgX=CS11+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea13file.pdf"
+        ),
+        (
+            "block-v1:orgX=CS11+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1file"
+        ),
+        (
+            "block-v1:orgX=CS11+20_T1+type@sequential"
+            "+block@d0d4a647742943e3951b45d9db8a0ea1file.jpg"
+        ),
     ),
 )
 @settings(max_examples=1)
@@ -76,7 +97,9 @@ def test_fields_edx_textbook_interaction_base_event_field_with_valid_content(fie
 def test_fields_edx_textbook_interaction_base_event_field_with_invalid_content(
     chapter, field
 ):
-    """Tests that an invalid `TextbookInteractionBaseEventField` raises a `ValidationError`."""
+    """Tests that an invalid `TextbookInteractionBaseEventField` raises a
+    `ValidationError`.
+    """
 
     invalid_field = json.loads(field.json())
     invalid_field["chapter"] = chapter
@@ -90,8 +113,8 @@ def test_fields_edx_textbook_interaction_base_event_field_with_invalid_content(
 def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_valid_content(
     field,
 ):
-    """Tests that a valid `TextbookPdfChapterNavigatedEventField` does not raise
-    a `ValidationError`.
+    """Tests that a valid `TextbookPdfChapterNavigatedEventField` does not raise a
+    `ValidationError`.
     """
 
     assert re.match(
@@ -103,14 +126,32 @@ def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_valid_conten
 @pytest.mark.parametrize(
     "chapter",
     (
-        "asset-v2:orgX=CS11+20_T1+type@asset+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
-        "asset-v1:orgX=CS1120_T1+type@asset+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
-        "asset-v1:orgX=CS11=20_T1+tipe@asset+block@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
+        (
+            "asset-v2:orgX=CS11+20_T1+type@asset+"
+            "block@d0d4a647742943e3951b45d9db8a0ea1file.pdf"
+        ),
+        (
+            "asset-v1:orgX=CS1120_T1+type@asset+"
+            "block@d0d4a647742943e3951b45d9db8a0ea1file.pdf"
+        ),
+        (
+            "asset-v1:orgX=CS11=20_T1+tipe@asset+"
+            "block@d0d4a647742943e3951b45d9db8a0ea1file.pdf"
+        ),
         "asset-v1:orgX=CS11+20_T1+",
         "type@assetblock@d0d4a647742943e3951b45d9db8a0ea1file.pdf",
-        "asset-v1:orgX=CS11+20_T1+type@asset+block@d0d4a647742943z3951b45d9db8a0ea1file.pdf",
-        "asset-v1:orgX=CS11+20_T1+type@asset+block@d0d4a647742943e3951b45d9db8a0ea13file.pdf",
-        "asset-v1:orgX=CS11+20_T1+type@asset+block@d0d4a647742943e3951b45d9db8a0ea1file",
+        (
+            "asset-v1:orgX=CS11+20_T1+type@asset+"
+            "block@d0d4a647742943z3951b45d9db8a0ea1file.pdf"
+        ),
+        (
+            "asset-v1:orgX=CS11+20_T1+type@asset+"
+            "block@d0d4a647742943e3951b45d9db8a0ea13file.pdf"
+        ),
+        (
+            "asset-v1:orgX=CS11+20_T1+type@asset+"
+            "block@d0d4a647742943e3951b45d9db8a0ea1file"
+        ),
     ),
 )
 @settings(max_examples=1)
@@ -118,7 +159,9 @@ def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_valid_conten
 def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_invalid_content(
     chapter, field
 ):
-    """Tests that an invalid `TextbookPdfChapterNavigatedEventField` raises a `ValidationError`."""
+    """Tests that an invalid `TextbookPdfChapterNavigatedEventField` raises a
+    `ValidationError`.
+    """
 
     invalid_field = json.loads(field.json())
     invalid_field["chapter"] = chapter
@@ -191,8 +234,8 @@ def test_models_edx_ui_textbook_pdf_thumbnails_toggled_with_valid_statement(stat
 def test_models_edx_ui_textbook_pdf_thumbnails_toggled_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.thumbnails.toggled` event the selector `get_model` method should
-    return `UITextbookPdfThumbnailsToggled` model.
+    """Tests given a `textbook.pdf.thumbnails.toggled` event the selector `get_model`
+    method should return `UITextbookPdfThumbnailsToggled` model.
     """
 
     statement = json.loads(statement.json())
@@ -214,8 +257,8 @@ def test_models_edx_ui_textbook_pdf_thumbnails_toggled_selector_with_valid_state
 def test_models_edx_ui_textbook_pdf_thumbnail_navigated_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.thumbnail.navigated` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.thumbnail.navigated` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.thumbnail.navigated"
@@ -234,8 +277,8 @@ def test_models_edx_ui_textbook_pdf_thumbnail_navigated_with_valid_statement(
 def test_models_edx_ui_textbook_pdf_thumbnail_navigated_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.thumbnail.navigated` statement the selector `get_model` method
-    should return `UITextbookPdfThumbnailNavigated` model.
+    """Tests given a `textbook.pdf.thumbnail.navigated` statement the selector
+    `get_model` method should return `UITextbookPdfThumbnailNavigated` model.
     """
 
     statement = json.loads(statement.json())
@@ -257,8 +300,8 @@ def test_models_edx_ui_textbook_pdf_thumbnail_navigated_selector_with_valid_stat
 def test_models_edx_ui_textbook_pdf_outline_toggled_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.outline.toggled` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.outline.toggled` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.outline.toggled"
@@ -277,8 +320,8 @@ def test_models_edx_ui_textbook_pdf_outline_toggled_with_valid_statement(
 def test_models_edx_ui_textbook_pdf_outline_toggled_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.outline.toggled` statement the selector `get_model` method
-    should return `UITextbookPdfOutlineToggled` model.
+    """Tests given a `textbook.pdf.outline.toggled` statement the selector `get_model`
+    method should return `UITextbookPdfOutlineToggled` model.
     """
 
     statement = json.loads(statement.json())
@@ -300,8 +343,8 @@ def test_models_edx_ui_textbook_pdf_outline_toggled_selector_with_valid_statemen
 def test_models_edx_ui_textbook_pdf_chapter_navigated_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.chapter.navigated` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.chapter.navigated` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.chapter.navigated"
@@ -320,8 +363,8 @@ def test_models_edx_ui_textbook_pdf_chapter_navigated_with_valid_statement(
 def test_models_edx_ui_textbook_pdf_chapter_navigated_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.chapter.navigated` statement the selector `get_model` method
-    should return `UITextbookPdfChapterNavigated` model.
+    """Tests given a `textbook.pdf.chapter.navigated` statement the selector `get_model`
+    method should return `UITextbookPdfChapterNavigated` model.
     """
 
     statement = json.loads(statement.json())
@@ -343,8 +386,8 @@ def test_models_edx_ui_textbook_pdf_chapter_navigated_selector_with_valid_statem
 def test_models_edx_ui_textbook_pdf_page_navigated_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.page.navigated` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.page.navigated` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.page.navigated"
@@ -363,8 +406,8 @@ def test_models_edx_ui_textbook_pdf_page_navigated_with_valid_statement(
 def test_models_edx_ui_textbook_pdf_page_navigated_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.page.navigated` statement the selector `get_model` method
-    should return `UITextbookPdfPageNavigated` model.
+    """Tests given a `textbook.pdf.page.navigated` statement the selector `get_model`
+    method should return `UITextbookPdfPageNavigated` model.
     """
 
     statement = json.loads(statement.json())
@@ -386,8 +429,8 @@ def test_models_edx_ui_textbook_pdf_page_navigated_selector_with_valid_statement
 def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.zoom.buttons.changed` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.zoom.buttons.changed` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.zoom.buttons.changed"
@@ -406,8 +449,8 @@ def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_with_valid_statement(
 def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.zoom.buttons.changed` statement the selector `get_model` method
-    should return `UITextbookPdfZoomButtonsChanged` model.
+    """Tests given a `textbook.pdf.zoom.buttons.changed` statement the selector
+    `get_model` method should return `UITextbookPdfZoomButtonsChanged` model.
     """
 
     statement = json.loads(statement.json())
@@ -427,7 +470,9 @@ def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_selector_with_valid_sta
     )
 )
 def test_models_edx_ui_textbook_pdf_zoom_menu_changed_with_valid_statement(statement):
-    """Tests that a `textbook.pdf.zoom.menu.changed` has the expected `event_type` and `name`."""
+    """Tests that a `textbook.pdf.zoom.menu.changed` has the expected `event_type` and
+    `name`.
+    """
 
     assert statement.event_type == "textbook.pdf.zoom.menu.changed"
     assert statement.name == "textbook.pdf.zoom.menu.changed"
@@ -445,8 +490,8 @@ def test_models_edx_ui_textbook_pdf_zoom_menu_changed_with_valid_statement(state
 def test_models_edx_ui_textbook_pdf_zoom_menu_changed_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.zoom.menu.changed` statement the selector `get_model` method
-    should return `UITextbookPdfZoomMenuChanged` model.
+    """Tests given a `textbook.pdf.zoom.menu.changed` statement the selector `get_model`
+    method should return `UITextbookPdfZoomMenuChanged` model.
     """
 
     statement = json.loads(statement.json())
@@ -466,8 +511,8 @@ def test_models_edx_ui_textbook_pdf_zoom_menu_changed_selector_with_valid_statem
     )
 )
 def test_models_edx_ui_textbook_pdf_display_scaled_with_valid_statement(statement):
-    """Tests that a `textbook.pdf.display.scaled` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.display.scaled` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.display.scaled"
@@ -486,8 +531,8 @@ def test_models_edx_ui_textbook_pdf_display_scaled_with_valid_statement(statemen
 def test_models_edx_ui_textbook_pdf_display_scaled_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.display.scaled` statement the selector `get_model` method
-    should return `UITextbookPdfDisplayScaled` model.
+    """Tests given a `textbook.pdf.display.scaled` statement the selector `get_model`
+    method should return `UITextbookPdfDisplayScaled` model.
     """
 
     statement = json.loads(statement.json())
@@ -507,8 +552,8 @@ def test_models_edx_ui_textbook_pdf_display_scaled_selector_with_valid_statement
     )
 )
 def test_models_edx_ui_textbook_pdf_page_scrolled_with_valid_statement(statement):
-    """Tests that a `textbook.pdf.page.scrolled` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.page.scrolled` statement has the expected `event_type`
+    and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.page.scrolled"
@@ -527,8 +572,8 @@ def test_models_edx_ui_textbook_pdf_page_scrolled_with_valid_statement(statement
 def test_models_edx_ui_textbook_pdf_page_scrolled_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.page.scrolled` statement the selector `get_model` method
-    should return `UITextbookPdfPageScrolled` model.
+    """Tests given a `textbook.pdf.page.scrolled` statement the selector `get_model`
+    method should return `UITextbookPdfPageScrolled` model.
     """
 
     statement = json.loads(statement.json())
@@ -548,8 +593,8 @@ def test_models_edx_ui_textbook_pdf_page_scrolled_selector_with_valid_statement(
     )
 )
 def test_models_edx_ui_textbook_pdf_search_executed_with_valid_statement(statement):
-    """Tests that a `textbook.pdf.search.executed` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.search.executed` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.search.executed"
@@ -568,8 +613,8 @@ def test_models_edx_ui_textbook_pdf_search_executed_with_valid_statement(stateme
 def test_models_edx_ui_textbook_pdf_search_executed_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.search.executed` statement the selector `get_model` method
-    should return `UITextbookPdfSearchExecuted` model.
+    """Tests given a `textbook.pdf.search.executed` statement the selector `get_model`
+    method should return `UITextbookPdfSearchExecuted` model.
     """
 
     statement = json.loads(statement.json())
@@ -591,8 +636,8 @@ def test_models_edx_ui_textbook_pdf_search_executed_selector_with_valid_statemen
 def test_models_edx_ui_textbook_pdf_search_navigated_next_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.search.navigatednext` statement has the expected `event_type` and
-    `name`.
+    """Tests that a `textbook.pdf.search.navigatednext` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.search.navigatednext"
@@ -611,8 +656,8 @@ def test_models_edx_ui_textbook_pdf_search_navigated_next_with_valid_statement(
 def test_models_edx_ui_textbook_pdf_search_navigated_next_selector_with_valid_statement(
     statement,
 ):
-    """Tests given a `textbook.pdf.search.navigatednext` statement the selector `get_model` method
-    should return `UITextbookPdfSearchNavigatedNext` model.
+    """Tests given a `textbook.pdf.search.navigatednext` statement the selector
+    `get_model` method should return `UITextbookPdfSearchNavigatedNext` model.
     """
 
     statement = json.loads(statement.json())
@@ -634,14 +679,15 @@ def test_models_edx_ui_textbook_pdf_search_navigated_next_selector_with_valid_st
 def test_models_edx_ui_textbook_pdf_search_highlight_toggled_with_valid_statement(
     statement,
 ):
-    """Tests that a `textbook.pdf.search.highlight.toggled` statement has the expected `event_type`
-    and `name`.
+    """Tests that a `textbook.pdf.search.highlight.toggled` statement has the expected
+    `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.search.highlight.toggled"
     assert statement.name == "textbook.pdf.search.highlight.toggled"
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -651,11 +697,11 @@ def test_models_edx_ui_textbook_pdf_search_highlight_toggled_with_valid_statemen
         event=st.builds(TextbookPdfSearchHighlightToggledEventField),
     )
 )
-def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid_statement(
+def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid_statement(  # noqa
     statement,
 ):
-    """Tests given a `textbook.pdf.search.highlight.toggled` statement
-    the selector `get_model` method should return `UITextbookPdfSearchHighlightToggled` model.
+    """Tests given a `textbook.pdf.search.highlight.toggled` statement the selector
+    `get_model` method should return `UITextbookPdfSearchHighlightToggled` model.
     """
 
     statement = json.loads(statement.json())
@@ -665,6 +711,7 @@ def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid
     )
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -674,17 +721,18 @@ def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid
         event=st.builds(TextbookPdfSearchCaseSensitivityToggledEventField),
     )
 )
-def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_statement(
+def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_statement(  # noqa
     statement,
 ):
-    """Tests that a `textbook.pdf.searchcasesensitivity.toggled` statement has the expected
-    `event_type` and `name`.
+    """Tests that a `textbook.pdf.searchcasesensitivity.toggled` statement has the
+    expected `event_type` and `name`.
     """
 
     assert statement.event_type == "textbook.pdf.searchcasesensitivity.toggled"
     assert statement.name == "textbook.pdf.searchcasesensitivity.toggled"
 
 
+# pylint: disable=line-too-long
 @settings(max_examples=1)
 @given(
     st.builds(
@@ -694,7 +742,7 @@ def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_s
         event=st.builds(TextbookPdfSearchCaseSensitivityToggledEventField),
     )
 )
-def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_selector_with_valid_statement(
+def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_selector_with_valid_statement(  # noqa
     statement,
 ):
     """Tests given a `textbook.pdf.searchcasesensitivity.toggled` statement the selector

--- a/tests/models/test_converter.py
+++ b/tests/models/test_converter.py
@@ -28,7 +28,10 @@ from ralph.models.xapi.constants import VERB_TERMINATED_ID
 
 
 @pytest.mark.parametrize(
-    "conversion_item,expected_dest,expected_src,expected_transfomers,expected_raw_input",
+    (
+        "conversion_item,expected_dest,expected_src,expected_transfomers,"
+        "expected_raw_input"
+    ),
     [
         (
             ConversionItem("destination", "source"),
@@ -102,7 +105,9 @@ def test_converter_conversion_item_get_value_with_successful_transformers(
 
 @pytest.mark.parametrize("event", [{}, {"foo": "bar"}])
 def test_converter_convert_dict_event_with_empty_conversion_set(event):
-    """Tests when the conversion_set is empty, convert_dict_event should return an empty model."""
+    """Tests when the conversion_set is empty, convert_dict_event should return an empty
+    model.
+    """
 
     class DummyBaseConversionSet(BaseConversionSet):
         """Dummy implementation of abstract BaseConversionSet."""
@@ -136,7 +141,9 @@ def test_converter_convert_dict_event_with_empty_conversion_set(event):
 def test_converter_convert_dict_event_with_one_conversion_item(
     event, source, transformer, expected
 ):
-    """Tests the convert_dict_event method with a conversion_set containing one conversion item."""
+    """Tests the convert_dict_event method with a conversion_set containing one
+    conversion item.
+    """
 
     class DummyBaseModel(BaseModel):
         """Dummy base model with one field."""
@@ -214,7 +221,9 @@ def test_converter_converter_convert_with_no_events(caplog, valid_uuid):
 def test_converter_convert_with_a_non_json_event_writes_an_error_message(
     event, valid_uuid, caplog
 ):
-    """Tests given a non JSON event, the convert method should write an error message."""
+    """Tests given a non JSON event, the convert method should write an error
+    message.
+    """
 
     result = Converter(platform_url="", uuid_namespace=valid_uuid).convert(
         [event], ignore_errors=True, fail_on_unknown=True
@@ -230,7 +239,9 @@ def test_converter_convert_with_a_non_json_event_writes_an_error_message(
 def test_converter_convert_with_a_non_json_event_raises_an_exception(
     event, valid_uuid, caplog
 ):
-    """Tests given a non JSON event, the convert method should raise a BadFormatException."""
+    """Tests given a non JSON event, the convert method should raise a
+    BadFormatException.
+    """
 
     result = Converter(platform_url="", uuid_namespace=valid_uuid).convert(
         [event], ignore_errors=False, fail_on_unknown=True
@@ -252,7 +263,9 @@ def test_converter_convert_with_a_non_json_event_raises_an_exception(
 def test_converter_convert_with_an_unknown_event_writes_an_error_message(
     event, valid_uuid, caplog
 ):
-    """Tests given an unknown event the convert method should write an error message."""
+    """Tests given an unknown event the convert method should write an error
+    message.
+    """
 
     result = Converter(platform_url="", uuid_namespace=valid_uuid).convert(
         [event], ignore_errors=False, fail_on_unknown=False
@@ -275,7 +288,9 @@ def test_converter_convert_with_an_unknown_event_writes_an_error_message(
 def test_converter_convert_with_an_unknown_event_raises_an_exception(
     event, valid_uuid, caplog
 ):
-    """Tests given an unknown event the convert method should raise an UnknownEventException."""
+    """Tests given an unknown event the convert method should raise an
+    UnknownEventException.
+    """
 
     result = Converter(platform_url="", uuid_namespace=valid_uuid).convert(
         [event], ignore_errors=False, fail_on_unknown=True
@@ -285,16 +300,17 @@ def test_converter_convert_with_an_unknown_event_raises_an_exception(
             list(result)
 
 
+# pylint: disable=line-too-long
 @pytest.mark.parametrize(
     "event",
     [json.dumps({"event_source": "browser", "event_type": "page_close"})],
 )
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
-def test_converter_convert_with_an_event_missing_a_conversion_set_writes_an_error_message(
+def test_converter_convert_with_an_event_missing_a_conversion_set_writes_an_error_message(  # noqa
     event, valid_uuid, caplog
 ):
-    """Tests given an event that doesn't have a corresponding conversion_set, the convert method
-    should write an error message.
+    """Tests given an event that doesn't have a corresponding conversion_set, the
+    convert method should write an error message.
     """
 
     result = Converter(module="os", platform_url="", uuid_namespace=valid_uuid).convert(
@@ -314,8 +330,8 @@ def test_converter_convert_with_an_event_missing_a_conversion_set_writes_an_erro
 def test_converter_convert_with_an_event_missing_a_conversion_set_raises_an_exception(
     event, valid_uuid, caplog
 ):
-    """Tests given an event that doesn't have a corresponding conversion_set, the convert method
-    should raise a MissingConversionSetException.
+    """Tests given an event that doesn't have a corresponding conversion_set, the
+    convert method should raise a MissingConversionSetException.
     """
 
     result = Converter(module="os", platform_url="", uuid_namespace=valid_uuid).convert(
@@ -326,18 +342,19 @@ def test_converter_convert_with_an_event_missing_a_conversion_set_raises_an_exce
             list(result)
 
 
+# pylint: disable=line-too-long
 @pytest.mark.parametrize(
     "event",
     [json.dumps({"event_source": "browser", "event_type": "page_close"})],
 )
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
-def test_converter_convert_with_an_invalid_page_close_event_writes_an_error_message(
+def test_converter_convert_with_an_invalid_page_close_event_writes_an_error_message(  # noqa
     event,
     valid_uuid,
     caplog,
 ):
-    """Tests given an event that matches a pydantic model but fails at the conversion step,
-    the convert method should write an error message.
+    """Tests given an event that matches a pydantic model but fails at the conversion
+    step, the convert method should write an error message.
     """
 
     result = Converter(platform_url="", uuid_namespace=valid_uuid).convert(
@@ -357,8 +374,8 @@ def test_converter_convert_with_an_invalid_page_close_event_writes_an_error_mess
 def test_converter_convert_with_invalid_page_close_event_raises_an_exception(
     event, valid_uuid, caplog
 ):
-    """Tests given an event that matches a pydantic model but fails at the conversion step,
-    the convert method should raise a ConversionException.
+    """Tests given an event that matches a pydantic model but fails at the conversion
+    step, the convert method should raise a ConversionException.
     """
 
     result = Converter(platform_url="", uuid_namespace=valid_uuid).convert(
@@ -376,8 +393,8 @@ def test_converter_convert_with_invalid_page_close_event_raises_an_exception(
 def test_converter_convert_with_invalid_arguments_writes_an_error_message(
     valid_uuid, invalid_platform_url, caplog, event
 ):
-    """Tests given invalid arguments causing the conversion to fail at the validation step,
-    the convert method should write an error message.
+    """Tests given invalid arguments causing the conversion to fail at the validation
+    step, the convert method should write an error message.
     """
 
     event_str = event.json()
@@ -398,8 +415,8 @@ def test_converter_convert_with_invalid_arguments_writes_an_error_message(
 def test_converter_convert_with_invalid_arguments_raises_an_exception(
     valid_uuid, invalid_platform_url, caplog, event
 ):
-    """Tests given invalid arguments causing the conversion to fail at the validation step,
-    the convert method should raise a ValidationError.
+    """Tests given invalid arguments causing the conversion to fail at the validation
+    step, the convert method should raise a ValidationError.
     """
 
     event_str = event.json()
@@ -432,7 +449,9 @@ def test_converter_convert_with_valid_events(
 @given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 def test_converter_convert_counter(valid_uuid, caplog, event):
-    """Tests given multiple events the convert method should log the total and invalid events."""
+    """Tests given multiple events the convert method should log the total and invalid
+    events.
+    """
 
     valid_event = event.json()
     invalid_event_1 = 1

--- a/tests/models/test_selector.py
+++ b/tests/models/test_selector.py
@@ -128,14 +128,18 @@ from ralph.models.selector import (
     ],
 )
 def test_models_selector_model_selector_decision_tree(model_rules, decision_tree):
-    """Given `model_rules` the ModelSelector should create the expected decision tree."""
+    """Given `model_rules` the ModelSelector should create the expected decision
+    tree.
+    """
 
     model_selector = ModelSelector(module="ralph.models.edx")
     assert model_selector.get_decision_tree(model_rules) == decision_tree
 
 
 def test_models_selector_model_selector_get_model_with_invalid_event():
-    """Tests given an invalid event the get_model method should raise UnknownEventException."""
+    """Tests given an invalid event the get_model method should raise
+    UnknownEventException.
+    """
 
     with pytest.raises(UnknownEventException):
         ModelSelector(module="ralph.models.edx").get_model({"invalid": "event"})
@@ -200,6 +204,8 @@ def test_models_selector_model_selector_model_rules(model_rules, rules):
     ],
 )
 def test_models_selector_model_selector_build_model_rules(module, model_rules):
-    """Given an imported module build_model_rules should return the corresponding model_rules."""
+    """Given an imported module build_model_rules should return the corresponding
+    model_rules.
+    """
 
     assert ModelSelector.build_model_rules(module) == model_rules

--- a/tests/models/test_validator.py
+++ b/tests/models/test_validator.py
@@ -30,7 +30,9 @@ def test_models_validator_validate_with_no_events(caplog):
 def test_models_validator_validate_with_a_non_json_event_writes_an_error_message(
     event, caplog
 ):
-    """Tests given a non JSON event, the validate method should write an error message."""
+    """Tests given a non JSON event, the validate method should write an error
+    message.
+    """
 
     result = Validator(ModelSelector(module="ralph.models.edx")).validate(
         [event], ignore_errors=True, fail_on_unknown=True
@@ -45,7 +47,9 @@ def test_models_validator_validate_with_a_non_json_event_writes_an_error_message
 def test_models_validator_validate_with_a_non_json_event_raises_an_exception(
     event, caplog
 ):
-    """Tests given a non JSON event, the validate method should raise a BadFormatException."""
+    """Tests given a non JSON event, the validate method should raise a
+    BadFormatException.
+    """
 
     result = Validator(ModelSelector(module="ralph.models.edx")).validate(
         [event], ignore_errors=False, fail_on_unknown=True
@@ -66,7 +70,9 @@ def test_models_validator_validate_with_a_non_json_event_raises_an_exception(
 def test_models_validator_validate_with_an_unknown_event_writes_an_error_message(
     event, caplog
 ):
-    """Tests given an unknown event the validate method should write an error message."""
+    """Tests given an unknown event the validate method should write an error
+    message.
+    """
 
     result = Validator(ModelSelector(module="ralph.models.edx")).validate(
         [event],
@@ -90,7 +96,9 @@ def test_models_validator_validate_with_an_unknown_event_writes_an_error_message
 def test_models_validator_validate_with_an_unknown_event_raises_an_exception(
     event, caplog
 ):
-    """Tests given an unknown event the validate method should raise an UnknownEventException."""
+    """Tests given an unknown event the validate method should raise an
+    UnknownEventException.
+    """
 
     result = Validator(ModelSelector(module="ralph.models.edx")).validate(
         [event],
@@ -102,11 +110,12 @@ def test_models_validator_validate_with_an_unknown_event_raises_an_exception(
             list(result)
 
 
-def test_models_validator_validate_with_an_invalid_page_close_event_writes_an_error_message(
+# pylint: disable=line-too-long
+def test_models_validator_validate_with_an_invalid_page_close_event_writes_an_error_message(  # noqa
     caplog,
 ):
-    """Tests given an event that match a pydantic model but fail at the model validation step,
-    the validate method should write an error message.
+    """Tests given an event that match a pydantic model but fail at the model validation
+    step, the validate method should write an error message.
     """
 
     result = Validator(ModelSelector(module="ralph.models.edx")).validate(
@@ -123,8 +132,8 @@ def test_models_validator_validate_with_an_invalid_page_close_event_writes_an_er
 def test_models_validator_validate_with_invalid_page_close_event_raises_an_exception(
     caplog,
 ):
-    """Tests given an event that match a pydantic model but fail at the model validation step,
-    the validate method should raise a BadFormatException.
+    """Tests given an event that match a pydantic model but fail at the model validation
+    step, the validate method should raise a BadFormatException.
     """
 
     result = Validator(ModelSelector(module="ralph.models.edx")).validate(
@@ -178,7 +187,9 @@ def test_models_validator_validate_counter(caplog, event):
 @settings(max_examples=1)
 @given(st.builds(Server, referer=provisional.urls(), event=st.builds(ServerEventField)))
 def test_models_validator_validate_typing_cleanup(event):
-    """Tests given a valid event with wrong field types, the validate method should fix them."""
+    """Tests given a valid event with wrong field types, the validate method should fix
+    them.
+    """
 
     valid_event_str = event.json()
     valid_event = json.loads(valid_event_str)

--- a/tests/models/xapi/test_navigation.py
+++ b/tests/models/xapi/test_navigation.py
@@ -25,7 +25,9 @@ from ralph.models.xapi.navigation.statements import PageTerminated, PageViewed
     )
 )
 def test_models_xapi_page_terminated_statement(statement):
-    """Tests that a page_terminated statement has the expected verb.id and object.definition."""
+    """Tests that a page_terminated statement has the expected verb.id and
+    object.definition.
+    """
 
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/terminated"
     assert statement.object.definition.type == "http://activitystrea.ms/schema/1.0/page"
@@ -45,8 +47,9 @@ def test_models_xapi_page_terminated_statement(statement):
     )
 )
 def test_models_xapi_page_terminated_selector_with_valid_statement(statement):
-    """Tests given a page terminated statement, the get_model method should return PageTerminated
-    model."""
+    """Tests given a page terminated statement, the get_model method should return
+    PageTerminated model.
+    """
 
     statement = json.loads(statement.json())
     assert (
@@ -68,7 +71,9 @@ def test_models_xapi_page_terminated_selector_with_valid_statement(statement):
     )
 )
 def test_models_xapi_page_viewed_statement(statement):
-    """Tests that a page_viewed statement has the expected verb.id and object.definition."""
+    """Tests that a page_viewed statement has the expected verb.id and
+    object.definition.
+    """
 
     assert statement.verb.id == "http://id.tincanapi.com/verb/viewed"
     assert statement.object.definition.type == "http://activitystrea.ms/schema/1.0/page"
@@ -88,7 +93,9 @@ def test_models_xapi_page_viewed_statement(statement):
     )
 )
 def test_models_xapi_page_viewed_selector_with_valid_statement(statement):
-    """Tests given a page viewed statement, the get_model method should return PageViewed model."""
+    """Tests given a page viewed statement, the get_model method should return
+    PageViewed model.
+    """
 
     statement = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(statement) is PageViewed

--- a/tests/models/xapi/test_video.py
+++ b/tests/models/xapi/test_video.py
@@ -93,8 +93,8 @@ def test_models_xapi_video_initialized_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_initialized_selector_with_valid_statement(statement):
-    """Tests given a video initialized event, the get_model method should return VideoInitialized
-    model."""
+    """Tests given a video initialized event, the get_model method should return
+    VideoInitialized model."""
 
     statement = json.loads(statement.json())
     assert (
@@ -150,7 +150,9 @@ def test_models_xapi_video_played_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_played_selector_with_valid_statement(statement):
-    """Tests given a video played event, the get_model method should return VideoPlayed model."""
+    """Tests given a video played event, the get_model method should return
+    VideoPlayed model.
+    """
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoPlayed
@@ -203,7 +205,9 @@ def test_models_xapi_video_paused_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_paused_selector_with_valid_statement(statement):
-    """Tests given a video paused event, the get_model method should return VideoPaused model."""
+    """Tests given a video paused event, the get_model method should return VideoPaused
+    model.
+    """
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoPaused
@@ -256,7 +260,9 @@ def test_models_xapi_video_seeked_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_seeked_selector_with_valid_statement(statement):
-    """Tests given a video seeked event, the get_model method should return VideoSeeked model."""
+    """Tests given a video seeked event, the get_model method should return VideoSeeked
+    model.
+    """
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoSeeked
@@ -309,8 +315,9 @@ def test_models_xapi_video_completed_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_completed_selector_with_valid_statement(statement):
-    """Tests given a video completed event, the get_model method should return VideoCompleted
-    model."""
+    """Tests given a video completed event, the get_model method should return
+    VideoCompleted model.
+    """
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoCompleted
@@ -363,8 +370,8 @@ def test_models_xapi_video_terminated_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_terminated_selector_with_valid_statement(statement):
-    """Tests given a video terminated event, the get_model method should return VideoTerminated
-    model."""
+    """Tests given a video terminated event, the get_model method should return
+    VideoTerminated model."""
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoTerminated
@@ -417,8 +424,8 @@ def test_models_xapi_video_interacted_with_valid_statement(statement):
     )
 )
 def test_models_xapi_video_interacted_selector_with_valid_statement(statement):
-    """Tests given a video interacted event, the get_model method should return VideoInteracted
-    model."""
+    """Tests given a video interacted event, the get_model method should return
+    VideoInteracted model."""
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoInteracted

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,12 +39,18 @@ def test_cli_comma_separated_key_value_param_type():
     # Bad options
     with pytest.raises(
         BadParameter,
-        match="You should provide key=value pairs separated by commas, e.g. foo=bar,bar=2",
+        match=(
+            "You should provide key=value pairs separated by commas, "
+            "e.g. foo=bar,bar=2"
+        ),
     ):
         param_type.convert("foo=bar,baz", None, None)
     with pytest.raises(
         BadParameter,
-        match="You should provide key=value pairs separated by commas, e.g. foo=bar,bar=2",
+        match=(
+            "You should provide key=value pairs separated by commas, "
+            "e.g. foo=bar,bar=2"
+        ),
     ):
         param_type.convert("foo=bar,", None, None)
 
@@ -100,9 +106,11 @@ def test_cli_help_option():
 
     assert result.exit_code == 0
     assert (
-        "-v, --verbosity LVL  Either CRITICAL, ERROR, WARNING, INFO (default) or DEBUG"
-        in result.output
-    )
+        (
+            "-v, --verbosity LVL  Either CRITICAL, ERROR, WARNING, INFO (default) or "
+            "DEBUG"
+        )
+    ) in result.output
 
 
 def test_cli_extract_command_usage():
@@ -183,13 +191,15 @@ def test_cli_convert_command_usage():
     assert (
         "Options:\n"
         "  From edX to xAPI converter options: \n"
-        "    -u, --uuid-namespace TEXT     The UUID namespace to use for the `ID` field\n"
+        "    -u, --uuid-namespace TEXT     The UUID namespace to use for the `ID` "
+        "field\n"
         "                                  generation\n"
         "    -p, --platform-url TEXT       The `actor.account.homePage` to use in the\n"
         "                                  xAPI statements  [required]\n"
         "  -f, --from [edx]                Input events format to convert  [required]\n"
         "  -t, --to [xapi]                 Output events format  [required]\n"
-        "  -I, --ignore-errors             Continue writing regardless of raised errors\n"
+        "  -I, --ignore-errors             Continue writing regardless of raised "
+        "errors\n"
         "  -F, --fail-on-unknown           Stop converting at first unknown event\n"
     ) in result.output
 
@@ -234,7 +244,9 @@ def test_cli_convert_command_from_edx_to_xapi_format(valid_uuid, event):
 
 @pytest.mark.parametrize("invalid_uuid", ["", None, 1, {}])
 def test_cli_convert_command_with_invalid_uuid(invalid_uuid):
-    """Tests that the convert command raises an exception when the uuid namespace is invalid."""
+    """Tests that the convert command raises an exception when the uuid namespace is
+    invalid.
+    """
 
     runner = CliRunner()
     result = runner.invoke(
@@ -466,9 +478,9 @@ def test_cli_list_command_usage():
     result = runner.invoke(cli, ["list"])
     assert result.exit_code > 0
     assert (
-        "Error: Missing option '-b' / '--backend'. Choose from:\n\tldp,\n\tfs,\n\tswift\n"
-        in result.output
-    )
+        "Error: Missing option '-b' / '--backend'. Choose from:\n\tldp,\n\tfs,\n\t"
+        "swift\n"
+    ) in result.output
 
 
 def test_cli_list_command_with_ldp_backend(monkeypatch):
@@ -486,7 +498,7 @@ def test_cli_list_command_with_ldp_backend(monkeypatch):
             "md5": "01585b394be0495e38dbb60b20cb40a9",
             "retrievalDelay": 0,
             "retrievalState": "sealed",
-            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
             "size": 67906662,
         },
         {
@@ -496,7 +508,7 @@ def test_cli_list_command_with_ldp_backend(monkeypatch):
             "md5": "01585b394be0495e38dbb60b20cb40a9",
             "retrievalDelay": 0,
             "retrievalState": "sealed",
-            "sha256": "645d8e21e6fdb8aa7ffc507acf091ada39dbdc9ce612d06df8dcf67cb29a45ca",
+            "sha256": "645d8e21e6fdb8aa7ffc5c[...]9ce612d06df8dcf67cb29a45ca",
             "size": 67906662,
         },
     ]

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -19,8 +19,9 @@ def test_defaults_config_default(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_defaults_config_file(fs, monkeypatch):
-    """Tests that when the environment and command-line arguments don't specify a
-    value, the value from the config file is taken instead."""
+    """Tests that when the environment and command-line arguments don't specify a value,
+    the value from the config file is taken instead.
+    """
 
     config_mock = {"RALPH_HISTORY_FILE": "history_config_file"}
 
@@ -32,8 +33,9 @@ def test_defaults_config_file(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_defaults_config_env(fs, monkeypatch):
-    """Tests that when the environment specifies a value, it is chosen instead of
-    the configuration file's value."""
+    """Tests that when the environment specifies a value, it is chosen instead of the
+    configuration file's value.
+    """
 
     config_mock = {"RALPH_HISTORY_FILE": "history_config_file"}
 
@@ -45,8 +47,9 @@ def test_defaults_config_env(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_defaults_load_config_no_config(fs, monkeypatch):
-    """Tests that loading when no configuration file is available results in
-    load_config returning None."""
+    """Tests that loading when no configuration file is available results in load_config
+    returning None.
+    """
 
     config_path = APP_DIR / "config.yml"
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,8 +7,8 @@ from ralph.exceptions import EventKeyError
 
 
 def test_filters_anonymous_with_empty_events():
-    """Tests the anonymous filter when input dict has not the expected
-    'username' key.
+    """Tests the anonymous filter when input dict has not the expected `username`
+    key.
     """
 
     event = {}

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -72,9 +72,11 @@ def test_parsers_gelfparser_parse_partially_invalid_file(caplog):
                 '{"short_message": "This seems valid."}\n',
                 # Invalid json
                 "{ This is not valid json and raises json.decoder.JSONDecodeError\n",
-                # Valid json but invalid gelf - raises KeyError: key "short_message" not found
+                # Valid json but invalid gelf raises KeyError:
+                # key "short_message" not found
                 "{}\n",
-                # As above but raises TypeError: list indices must be integers or slices, not str
+                # As above but raises TypeError:
+                # list indices must be integers or slices, not str
                 "[]\n",
                 # Another assumed valid gelf
                 '{"short_message": {"username": "This seems valid too."}}\n',
@@ -101,7 +103,8 @@ def test_parsers_gelfparser_parse_partially_invalid_file(caplog):
     assert (
         "ralph.parsers",
         logging.ERROR,
-        "Input event '{ This is not valid json and raises json.decoder.JSONDecodeError\n' "
+        "Input event '{ This is not valid json and raises "
+        "json.decoder.JSONDecodeError\n' "
         "is not a valid JSON string! It will be ignored.",
     ) in caplog.record_tuples
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,7 +97,9 @@ def test_utils_get_instance_from_class():
 
 @pytest.mark.parametrize("path,value", [(["foo", "bar"], "bar_value")])
 def test_utils_get_dict_value_from_path_should_return_given_value(path, value):
-    """Tests the get_dict_value_from_path function should return the value when it's present."""
+    """Tests the get_dict_value_from_path function should return the value when it's
+    present.
+    """
 
     dictionary = {"foo": {"bar": "bar_value"}}
     assert ralph_utils.get_dict_value_from_path(dictionary, path) == value
@@ -115,14 +117,18 @@ def test_utils_get_dict_value_from_path_should_return_given_value(path, value):
 def test_utils_get_dict_value_from_path_should_return_none_when_value_does_not_exists(
     path,
 ):
-    """Tests the get_dict_value_from_path function should return None if the value is not found."""
+    """Tests the get_dict_value_from_path function should return None if the value is
+    not found.
+    """
 
     dictionary = {"foo": {"bar": "bar_value"}}
     assert ralph_utils.get_dict_value_from_path(dictionary, path) is None
 
 
 def test_utils_set_dict_value_from_path_creating_new_fields():
-    """Tests when the fields are not present, set_dict_value_from_path should add them."""
+    """Tests when the fields are not present, set_dict_value_from_path should add
+    them.
+    """
 
     dictionary = {}
     ralph_utils.set_dict_value_from_path(dictionary, ["foo", "bar"], "baz")
@@ -130,7 +136,9 @@ def test_utils_set_dict_value_from_path_creating_new_fields():
 
 
 def test_utils_set_dict_value_from_path_updating_fields():
-    """Tests when the fields are present, set_dict_value_from_path should update them."""
+    """Tests when the fields are present, set_dict_value_from_path should update
+    them.
+    """
 
     dictionary = {"foo": {"bar": "bar_value"}}
     ralph_utils.set_dict_value_from_path(dictionary, ["foo", "bar"], "baz")


### PR DESCRIPTION
## Purpose

At first, we wanted to homogeneise the maximal line length in the project linter settings following Black formatter default (88 chars). Then, we decided to stick to Black recommended-configuration for other tools [1].

[1] https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html

## Proposal

- [x] upgrade Black as renovate ignore beta updates
- [x] fix Flake8, isort and pylint configuration
- [x] fix docstrings and strings line lenghts ~~using an automated tool~~
