### PR TITLE
♻️(api) make statements GET endpoint asynchronous

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
+    aiohttp==3.8.1
     bcrypt==3.2.0
     click==8.0.3
     click-option-group==0.5.3
@@ -52,6 +53,7 @@ dev =
     factory-boy==3.2.1
     Faker==12.3.0
     flake8==4.0.1
+    httpx==0.22.0
     hypothesis==6.36.2
     ipdb==0.13.9
     ipython==8.0.1
@@ -65,6 +67,7 @@ dev =
     pyfakefs==4.5.4
     pylint==2.12.2
     pytest==7.0.1
+    pytest-asyncio==0.18.1
     pytest-cov==3.0.0
 ci =
     twine==3.8.0

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from elasticsearch import Elasticsearch
+from elasticsearch import AsyncElasticsearch
 from fastapi import APIRouter, Depends, Query, Request
 
 from ...defaults import ES_HOSTS, ES_MAX_SEARCH_HITS_COUNT, ES_POINT_IN_TIME_KEEP_ALIVE
@@ -16,7 +16,7 @@ router = APIRouter(
 )
 
 
-ES_CLIENT = Elasticsearch(ES_HOSTS)
+ES_CLIENT = AsyncElasticsearch(ES_HOSTS)
 
 
 @router.get("/")
@@ -199,7 +199,7 @@ async def get(
     # results over multiple pages.
     if not pit_id:
         # pylint: disable=unexpected-keyword-arg
-        pit_response = ES_CLIENT.open_point_in_time(
+        pit_response = await ES_CLIENT.open_point_in_time(
             index="statements", keep_alive=ES_POINT_IN_TIME_KEEP_ALIVE
         )
         pit_id = pit_response["id"]
@@ -223,7 +223,7 @@ async def get(
     limit = min(limit, ES_MAX_SEARCH_HITS_COUNT)
 
     # pylint: disable=unexpected-keyword-arg
-    es_response = ES_CLIENT.search(
+    es_response = await ES_CLIENT.search(
         body=es_query,
         size=limit,
     )


### PR DESCRIPTION


## Purpose

As we're building a performance-oriented application in Ralph, we want our API server to only use non-blocking queries. Update the Elasticsearch powered GET endpoint to be async.

## Proposal

- [x] replace `Elasticsearch` with `AsyncElasticsearch` to make requests non-blocking
- [x] update unit tests to use an async client
- [ ] update test config to be able to run async tests

