### PR TITLE
Fix port binding conflicts due to the new `runserver` command

### DIFF
--- a/bin/ralph
+++ b/bin/ralph
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
+# docker-compose run extra arguments can be set via environment variables
+declare -i NO_DEPS="${NO_DEPS:-0}"
+declare -i SERVICE_PORTS="${SERVICE_PORTS:-0}"
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-NO_DEPS=""
-if [ "$1" == "--no-deps" ]; then
-    NO_DEPS="--no-deps"
-    shift
+declare -a RUN_EXTRA_OPTS
+if [[ NO_DEPS -eq 1 ]]; then
+    RUN_EXTRA_OPTS+=("--no-deps")
+fi
+if [[ SERVICE_PORTS -eq 1 ]] || [[ "${@}" == *"runserver"* ]]; then
+    RUN_EXTRA_OPTS+=("--service-ports")
 fi
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --service-ports --rm -T ${NO_DEPS} app ralph ${@}
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm -T "${RUN_EXTRA_OPTS[@]}" app ralph "${@}"


### PR DESCRIPTION
## Purpose

As we added the `ralph runserver` command, we added port bindings on `docker-compose run` through the `--service-ports` option. This caused issues when starting more than one `ralph` command (eg. for piping) because both processes attempted to bind the same port.

## Proposal

We can bind ports only when running the `ralph runserver` commands to avoid these conflicts.

Note: @jmaupetit I had to remove your logging additions as they broke piping JSON between `ralph` calls:
```
echo "Docker user: ${DOCKER_USER}"
echo "Extra options: ${RUN_EXTRA_OPTS[@]}"
```
