### PR TITLE
👷(circleci) migrate to machine image stable release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,7 @@ jobs:
   # ---- Tray jobs (k8s) ----
   tray:
     machine:
+      image: ubuntu-2004:202201-02
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/fun


### PR DESCRIPTION
## Purpose

CircleCI will soon deprecate default base image for the machine executor.

## Proposal

We need to explicitly switch to the latest image stable release.

For more information about this migration please, refer to the migration guide:

https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/

