### PR TITLE
Fix elasticsearch config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
 
 ### Changed
 
-- Upgrade `elasticsearch` to `7.15.2`
+- Upgrade `elasticsearch` to `7.16.2`
 - Upgrade `python-keystoneclient` to `4.3.0`
 - Upgrade `python-swiftclient` to `3.13.0`
 - Upgrade `pyyaml` to `6.0`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # -- backends
   elasticsearch:
-    image: elasticsearch:7.13.3
+    image: elasticsearch:7.16.2
     environment:
       discovery.type: single-node
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       discovery.type: single-node
     ports:
       - "9200:9200"
+    mem_limit: 2g
     networks:
       potsie:
         aliases:


### PR DESCRIPTION
## Purpose

Some fix about `elasticsearch` were necessary in the `docker-compose` file.

## Proposal

- [x] Upgrade of the `elasticsearch` service version
- [x] Limit the memory allocated to the `elasticsearch` service

