### PR TITLE
♻️(api) rework authentication to use a fastapi dependency

### DIFF
--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,20 +1,16 @@
 """
 Main module for Ralph's LRS API.
 """
-from fastapi import FastAPI, Request
-from starlette.middleware.authentication import AuthenticationMiddleware
+from fastapi import Depends, FastAPI
 
-from .auth import BasicAuthBackend, on_auth_error
+from .auth import AuthenticatedUser, authenticated_user
 
 app = FastAPI()
-app.add_middleware(
-    AuthenticationMiddleware, backend=BasicAuthBackend(), on_error=on_auth_error
-)
 
 
 @app.get("/whoami")
-async def whoami(request: Request):
+async def whoami(user: AuthenticatedUser = Depends(authenticated_user)):
     """
     Return the current user's username along with their scopes.
     """
-    return {"username": request.user.username, "scopes": request.auth.scopes}
+    return {"username": user.username, "scopes": user.scopes}

--- a/src/ralph/api/auth.py
+++ b/src/ralph/api/auth.py
@@ -1,20 +1,15 @@
 """
 Authentication & authorization related tools for the Ralph API.
 """
-import base64
-import binascii
 import json
 from functools import lru_cache
+from typing import List
 
 import bcrypt
-from fastapi import Request
-from fastapi.responses import JSONResponse
-from starlette.authentication import (
-    AuthCredentials,
-    AuthenticationBackend,
-    AuthenticationError,
-    SimpleUser,
-)
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pydantic import BaseModel
+from starlette.authentication import AuthenticationError
 
 from ralph.defaults import AUTH_FILE, LOCALE_ENCODING
 
@@ -22,6 +17,19 @@ from ralph.defaults import AUTH_FILE, LOCALE_ENCODING
 # with invalid credentials to something innocuous with the same method as if
 # it were a legitimate user.
 UNUSED_PASSWORD = bcrypt.hashpw(b"ralph", bcrypt.gensalt())
+
+
+security = HTTPBasic()
+
+
+class AuthenticatedUser(BaseModel):
+    """
+    Base User class used for authentication purposes. Carries the username
+    as well as the scopes the user has access to.
+    """
+
+    username: str
+    scopes: List[str]
 
 
 @lru_cache()
@@ -38,66 +46,47 @@ def get_stored_credentials(auth_file):
     return stored_credentials
 
 
-class BasicAuthBackend(AuthenticationBackend):
+def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
     """
-    Custom authentication backend that verifies user credentials passed through
-    basic auth and sets up the user's allowed scopes.
+    Get the basic auth parameters from the Authorization header, and check them
+    against our own list of hashed credentials.
     """
-
-    # pylint: disable=arguments-renamed
-    async def authenticate(self, request: Request):
-        """
-        Get the basic auth parameters from the Authorization header, and check them
-        against our own list of hashed credentials.
-        """
-        if "Authorization" not in request.headers:
-            raise AuthenticationError("Missing authentication credentials.")
-
-        # Extract basic auth credentials from the relevant header
-        auth = request.headers["Authorization"]
-        try:
-            scheme, credentials = auth.split()
-            if scheme.lower() != "basic":
-                raise AuthenticationError("Missing authentication credentials.")
-            decoded = base64.b64decode(credentials).decode("ascii")
-        except (ValueError, UnicodeDecodeError, binascii.Error) as exc:
-            raise AuthenticationError("Invalid authentication credentials.") from exc
-
-        # Split username/password and check them against our stored user credentials
-        username, password = decoded.split(":")
-        try:
-            user_info = next(
-                filter(
-                    lambda u: u.get("username") == username,
-                    get_stored_credentials(AUTH_FILE),
-                )
+    try:
+        user_info = next(
+            filter(
+                lambda u: u.get("username") == credentials.username,
+                get_stored_credentials(AUTH_FILE),
             )
-            hashed_password = user_info.get("hash", None)
-        except StopIteration:
-            # next() gets the first item in the enumerable; if there is none, it raises
-            # a StopIteration error as it is out of bounds.
-            hashed_password = None
+        )
+        hashed_password = user_info.get("hash", None)
+    except StopIteration:
+        # next() gets the first item in the enumerable; if there is none, it raises
+        # a StopIteration error as it is out of bounds.
+        hashed_password = None
+    except AuthenticationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
 
-        if not hashed_password:
-            # We're doing a bogus password check anyway to avoid
-            # timing attacks on usernames
-            bcrypt.checkpw(password.encode("UTF-8"), UNUSED_PASSWORD)
-            raise AuthenticationError("Invalid authentication credentials.")
-
-        if not bcrypt.checkpw(
-            password.encode("UTF-8"), hashed_password.encode("UTF-8")
-        ):
-            raise AuthenticationError("Invalid authentication credentials.")
-
-        return AuthCredentials(["authenticated", *user_info.get("scopes")]), SimpleUser(
-            username
+    if not hashed_password:
+        # We're doing a bogus password check anyway to avoid
+        # timing attacks on usernames
+        bcrypt.checkpw(credentials.password.encode("UTF-8"), UNUSED_PASSWORD)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Basic"},
         )
 
+    if not bcrypt.checkpw(
+        credentials.password.encode("UTF-8"), hashed_password.encode("UTF-8")
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
 
-# pylint: disable=unused-argument
-def on_auth_error(request: Request, exc: Exception):
-    """
-    Format authentication errors as JSON Responses. Keep the default
-    error code 400 from starlette.
-    """
-    return JSONResponse({"error": str(exc)}, status_code=400)
+    return AuthenticatedUser(
+        username=credentials.username, scopes=user_info.get("scopes")
+    )


### PR DESCRIPTION
## Purpose

As we built authentication into our Ralph API, we looked for auth middleware and found built-in, compatible middleware from Starlette that was explicitly compatible with FastAPI.

We did not know at that time that there are incompatibilities with this specific middleware that prevent us from doing any sort of authorization work with FastAPI, like this middleware does if used directly with Starlette.

See https://github.com/tiangolo/fastapi/issues/104

## Proposal

We moved on to refactor our authentication to use a FastAPI dependency instead of a middleware.

As we start actually using authorization scopes, we can build another layer of FastAPI dependency on top of our `authenticated_user` to require certain scopes to access a given resource.
