### PR TITLE
✨(models) add optional fields to base xAPI model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to
 - Tray: enable ralph app deployment command configuration
 - Add a `runserver` command with basic auth and a `whoami` route
 - Create a `get` endpoint for statements implementing the LRS spec
+- Add optional fields to BaseXapiModel
 
 ### Changed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,13 +30,15 @@ install_requires =
     fastapi==0.75.2
     gunicorn==20.1.0
     Jinja2==3.1.1
+    langcodes==3.3.0
     ovh==1.0.0
-    pydantic==1.9.0
+    pydantic[email]==1.9.0
     pyparsing==3.0.8
     python-keystoneclient==4.4.0
     python-swiftclient==3.13.1
     pyyaml==6.0
     requests==2.27.1
+    rfc3987==1.3.8
     sentry_sdk==1.5.10
     uvicorn[standard]==0.17.6
     watchgod==0.8.2

--- a/src/ralph/api/auth.py
+++ b/src/ralph/api/auth.py
@@ -3,7 +3,6 @@ Authentication & authorization related tools for the Ralph API.
 """
 import json
 from functools import lru_cache
-from typing import List
 
 import bcrypt
 from fastapi import Depends, HTTPException, status
@@ -29,7 +28,7 @@ class AuthenticatedUser(BaseModel):
     """
 
     username: str
-    scopes: List[str]
+    scopes: list[str]
 
 
 @lru_cache()

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from ipaddress import IPv4Address
 from pathlib import Path
-from typing import Dict, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import AnyHttpUrl, BaseModel, constr
 
@@ -76,7 +76,7 @@ class BaseContextField(BaseModelWithConfig):
     """
 
     course_id: constr(regex=r"^$|^course-v1:.+\+.+\+.+$")  # noqa:F722
-    course_user_tags: Optional[Dict[str, str]]
+    course_user_tags: Optional[dict[str, str]]
     module: Optional[ContextModuleField]
     org_id: str
     path: Path

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -5,7 +5,7 @@ from ipaddress import IPv4Address
 from pathlib import Path
 from typing import Dict, Literal, Optional, Union
 
-from pydantic import BaseModel, HttpUrl, constr
+from pydantic import AnyHttpUrl, BaseModel, constr
 
 
 class BaseModelWithConfig(BaseModel):
@@ -149,7 +149,7 @@ class BaseEdxModel(BaseModelWithConfig):
     ip: Union[IPv4Address, Literal[""]]
     agent: str
     host: str
-    referer: Union[HttpUrl, Literal[""]]
+    referer: Union[AnyHttpUrl, Literal[""]]
     accept_language: str
     context: BaseContextField
     time: datetime

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,6 +1,5 @@
 """Browser event model definitions"""
 
-from pathlib import Path
 from typing import Literal, Union
 
 from pydantic import AnyUrl, constr
@@ -15,7 +14,7 @@ class BaseBrowserModel(BaseEdxModel):
 
     Attributes:
         event_source (str): Consists of the value `browser`.
-        page (Path): Consists of the URL (with hostname) of the visited page.
+        page (AnyUrl): Consists of the URL (with hostname) of the visited page.
             Retrieved with:
                 `window.location.href` from the JavaScript front-end.
         session (str): Consists of the md5 encrypted Django session key or an empty
@@ -23,5 +22,5 @@ class BaseBrowserModel(BaseEdxModel):
     """
 
     event_source: Literal["browser"]
-    page: Union[AnyUrl, Path]
+    page: AnyUrl
     session: Union[constr(regex=r"^[a-f0-9]{32}$"), Literal[""]]  # noqa: F722

--- a/src/ralph/models/edx/converters/xapi/base.py
+++ b/src/ralph/models/edx/converters/xapi/base.py
@@ -50,7 +50,7 @@ class BaseXapiConverter(BaseConversionSet):
             ConversionItem(
                 "actor__account__name",
                 "context__user_id",
-                lambda user_id: user_id if user_id else "anonymous",
+                lambda user_id: str(user_id) if user_id else "anonymous",
             ),
             ConversionItem(
                 "object__definition__extensions__" + EXTENSION_SCHOOL_ID,

--- a/src/ralph/models/edx/converters/xapi/navigational.py
+++ b/src/ralph/models/edx/converters/xapi/navigational.py
@@ -12,7 +12,8 @@ class UIPageCloseToPageTerminated(BaseXapiConverter):
 
     Example Statement: John terminated https://www.fun-mooc.fr/ page.
 
-    WARNING: The converter does not use the `self.platform_url` in the `object__id`.
+    WARNING: The converter does not use the `self.platform_url` in the `object__id`
+    because the `platform_url` is present in the edX's event `page` field.
     """
 
     __src__ = UIPageClose

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -71,9 +71,8 @@ class UISeqNext(BaseBrowserModel):
     name: Literal["seq_next"]
 
     @validator("event")
-    def validate_next_jump_event_field(
-        cls, value
-    ):  # pylint: disable=no-self-argument, no-self-use
+    @classmethod
+    def validate_next_jump_event_field(cls, value):
         """Checks that event.new is equal to event.old + 1."""
 
         if value.new != value.old + 1:
@@ -103,9 +102,8 @@ class UISeqPrev(BaseBrowserModel):
     name: Literal["seq_prev"]
 
     @validator("event")
-    def validate_prev_jump_event_field(
-        cls, value
-    ):  # pylint: disable=no-self-argument, no-self-use
+    @classmethod
+    def validate_prev_jump_event_field(cls, value):
         """Checks that event.new is equal to event.old - 1."""
 
         if value.new != value.old - 1:

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -1,7 +1,7 @@
 """Problem interaction events model event fields definitions"""
 
 from datetime import datetime
-from typing import Dict, List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import constr
 
@@ -55,7 +55,7 @@ class State(BaseModelWithConfig):
         student_answers (dict): Consists of the answer(s) given by the user.
     """
 
-    correct_map: Dict[
+    correct_map: dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
         CorrectMap,
     ]
@@ -80,7 +80,7 @@ class SubmissionAnswerField(BaseModelWithConfig):
             this user.
     """
 
-    answer: Union[str, List[str]]
+    answer: Union[str, list[str]]
     correct: bool
     input_type: str
     question: str
@@ -129,10 +129,10 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
             `student_answer` response. Consists either of `single` or `compound` value.
     """
 
-    choice_all: Optional[List[str]]
+    choice_all: Optional[list[str]]
     correctness: bool
     hint_label: str
-    hints: List[dict]
+    hints: list[dict]
     module_id: str
     problem_part_id: str
     question_type: Union[
@@ -142,7 +142,7 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
         Literal["numericalresponse"],
         Literal["optionresponse"],
     ]
-    student_answer: List[str]
+    student_answer: list[str]
     trigger_type: Union[Literal["single"], Literal["compound"]]
 
 
@@ -163,12 +163,12 @@ class ProblemCheckEventField(AbstractBaseEventField):
         success (str): Consists of either the `correct` or `incorrect` value.
     """
 
-    answers: Dict[
+    answers: dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
-        Union[List[str], str],
+        Union[list[str], str],
     ]
     attempts: int
-    correct_map: Dict[
+    correct_map: dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
         CorrectMap,
     ]
@@ -179,7 +179,7 @@ class ProblemCheckEventField(AbstractBaseEventField):
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
     )
     state: State
-    submission: Dict[
+    submission: dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
         SubmissionAnswerField,
     ]
@@ -197,10 +197,9 @@ class ProblemCheckFailEventField(AbstractBaseEventField):
         state (dict): Consists of the current problem state.
     """
 
-    # pylint: disable=unsubscriptable-object
-    answers: Dict[
+    answers: dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
-        Union[List[str], str],
+        Union[list[str], str],
     ]
     failure: Union[Literal["closed"], Literal["unreset"]]
     problem_id: constr(
@@ -263,7 +262,7 @@ class UIProblemResetEventField(AbstractBaseEventField):
             strings if multiple choices are allowed.
     """
 
-    answers: Union[str, List[str]]
+    answers: Union[str, list[str]]
 
 
 class UIProblemShowEventField(AbstractBaseEventField):
@@ -322,7 +321,7 @@ class SaveProblemFailEventField(AbstractBaseEventField):
         state (json): see StateField.
     """
 
-    answers: Dict[str, Union[int, str, list, dict]]
+    answers: dict[str, Union[int, str, list, dict]]
     failure: Union[Literal["closed"], Literal["done"]]
     problem_id: constr(
         regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
@@ -341,7 +340,7 @@ class SaveProblemSuccessEventField(AbstractBaseEventField):
         state (json): see StateField.
     """
 
-    answers: Dict[str, Union[int, str, list, dict]]
+    answers: dict[str, Union[int, str, list, dict]]
     problem_id: constr(
         regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -1,6 +1,6 @@
 """Problem interaction events model definitions"""
 
-from typing import List, Literal, Union
+from typing import Literal, Union
 
 from pydantic import Json
 
@@ -132,7 +132,7 @@ class UIProblemGraded(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="problem_graded")
 
-    event: List[Union[str, Literal[None], None]]
+    event: list[Union[str, Literal[None], None]]
     event_type: Literal["problem_graded"]
     name: Literal["problem_graded"]
 

--- a/src/ralph/models/xapi/base.py
+++ b/src/ralph/models/xapi/base.py
@@ -1,25 +1,72 @@
 """Base xAPI model definition"""
 
 from datetime import datetime
+from typing import Optional
 from uuid import UUID
+
+from pydantic import constr, root_validator
 
 from .config import BaseModelWithConfig
 from .fields.actors import ActorField
+from .fields.attachments import AttachmentField
+from .fields.contexts import ContextField
+from .fields.objects import ObjectField
+from .fields.results import ResultField
+from .fields.verbs import VerbField
 
 
 class BaseXapiModel(BaseModelWithConfig):
     """Base model for xAPI statements.
 
-    WARNING: It doesn't include the required `verb` and `object` fields nor the optional
-    `context`, `result`, `stored`, `authority`, `version` and `attachments` fields.
-
     Attributes:
         id (UUID): Consists of a generated UUID string from the source event string.
-        actor (ActorField): See ActorField.
-        timestamp (datetime): Consists of the UTC time in ISO format when the event was
-            emitted.
+        actor (ActorField): Consists of a definition of who performed the action.
+        verb (VerbField): Consists of the action between an Actor and an Activity.
+        object (ObjectField): Consists of a definition of the thing that was acted on.
+        result (ResultField): Consists of the outcome related to the Statement.
+        context (ContextField): Consists of contextual information for the Statement.
+        timestamp (datetime): Consists of the timestamp of when the event occurred.
+        stored (datetime): Consists of the timestamp of when the event was recorded.
+        authority (ActorField): Consists of the Actor asserting this Statement is true.
+        version (str): Consists of the associated xAPI version of the Statement.
+        attachments (list): Consists of a list of Attachments.
     """
 
-    id: UUID
+    id: Optional[UUID]
     actor: ActorField
-    timestamp: datetime
+    verb: VerbField
+    object: ObjectField
+    result: Optional[ResultField]
+    context: Optional[ContextField]
+    timestamp: Optional[datetime]
+    stored: Optional[datetime]
+    authority: Optional[ActorField]
+    version: constr(regex=r"^1\.0\.[0-9]+$") = "1.0.0"  # noqa:F722
+    attachments: Optional[list[AttachmentField]]
+
+    @root_validator(pre=True)
+    @classmethod
+    def check_abscence_of_empty_and_invalid_values(cls, values):
+        """Checks the model for empty and invalid values.
+
+        Checks that the `context` field contains `platform` and `revision` fields
+        only if the `object.objectType` property is equal to `Activity`.
+        """
+
+        for field, value in list(values.items()):
+            if value in [None, "", {}]:
+                raise ValueError(f"{field}: invalid empty value")
+            if isinstance(value, dict) and field != "extensions":
+                cls.check_abscence_of_empty_and_invalid_values(value)
+
+        context = dict(values.get("context", {}))
+        if context:
+            platform = context.get("platform", {})
+            revision = context.get("revision", {})
+            object_type = dict(values["object"]).get("objectType", "Activity")
+            if (platform or revision) and object_type != "Activity":
+                raise ValueError(
+                    "revision and platform properties can only be used if the "
+                    "Statement's Object is an Activity"
+                )
+        return values

--- a/src/ralph/models/xapi/config.py
+++ b/src/ralph/models/xapi/config.py
@@ -1,11 +1,11 @@
 """Base xAPI model configuration"""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 
 class BaseModelWithConfig(BaseModel):
     """Base model defining configuration shared among all models."""
 
     class Config:  # pylint: disable=missing-class-docstring
-        extra = "forbid"
+        extra = Extra.forbid
         min_anystr_length = 1

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -3,7 +3,6 @@
 from typing import Literal
 
 # Languages
-LANG_EN_DISPLAY = Literal["en"]  # pylint:disable=invalid-name
 LANG_EN_US_DISPLAY = Literal["en-US"]  # pylint:disable=invalid-name
 
 # xAPI activities

--- a/src/ralph/models/xapi/fields/actors.py
+++ b/src/ralph/models/xapi/fields/actors.py
@@ -1,33 +1,125 @@
 """Common xAPI actor field definitions"""
 
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
-from pydantic import AnyUrl
+from pydantic import AnyUrl, StrictStr, constr
 
 from ..config import BaseModelWithConfig
+from .common import IRI, MailtoEmail
 
 
-class ActorAccountField(BaseModelWithConfig):
+class AccountActorAccountField(BaseModelWithConfig):
     """Represents the `actor.account` xAPI field.
 
     Attributes:
-        name (str): Consists of the unique id or name used to log in to this account.
-        homePage (URL): Consists of the canonical home page for the system the account
-            is on.
+        homePage (IRI): Consists of the home page of the account's service provider.
+        name (str): Consists of the unique id or name of the Actor's account.
     """
 
-    name: str
-    homePage: AnyUrl  # URL < URI < IRI < String
+    homePage: IRI
+    name: StrictStr
 
 
-class ActorField(BaseModelWithConfig):
-    """Represents the `actor` xAPI Field.
-
-    WARNING: It doesn't include the optional `objectType` and `name` fields.
+class BaseActorField(BaseModelWithConfig):
+    """Represents the base `actor` xAPI Field defining who performed the action.
 
     Attributes:
-        account (ActorAccountField): See ActorAccountField.
+        objectType (str): Consists of the value `Agent`.
+        name (str): Consists of the full name of the Agent.
     """
 
     objectType: Optional[Literal["Agent"]]
-    account: ActorAccountField
+    name: Optional[StrictStr]
+
+
+class MboxActorField(BaseActorField):
+    """Represents the `actor` xAPI Field with a mailto Inverse Functional Identifier.
+
+    Attributes:
+        mbox (MailtoEmail): Consists of the Agent's email address.
+    """
+
+    mbox: MailtoEmail
+
+
+class MboxSha1SumActorField(BaseActorField):
+    """Represents the `actor` xAPI Field with a hash Inverse Functional Identifier.
+
+    Attributes:
+        mbox_sha1sum (str): Consists of the SHA1 hash of the Agent's email address.
+    """
+
+    mbox_sha1sum: constr(regex=r"^[0-9a-f]{40}$")  # noqa:F722
+
+
+class OpenIdActorField(BaseActorField):
+    """Represents the `actor` xAPI Field with an OpenID Inverse Functional Identifier.
+
+    Attributes:
+        openid (URI): Consists of an openID that uniquely identifies the Agent.
+    """
+
+    openid: AnyUrl
+
+
+class AccountActorField(BaseActorField):
+    """Represents the `actor` xAPI Field with an account Inverse Functional Identifier.
+
+    Attributes:
+        account (dict): See AccountActorAccountField.
+    """
+
+    account: AccountActorAccountField
+
+
+AgentActorField = Union[
+    MboxActorField, MboxSha1SumActorField, OpenIdActorField, AccountActorField
+]
+
+
+class AnonymousGroupActorField(BaseActorField):
+    """Represents the `actor` xAPI Field of type Anonymous Group.
+
+    Attributes:
+        objectType (str): Consists of the value `Group`.
+        member (list): Consist of a list of the members of this Group.
+    """
+
+    objectType: Literal["Group"]
+    member: list[AgentActorField]
+
+
+class BaseIdentifiedGroupActorField(AnonymousGroupActorField):
+    """Represents the base `actor` xAPI Field of Identified Group type.
+
+    Attributes:
+        member (list): Consist of a list of the members of this Group.
+    """
+
+    member: Optional[list[AgentActorField]]
+
+
+class MboxGroupActorField(BaseIdentifiedGroupActorField, MboxActorField):
+    """Represents the `actor` xAPI Field of group type with a mailto IFI."""
+
+
+class MboxSha1SumGroupActorField(BaseIdentifiedGroupActorField, MboxSha1SumActorField):
+    """Represents the `actor` xAPI Field of group type with a hash IFI."""
+
+
+class OpenIdGroupActorField(BaseIdentifiedGroupActorField, OpenIdActorField):
+    """Represents the `actor` xAPI Field of group type with an openID IFI."""
+
+
+class AccountGroupActorField(BaseIdentifiedGroupActorField, AccountActorField):
+    """Represents the `actor` xAPI Field of group type with an account IFI."""
+
+
+GroupActorField = Union[
+    AnonymousGroupActorField,
+    MboxGroupActorField,
+    MboxSha1SumGroupActorField,
+    OpenIdGroupActorField,
+    AccountGroupActorField,
+]
+ActorField = Union[AgentActorField, GroupActorField]

--- a/src/ralph/models/xapi/fields/attachments.py
+++ b/src/ralph/models/xapi/fields/attachments.py
@@ -1,0 +1,30 @@
+"""Common xAPI attachments field definitions"""
+
+from typing import Optional
+
+from pydantic import AnyUrl
+
+from ..config import BaseModelWithConfig
+from .common import IRI, LanguageMap
+
+
+class AttachmentField(BaseModelWithConfig):
+    """Represents the `attachment` xAPI field.
+
+    Attributes:
+        usageType (IRI): Identifies the usage of this Attachment.
+        display (LanguageMap): Consists of the Attachment's title.
+        description (LanguageMap): Consists of the Attachment's description.
+        contentType (str): Consists of the Attachment's content type.
+        length (int): Consists of the length of the Attachment's data in octets.
+        sha2 (str): Consists of the SHA-2 hash of the Attachment data.
+        fileUrl (URL): Consists of the URL from which the Attachment can be retrieved.
+    """
+
+    usageType: IRI
+    display: LanguageMap
+    description: Optional[LanguageMap]
+    contentType: str
+    length: int
+    sha2: str
+    fileUrl: Optional[AnyUrl]

--- a/src/ralph/models/xapi/fields/common.py
+++ b/src/ralph/models/xapi/fields/common.py
@@ -1,0 +1,55 @@
+"""Common xAPI field definitions"""
+
+from langcodes import tag_is_valid
+from pydantic import StrictStr, validate_email
+from rfc3987 import parse
+
+
+class IRI(str):
+    """Represents a pydantic custom data type validating RFC 3987 IRIs."""
+
+    @classmethod
+    def __get_validators__(cls):
+        def validate(iri: str):
+            """Checks whether the provided IRI is a valid RFC 3987 IRI."""
+
+            parse(iri, rule="IRI")
+            return cls(iri)
+
+        yield validate
+
+
+class LanguageTag(str):
+    """Represents a pydantic custom data type validating RFC 5646 Language tags."""
+
+    @classmethod
+    def __get_validators__(cls):
+        def validate(tag: str):
+            """Checks whether the provided tag is a valid RFC 5646 Language tag."""
+
+            if not tag_is_valid(tag):
+                raise TypeError("Invalid RFC 5646 Language tag")
+            return cls(tag)
+
+        yield validate
+
+
+# Python 3.10
+# LanguageMap: TypeAlias = dict[LanguageTag, str]
+LanguageMap = dict[LanguageTag, StrictStr]
+
+
+class MailtoEmail(str):
+    """Represents a pydantic custom data type validating `mailto:email` format."""
+
+    @classmethod
+    def __get_validators__(cls):
+        def validate(mailto: str):
+            """Checks whether the provided value follows the `mailto:email` format."""
+
+            if not mailto.startswith("mailto:"):
+                raise TypeError("Invalid `mailto:email` value")
+            valid = validate_email(mailto[7:])
+            return cls(f"mailto:{valid[1]}")
+
+        yield validate

--- a/src/ralph/models/xapi/fields/contexts.py
+++ b/src/ralph/models/xapi/fields/contexts.py
@@ -1,0 +1,54 @@
+"""Common xAPI context field definitions"""
+
+from typing import Optional, Union
+from uuid import UUID
+
+from pydantic import StrictStr
+
+from ..config import BaseModelWithConfig
+from .actors import ActorField, GroupActorField
+from .common import IRI, LanguageTag
+from .unnested_objects import ActivityObjectField, StatementRefObjectField
+
+
+class ContextActivitiesContextField(BaseModelWithConfig):
+    """Represents the `context.contextActivities` xAPI field.
+
+    Attributes:
+        parent (list): An Activity with a direct relation to the statement's Activity.
+        grouping (list): An Activity with an indirect relation to the statement's
+            Activity.
+        category (list): An Activity used to categorize the Statement.
+        other (list): A contextActivity that doesn't fit one of the other properties.
+    """
+
+    parent: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
+    grouping: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
+    category: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
+    other: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
+
+
+class ContextField(BaseModelWithConfig):
+    """Represents the `context` xAPI field.
+
+    Attributes:
+        registration (UUID): The registration that the Statement is associated with.
+        instructor (ActorField): The instructor that the Statement relates to.
+        team (GroupActorField): The team that this Statement relates to.
+        contextActivities (dict): See ContextActivitiesContextField.
+        revision (str): The revision of the activity associated with this Statement.
+        platform (str): The platform where the learning activity took place.
+        language (LanguageTag): The language in which the experience occurred.
+        statement (StatementRef): Another Statement giving context for this Statement.
+        extensions (dict): Consists of an dictionary of other properties as needed.
+    """
+
+    registration: Optional[UUID]
+    instructor: Optional[ActorField]
+    team: Optional[GroupActorField]
+    contextActivities: Optional[ContextActivitiesContextField]
+    revision: Optional[StrictStr]
+    platform: Optional[StrictStr]
+    language: Optional[LanguageTag]
+    statement: Optional[StatementRefObjectField]
+    extensions: Optional[dict[IRI, Union[str, int, bool, list, dict, None]]]

--- a/src/ralph/models/xapi/fields/objects.py
+++ b/src/ralph/models/xapi/fields/objects.py
@@ -1,23 +1,43 @@
 """Common xAPI object field definitions"""
 
-from typing import Optional
+# Nota bene: we split object definitions into `objects.py` and `unnested_objects.py`
+# because of the circular dependency : objects -> context -> objects.
 
-from pydantic import AnyUrl, Field
+from datetime import datetime
+from typing import Literal, Optional, Union
+
+from pydantic import Field
 
 from ..config import BaseModelWithConfig
 from ..constants import EXTENSION_COURSE_ID, EXTENSION_MODULE_ID, EXTENSION_SCHOOL_ID
+from .actors import ActorField
+from .attachments import AttachmentField
+from .contexts import ContextField
+from .results import ResultField
+from .unnested_objects import UnnestedObjectField
+from .verbs import VerbField
 
 
-class ObjectField(BaseModelWithConfig):
-    """Represents the `object` xAPI field.
-
-    WARNING: It doesn't include the optional `objectType` and `definition` fields.
+class SubStatementObjectField(BaseModelWithConfig):
+    """Represents the `object` xAPI field of type SubStatement.
 
     Attributes:
-        id (URL): Consists of an identifier for a single unique Activity.
+        actor (ActorField): See ActorField.
+        verb (VerbField): See VerbField.
+        object (UnnestedObjectField): See UnnestedObjectField.
     """
 
-    id: AnyUrl
+    actor: ActorField
+    verb: VerbField
+    object: UnnestedObjectField
+    objectType: Literal["SubStatement"]
+    result: Optional[ResultField]
+    context: Optional[ContextField]
+    timestamp: Optional[datetime]
+    attachments: Optional[list[AttachmentField]]
+
+
+ObjectField = Union[UnnestedObjectField, SubStatementObjectField]
 
 
 class ObjectDefinitionExtensionsField(BaseModelWithConfig):

--- a/src/ralph/models/xapi/fields/results.py
+++ b/src/ralph/models/xapi/fields/results.py
@@ -1,0 +1,66 @@
+"""Common xAPI result field definitions"""
+
+from datetime import timedelta
+from decimal import Decimal
+from typing import Optional, Union
+
+from pydantic import StrictBool, StrictStr, conint, root_validator
+
+from ..config import BaseModelWithConfig
+from .common import IRI
+
+
+class ScoreResultField(BaseModelWithConfig):
+    """Represents the `results.score` xAPI field.
+
+    Attributes:
+        scaled (int): Consists of the normalized score related to the experience.
+        raw (Decimal): Consists of the non-normalized score achieved by the Actor.
+        min (Decimal): Consists of lowest possible score.
+        max (Decimal): Consists of highest possible score.
+    """
+
+    scaled: Optional[conint(ge=-1, le=1)]
+    raw: Optional[Decimal]
+    min: Optional[Decimal]
+    max: Optional[Decimal]
+
+    @root_validator
+    @classmethod
+    def check_raw_min_max_relation(cls, values):
+        """Checks the relationship `min < raw < max`."""
+
+        raw_value = values.get("raw", None)
+        min_value = values.get("min", None)
+        max_value = values.get("max", None)
+
+        if min_value:
+            if max_value and min_value > max_value:
+                raise ValueError("min cannot be greater than max")
+            if raw_value and min_value > raw_value:
+                raise ValueError("min cannot be greater than raw")
+        if max_value:
+            if raw_value and raw_value > max_value:
+                raise ValueError("raw cannot be greater than max")
+
+        return values
+
+
+class ResultField(BaseModelWithConfig):
+    """Represents the `result` xAPI field.
+
+    Attributes:
+        score (ScoreResultField): See ScoreResultField.
+        success (bool): Indicates whether the attempt on the Activity was successful.
+        completion (bool): Indicates whether the Activity was completed.
+        response (str): Consists of the response for the given Activity.
+        duration (str): Consists of the duration over which the Statement occurred.
+        extensions (dict): Consists of a dictionary of other properties as needed.
+    """
+
+    score: Optional[ScoreResultField]
+    success: Optional[StrictBool]
+    completion: Optional[StrictBool]
+    response: Optional[StrictStr]
+    duration: Optional[timedelta]
+    extensions: Optional[dict[IRI, Union[str, int, bool, list, dict, None]]]

--- a/src/ralph/models/xapi/fields/unnested_objects.py
+++ b/src/ralph/models/xapi/fields/unnested_objects.py
@@ -1,0 +1,109 @@
+"""Common xAPI object field definitions"""
+
+from typing import Literal, Optional, Union
+from uuid import UUID
+
+from pydantic import AnyUrl, StrictStr, constr, validator
+
+from ..config import BaseModelWithConfig
+from .common import IRI, LanguageMap
+
+
+class ObjectDefinitionField(BaseModelWithConfig):
+    """Represents the `object.definition` xAPI field.
+
+    Attributes:
+        name (LanguageMap): Consists of the human readable/visual name of the Activity.
+        description (LanguageMap): Consists of a description of the Activity.
+        type (IRI): Consists of the type of the Activity.
+        moreInfo (URL): Consists of an URL to a document about the Activity.
+        extensions (dict): Consists of a dictionary of other properties as needed.
+    """
+
+    name: Optional[LanguageMap]
+    description: Optional[LanguageMap]
+    type: Optional[IRI]
+    moreInfo: Optional[AnyUrl]
+    extensions: Optional[dict[IRI, Union[str, int, bool, list, dict, None]]]
+
+
+class InteractionComponent(BaseModelWithConfig):
+    """Represents an xAPI Interaction component.
+
+    Attributes:
+        id (str): Consists of an identifier of the interaction component.
+        description (LanguageMap): Consists of the description of the interaction.
+    """
+
+    id: constr(regex=r"^[^\s]+$")  # noqa:F722
+    description: Optional[LanguageMap]
+
+
+class InteractionObjectDefinitionField(ObjectDefinitionField):
+    """Represents the `object.definition` xAPI field with interaction properties.
+
+    Attributes:
+        interactionType (str): Consists of the type of the interaction.
+        correctResponsesPattern (list): Consists of a pattern for the correct response.
+        choices (list): Consists of a list of selectable choices.
+        scale (list): Consists of a list of the options on the `likert` scale.
+        source (list): Consists of a list of sources to be matched.
+        target (list): Consists of a list of targets to be matched.
+        steps (list): Consists of a list of the elements making up the interaction.
+    """
+
+    interactionType: Literal[
+        "true-false",
+        "choice",
+        "fill-in",
+        "long-fill-in",
+        "matching",
+        "performance",
+        "sequencing",
+        "likert",
+        "numeric",
+        "other",
+    ]
+    correctResponsesPattern: Optional[list[StrictStr]]
+    choices: Optional[list[InteractionComponent]]
+    scale: Optional[list[InteractionComponent]]
+    source: Optional[list[InteractionComponent]]
+    target: Optional[list[InteractionComponent]]
+    steps: Optional[list[InteractionComponent]]
+
+    @validator("choices", "scale", "source", "target", "steps")
+    @classmethod
+    def check_unique_ids(cls, value):
+        """Checks the uniqueness of interaction components IDs."""
+
+        if len(value) != len({x.id for x in value}):
+            raise ValueError("Duplicate InteractionComponents are not valid")
+
+
+class ActivityObjectField(BaseModelWithConfig):
+    """Represents the `object` xAPI field of type Activity.
+
+    Attributes:
+        objectType (str): Consists of the value `Activity`.
+        id (IRI): Consists of an identifier for a single unique Activity.
+        definition (dict): See ObjectDefinitionField.
+    """
+
+    id: IRI
+    objectType: Optional[Literal["Activity"]]
+    definition: Optional[Union[ObjectDefinitionField, InteractionObjectDefinitionField]]
+
+
+class StatementRefObjectField(BaseModelWithConfig):
+    """Represents the `object` xAPI field of type StatementRef.
+
+    Attributes:
+        objectType (str): Consists of the value `StatementRef`.
+        id (UUID): Consists of the UUID of the referenced statement.
+    """
+
+    id: UUID
+    objectType: Literal["StatementRef"]
+
+
+UnnestedObjectField = Union[ActivityObjectField, StatementRefObjectField]

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -2,7 +2,7 @@
 
 from ..config import BaseModelWithConfig
 from ..constants import (
-    LANG_EN_DISPLAY,
+    LANG_EN_US_DISPLAY,
     VERB_TERMINATED_DISPLAY,
     VERB_TERMINATED_ID,
     VERB_VIEWED_DISPLAY,
@@ -15,12 +15,12 @@ class ViewedVerbField(BaseModelWithConfig):
 
     Attributes:
        id (str): Consists of the value `http://id.tincanapi.com/verb/viewed`.
-       display (dict): Consists of the dictionary `{"en": "viewed"}`.
+       display (dict): Consists of the dictionary `{"en-US": "viewed"}`.
     """
 
     id: VERB_VIEWED_ID = VERB_VIEWED_ID.__args__[0]
-    display: dict[LANG_EN_DISPLAY, VERB_VIEWED_DISPLAY] = {
-        LANG_EN_DISPLAY.__args__[0]: VERB_VIEWED_DISPLAY.__args__[0]
+    display: dict[LANG_EN_US_DISPLAY, VERB_VIEWED_DISPLAY] = {
+        LANG_EN_US_DISPLAY.__args__[0]: VERB_VIEWED_DISPLAY.__args__[0]
     }
 
 
@@ -29,10 +29,10 @@ class TerminatedVerbField(BaseModelWithConfig):
 
     Attributes:
        id (str): Consists of the value `http://adlnet.gov/expapi/verbs/terminated`.
-       display (dict): Consists of the dictionary `{"en": "terminated"}`.
+       display (dict): Consists of the dictionary `{"en-US": "terminated"}`.
     """
 
     id: VERB_TERMINATED_ID = VERB_TERMINATED_ID.__args__[0]
-    display: dict[LANG_EN_DISPLAY, VERB_TERMINATED_DISPLAY] = {
-        LANG_EN_DISPLAY.__args__[0]: VERB_TERMINATED_DISPLAY.__args__[0]
+    display: dict[LANG_EN_US_DISPLAY, VERB_TERMINATED_DISPLAY] = {
+        LANG_EN_US_DISPLAY.__args__[0]: VERB_TERMINATED_DISPLAY.__args__[0]
     }

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -1,5 +1,7 @@
 """Common xAPI verb field definitions"""
 
+from typing import Optional
+
 from ..config import BaseModelWithConfig
 from ..constants import (
     LANG_EN_US_DISPLAY,
@@ -8,10 +10,23 @@ from ..constants import (
     VERB_VIEWED_DISPLAY,
     VERB_VIEWED_ID,
 )
+from .common import IRI, LanguageMap
 
 
-class ViewedVerbField(BaseModelWithConfig):
-    """Represents the `verb` xAPI Field for page viewed xAPI statement.
+class VerbField(BaseModelWithConfig):
+    """Represents the `verb` xAPI field.
+
+    Attributes:
+        id (IRI): Consists of an identifier for the verb.
+        display (LanguageMap): Consists of a human readable representation of the verb.
+    """
+
+    id: IRI
+    display: Optional[LanguageMap]
+
+
+class ViewedVerbField(VerbField):
+    """Represents the `verb` xAPI Field for the action `viewed`.
 
     Attributes:
        id (str): Consists of the value `http://id.tincanapi.com/verb/viewed`.
@@ -24,8 +39,8 @@ class ViewedVerbField(BaseModelWithConfig):
     }
 
 
-class TerminatedVerbField(BaseModelWithConfig):
-    """Represents the `verb` xAPI Field for page terminated xAPI statement.
+class TerminatedVerbField(VerbField):
+    """Represents the `verb` xAPI Field for the action `terminated`.
 
     Attributes:
        id (str): Consists of the value `http://adlnet.gov/expapi/verbs/terminated`.

--- a/src/ralph/models/xapi/navigation/fields/objects.py
+++ b/src/ralph/models/xapi/navigation/fields/objects.py
@@ -2,16 +2,13 @@
 
 from typing import Optional
 
-from ...base import BaseModelWithConfig
 from ...constants import ACTIVITY_PAGE_DISPLAY, ACTIVITY_PAGE_ID, LANG_EN_US_DISPLAY
-from ...fields.objects import ObjectDefinitionExtensionsField, ObjectField
+from ...fields.objects import ObjectDefinitionExtensionsField
+from ...fields.unnested_objects import ActivityObjectField, ObjectDefinitionField
 
 
-class PageObjectDefinitionField(BaseModelWithConfig):
+class PageObjectDefinitionField(ObjectDefinitionField):
     """Represents the `object.definition` xAPI field for page viewed xAPI statement.
-
-    WARNING: It doesn't include the recommended `description` field nor the optional
-        `moreInfo`, `Interaction properties` and `extensions` fields.
 
     Attributes:
        type (str): Consists of the value `http://activitystrea.ms/schema/1.0/page`.
@@ -26,13 +23,11 @@ class PageObjectDefinitionField(BaseModelWithConfig):
     extensions: Optional[ObjectDefinitionExtensionsField]
 
 
-class PageObjectField(ObjectField):
+class PageObjectField(ActivityObjectField):
     """Represents the `object` xAPI field for page viewed xAPI statement.
 
-    WARNING: It doesn't include the optional `objectType` field.
-
     Attributes:
-        definition (PageObjectDefinitionField): See PageObjectDefinitionField.
+        definition (dict): See PageObjectDefinitionField.
     """
 
     definition: PageObjectDefinitionField = PageObjectDefinitionField()

--- a/src/ralph/models/xapi/navigation/fields/objects.py
+++ b/src/ralph/models/xapi/navigation/fields/objects.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from ...base import BaseModelWithConfig
-from ...constants import ACTIVITY_PAGE_DISPLAY, ACTIVITY_PAGE_ID, LANG_EN_DISPLAY
+from ...constants import ACTIVITY_PAGE_DISPLAY, ACTIVITY_PAGE_ID, LANG_EN_US_DISPLAY
 from ...fields.objects import ObjectDefinitionExtensionsField, ObjectField
 
 
@@ -15,12 +15,12 @@ class PageObjectDefinitionField(BaseModelWithConfig):
 
     Attributes:
        type (str): Consists of the value `http://activitystrea.ms/schema/1.0/page`.
-       name (dict): Consists of the dictionary `{"en": "page"}`.
+       name (dict): Consists of the dictionary `{"en-US": "page"}`.
        extensions (dict): See ObjectDefinitionExtensionsField.
     """
 
-    name: dict[LANG_EN_DISPLAY, ACTIVITY_PAGE_DISPLAY] = {
-        LANG_EN_DISPLAY.__args__[0]: ACTIVITY_PAGE_DISPLAY.__args__[0]
+    name: dict[LANG_EN_US_DISPLAY, ACTIVITY_PAGE_DISPLAY] = {
+        LANG_EN_US_DISPLAY.__args__[0]: ACTIVITY_PAGE_DISPLAY.__args__[0]
     }
     type: ACTIVITY_PAGE_ID = ACTIVITY_PAGE_ID.__args__[0]
     extensions: Optional[ObjectDefinitionExtensionsField]

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -5,6 +5,7 @@ from typing import Literal, Optional
 from pydantic import UUID4, Field
 
 from ...base import BaseModelWithConfig
+from ...fields.contexts import ContextActivitiesContextField, ContextField
 from ..constants import (
     VIDEO_CONTEXT_CATEGORY,
     VIDEO_EXTENSION_CC_SUBTITLE_ENABLED,
@@ -24,7 +25,7 @@ from ..constants import (
 )
 
 
-class VideoContextActivitiesField(BaseModelWithConfig):
+class VideoContextActivitiesField(ContextActivitiesContextField):
     """Represents the contextActivities field for video xAPI statements.
 
     Attributes:
@@ -37,7 +38,7 @@ class VideoContextActivitiesField(BaseModelWithConfig):
     ]
 
 
-class BaseVideoContextField(BaseModelWithConfig):
+class BaseVideoContextField(ContextField):
     """Base model for xAPI video context field.
 
     Attributes:

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -33,7 +33,7 @@ class VideoContextActivitiesField(BaseModelWithConfig):
     """
 
     category: List[dict[Literal["id"], VIDEO_CONTEXT_CATEGORY]] = [
-        {Literal["id"]: VIDEO_CONTEXT_CATEGORY.__args__[0]}
+        {"id": VIDEO_CONTEXT_CATEGORY.__args__[0]}
     ]
 
 

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -1,6 +1,6 @@
 """Video xAPI events context fields definitions"""
 
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import UUID4, Field
 
@@ -32,7 +32,7 @@ class VideoContextActivitiesField(BaseModelWithConfig):
             {"id": "https://w3id.org/xapi/video"}.
     """
 
-    category: List[dict[Literal["id"], VIDEO_CONTEXT_CATEGORY]] = [
+    category: list[dict[Literal["id"], VIDEO_CONTEXT_CATEGORY]] = [
         {"id": VIDEO_CONTEXT_CATEGORY.__args__[0]}
     ]
 

--- a/src/ralph/models/xapi/video/fields/objects.py
+++ b/src/ralph/models/xapi/video/fields/objects.py
@@ -1,39 +1,36 @@
 """Video xAPI events object fields definitions"""
 
-from typing import Literal, Optional
-
-from ralph.models.xapi.config import BaseModelWithConfig
+from typing import Optional
 
 from ...constants import LANG_EN_US_DISPLAY
-from ...fields.objects import ObjectDefinitionExtensionsField, ObjectField
+from ...fields.objects import ObjectDefinitionExtensionsField
+from ...fields.unnested_objects import ActivityObjectField, ObjectDefinitionField
 from ..constants import VIDEO_OBJECT_DEFINITION_TYPE
 
 
-class VideoObjectDefinitionField(BaseModelWithConfig):
+class VideoObjectDefinitionField(ObjectDefinitionField):
     """Represents the `object.definition` xAPI field for page viewed xAPI statement.
 
-    WARNING: It doesn't include the recommended `description` field nor the optional
-    `moreInfo`, `Interaction properties` and `extensions` fields.
-
     Attributes:
-       name (dict): Consists of the dictionary `{"en-US": <name of the video>}`.
-       type (str): Consists of the value
-        `https://w3id.org/xapi/video/activity-type/video`.
+        type (str): Consists of the value
+            `https://w3id.org/xapi/video/activity-type/video`.
+        extensions (dict): See ObjectDefinitionExtensionsField.
     """
 
-    name: Optional[dict[LANG_EN_US_DISPLAY, str]]
     type: VIDEO_OBJECT_DEFINITION_TYPE = VIDEO_OBJECT_DEFINITION_TYPE.__args__[0]
     extensions: Optional[ObjectDefinitionExtensionsField]
 
 
-class VideoObjectField(ObjectField):
+class VideoObjectField(ActivityObjectField):
     """Represents the `object` xAPI field for video statements.
 
+    WARNING: Contains an optional name property, this is not a violation of
+    conformity but goes against xAPI specification recommendations.
+
     Attributes:
-        definition (VideoObjectDefinitionField): See VideoObjectDefinitionField.
-        objectType: Consists of the value "Activity".
+        name (dict): Consists of the dictionary `{"en-US": <name of the video>}`.
+        definition (dict): See VideoObjectDefinitionField.
     """
 
     name: Optional[dict[LANG_EN_US_DISPLAY, str]]
     definition: VideoObjectDefinitionField
-    objectType: Optional[Literal["Activity"]]

--- a/src/ralph/models/xapi/video/fields/results.py
+++ b/src/ralph/models/xapi/video/fields/results.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 from pydantic import Field
 
 from ...base import BaseModelWithConfig
+from ...fields.results import ResultField
 from ..constants import (
     VIDEO_EXTENSION_LENGTH,
     VIDEO_EXTENSION_PLAYED_SEGMENTS,
@@ -99,7 +100,7 @@ class VideoTerminatedResultExtensionsField(VideoActionResultExtensionsField):
         min_anystr_length = 0
 
 
-class VideoPlayedResultField(BaseModelWithConfig):
+class VideoPlayedResultField(ResultField):
     """Represents the result field for video `played` xAPI statement.
 
     Attributes:
@@ -109,7 +110,7 @@ class VideoPlayedResultField(BaseModelWithConfig):
     extensions: Optional[VideoActionResultExtensionsField]
 
 
-class VideoPausedResultField(BaseModelWithConfig):
+class VideoPausedResultField(ResultField):
     """Represents the result field for video `paused` xAPI statement.
 
     Attributes:
@@ -119,7 +120,7 @@ class VideoPausedResultField(BaseModelWithConfig):
     extensions: Optional[VideoPausedResultExtensionsField]
 
 
-class VideoSeekedResultField(BaseModelWithConfig):
+class VideoSeekedResultField(ResultField):
     """Represents the result field for video `seeked` xAPI statement.
 
     Attributes:
@@ -129,7 +130,7 @@ class VideoSeekedResultField(BaseModelWithConfig):
     extensions: Optional[VideoSeekedResultExtensionsField]
 
 
-class VideoCompletedResultField(BaseModelWithConfig):
+class VideoCompletedResultField(ResultField):
     """Represents the result field for video `completed` xAPI statement.
 
     Attributes:
@@ -141,10 +142,10 @@ class VideoCompletedResultField(BaseModelWithConfig):
 
     extensions: Optional[VideoCompletedResultExtensionsField]
     completion: Optional[Literal[True]]
-    duration: Optional[timedelta]  # noqa: F722
+    duration: Optional[timedelta]
 
 
-class VideoTerminatedResultField(BaseModelWithConfig):
+class VideoTerminatedResultField(ResultField):
     """Represents the result field for video `terminated` xAPI statement.
 
     Attributes:
@@ -154,7 +155,7 @@ class VideoTerminatedResultField(BaseModelWithConfig):
     extensions: Optional[VideoTerminatedResultExtensionsField]
 
 
-class VideoInteractedResultField(BaseModelWithConfig):
+class VideoInteractedResultField(ResultField):
     """Represents the result field for video `terminated` xAPI statement.
 
     Attributes:

--- a/src/ralph/models/xapi/video/fields/verbs.py
+++ b/src/ralph/models/xapi/video/fields/verbs.py
@@ -1,6 +1,5 @@
 """Video xAPI events verb fields definitions"""
 
-from ...base import BaseModelWithConfig
 from ...constants import (
     LANG_EN_US_DISPLAY,
     VERB_COMPLETED_DISPLAY,
@@ -15,10 +14,11 @@ from ...constants import (
     VERB_TERMINATED_DISPLAY,
     VERB_TERMINATED_ID,
 )
+from ...fields.verbs import VerbField
 from ..constants import VERB_VIDEO_PAUSED_ID, VERB_VIDEO_PLAYED_ID, VERB_VIDEO_SEEKED_ID
 
 
-class VideoInitializedVerbField(BaseModelWithConfig):
+class VideoInitializedVerbField(VerbField):
     """Represents the `verb` field for video initialized xAPI statement.
 
     Attributes:
@@ -32,7 +32,7 @@ class VideoInitializedVerbField(BaseModelWithConfig):
     }
 
 
-class VideoPlayedVerbField(BaseModelWithConfig):
+class VideoPlayedVerbField(VerbField):
     """Represents the `verb` field for video played xAPI statement.
 
     Attributes:
@@ -46,7 +46,7 @@ class VideoPlayedVerbField(BaseModelWithConfig):
     }
 
 
-class VideoPausedVerbField(BaseModelWithConfig):
+class VideoPausedVerbField(VerbField):
     """Represents the `verb` field for video paused xAPI statement.
 
     Attributes:
@@ -60,7 +60,7 @@ class VideoPausedVerbField(BaseModelWithConfig):
     }
 
 
-class VideoSeekedVerbField(BaseModelWithConfig):
+class VideoSeekedVerbField(VerbField):
     """Represents the `verb` field for video seeked xAPI statement.
 
     Attributes:
@@ -74,7 +74,7 @@ class VideoSeekedVerbField(BaseModelWithConfig):
     }
 
 
-class VideoCompletedVerbField(BaseModelWithConfig):
+class VideoCompletedVerbField(VerbField):
     """Represents the `verb` field for video completed xAPI statement.
 
     Attributes:
@@ -88,7 +88,7 @@ class VideoCompletedVerbField(BaseModelWithConfig):
     }
 
 
-class VideoTerminatedVerbField(BaseModelWithConfig):
+class VideoTerminatedVerbField(VerbField):
     """Represents the `verb` field for video terminated xAPI statement.
 
     Attributes:
@@ -102,7 +102,7 @@ class VideoTerminatedVerbField(BaseModelWithConfig):
     }
 
 
-class VideoInteractedVerbField(BaseModelWithConfig):
+class VideoInteractedVerbField(VerbField):
     """Represents the `verb` field for video interacted xAPI statement.
 
     Attributes:

--- a/src/ralph/models/xapi/video/fields/verbs.py
+++ b/src/ralph/models/xapi/video/fields/verbs.py
@@ -36,7 +36,7 @@ class VideoPlayedVerbField(VerbField):
     """Represents the `verb` field for video played xAPI statement.
 
     Attributes:
-        id (str): Consists of the value `http://adlnet.gov/expapi/verbs/played`.
+        id (str): Consists of the value `https://w3id.org/xapi/video/verbs/played`.
         display (dict): Consists of the dictionary `{"en-US": "played"}`.
     """
 
@@ -50,7 +50,7 @@ class VideoPausedVerbField(VerbField):
     """Represents the `verb` field for video paused xAPI statement.
 
     Attributes:
-        id (str): Consists of the value `http://adlnet.gov/expapi/verbs/paused`.
+        id (str): Consists of the value `https://w3id.org/xapi/video/verbs/paused`.
         display (dict): Consists of the dictionary `{"en-US": "paused"}`.
     """
 
@@ -64,7 +64,7 @@ class VideoSeekedVerbField(VerbField):
     """Represents the `verb` field for video seeked xAPI statement.
 
     Attributes:
-        id (str): Consists of the value `http://adlnet.gov/expapi/verbs/seeked`.
+        id (str): Consists of the value `https://w3id.org/xapi/video/verbs/seeked`.
         display (dict): Consists of the dictionary `{"en-US": "seeked"}`.
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,7 @@ Module py.test fixtures
 """
 # pylint: disable=unused-import
 
+from .fixtures import hypothesis_configuration  # noqa: F401
+from .fixtures import hypothesis_strategies  # noqa: F401
 from .fixtures.backends import es, es_data_stream, events, swift, ws  # noqa: F401
 from .fixtures.logs import gelf_logger  # noqa: F401

--- a/tests/fixtures/hypothesis_configuration.py
+++ b/tests/fixtures/hypothesis_configuration.py
@@ -1,0 +1,33 @@
+"""Hypothesis fixture configuration"""
+
+from hypothesis import provisional, settings
+from hypothesis import strategies as st
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Json, JsonWrapper
+from pydantic._hypothesis_plugin import RESOLVERS, resolve_json
+
+
+def is_base_model(klass):
+    """Returns True if the given class is a subclass of the pydantic BaseModel."""
+
+    try:
+        return issubclass(klass, BaseModel)
+    except TypeError:
+        return False
+
+
+def custom_resolve_json(cls):
+    """Returns a hypothesis build strategy for Json types."""
+
+    if not is_base_model(getattr(cls, "inner_type", None)):
+        return resolve_json(cls)
+    return st.builds(cls.inner_type.json, st.from_type(cls.inner_type))
+
+
+settings.register_profile("development", max_examples=1)
+settings.load_profile("development")
+
+st.register_type_strategy(str, st.text(min_size=1))
+st.register_type_strategy(AnyUrl, provisional.urls())
+st.register_type_strategy(AnyHttpUrl, provisional.urls())
+st.register_type_strategy(Json, custom_resolve_json)
+RESOLVERS[JsonWrapper] = custom_resolve_json

--- a/tests/fixtures/hypothesis_configuration.py
+++ b/tests/fixtures/hypothesis_configuration.py
@@ -1,9 +1,13 @@
 """Hypothesis fixture configuration"""
 
+import operator
+
 from hypothesis import provisional, settings
 from hypothesis import strategies as st
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Json, JsonWrapper
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Json, JsonWrapper, StrictStr
 from pydantic._hypothesis_plugin import RESOLVERS, resolve_json
+
+from ralph.models.xapi.fields.common import IRI, LanguageTag, MailtoEmail
 
 
 def is_base_model(klass):
@@ -27,7 +31,13 @@ settings.register_profile("development", max_examples=1)
 settings.load_profile("development")
 
 st.register_type_strategy(str, st.text(min_size=1))
+st.register_type_strategy(StrictStr, st.text(min_size=1))
 st.register_type_strategy(AnyUrl, provisional.urls())
 st.register_type_strategy(AnyHttpUrl, provisional.urls())
+st.register_type_strategy(IRI, provisional.urls())
+st.register_type_strategy(
+    MailtoEmail, st.builds(operator.add, st.just("mailto:"), st.emails())
+)
+st.register_type_strategy(LanguageTag, st.just("en-US"))
 st.register_type_strategy(Json, custom_resolve_json)
 RESOLVERS[JsonWrapper] = custom_resolve_json

--- a/tests/fixtures/hypothesis_strategies.py
+++ b/tests/fixtures/hypothesis_strategies.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel
 
 from ralph.models.edx.navigational.fields.events import NavigationalEventField
 from ralph.models.edx.navigational.statements import UISeqNext, UISeqPrev
+from ralph.models.xapi.fields.contexts import ContextField
+from ralph.models.xapi.fields.results import ScoreResultField
 
 from tests.fixtures.hypothesis_configuration import is_base_model
 
@@ -24,7 +26,7 @@ def get_strategy_from(annotation):
         return custom_builds(annotation)
     if origin is Union:
         return st.one_of(
-            [get_strategy_from(t) for t in args if t is not type(None)]  # noqa: E721
+            [get_strategy_from(t) for t in args if not isinstance(t, type(None))]
         )
     if origin is list:
         return st.lists(get_strategy_from(args[0]), min_size=1)
@@ -89,4 +91,6 @@ OVERWRITTEN_STATEGIES = {
     UISeqNext: {
         "event": custom_builds(NavigationalEventField, old=st.just(0), new=st.just(1))
     },
+    ContextField: {"revision": False, "platform": False},
+    ScoreResultField: {"raw": False, "min": False, "max": False},
 }

--- a/tests/fixtures/hypothesis_strategies.py
+++ b/tests/fixtures/hypothesis_strategies.py
@@ -1,0 +1,92 @@
+"""Hypothesis build strategies with special constraints"""
+
+import random
+from typing import Union
+
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import BaseModel
+
+from ralph.models.edx.navigational.fields.events import NavigationalEventField
+from ralph.models.edx.navigational.statements import UISeqNext, UISeqPrev
+
+from tests.fixtures.hypothesis_configuration import is_base_model
+
+OVERWRITTEN_STATEGIES = {}
+
+
+def get_strategy_from(annotation):
+    """Infers a Hypothesis strategy from the given annotation."""
+
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", None)
+    if is_base_model(annotation):
+        return custom_builds(annotation)
+    if origin is Union:
+        return st.one_of(
+            [get_strategy_from(t) for t in args if t is not type(None)]  # noqa: E721
+        )
+    if origin is list:
+        return st.lists(get_strategy_from(args[0]), min_size=1)
+    if origin is dict:
+        keys = get_strategy_from(args[0])
+        values = get_strategy_from(args[1])
+        return st.dictionaries(keys, values, min_size=1)
+    if annotation is None:
+        return st.none()
+    return st.from_type(annotation)
+
+
+def custom_builds(
+    klass: BaseModel, _overwrite_default=True, **kwargs: Union[st.SearchStrategy, bool]
+):
+    """Returns a fixed_dictionaries Hypothesis strategy for pydantic models.
+
+    Args:
+        klass (BaseModel): The pydantic model for which to generate a strategy.
+        _overwrite_default (bool): By default, fields overwritten by kwargs become
+            required. If _overwrite_default is set to False, we keep the original field
+            requirement (either required or optional).
+        **kwargs (SearchStrategy or bool): If kwargs contain search strategies, they
+            overwrite the default strategy for the given key.
+            If kwargs contains booleans, they set whether the given key should be
+            present (True) or omitted (False) in the generated model.
+    """
+
+    for special_class, special_kwargs in OVERWRITTEN_STATEGIES.items():
+        if issubclass(klass, special_class):
+            kwargs = special_kwargs | kwargs
+            break
+    optional = {}
+    required = {}
+    for name, field in klass.__fields__.items():
+        arg = kwargs.get(name, None)
+        if arg is False:
+            continue
+        is_required = field.required or (arg and _overwrite_default)
+        required_optional = required if is_required or arg else optional
+        field_strategy = arg if arg else get_strategy_from(field.outer_type_)
+        required_optional[field.alias] = field_strategy
+    if not required:
+        # To avoid generating empty values
+        key, value = random.choice(list(optional.items()))
+        required[key] = value
+        del optional[key]
+    return st.fixed_dictionaries(required, optional=optional).map(klass.parse_obj)
+
+
+def custom_given(klass: Union[st.SearchStrategy, BaseModel], *args, **kwargs):
+    """Wraps the Hypothesis `given` function. Replaces st.builds with custom_builds."""
+
+    strategy = custom_builds(klass) if is_base_model(klass) else klass
+    return given(strategy, *args, **kwargs)
+
+
+OVERWRITTEN_STATEGIES = {
+    UISeqPrev: {
+        "event": custom_builds(NavigationalEventField, old=st.just(1), new=st.just(0))
+    },
+    UISeqNext: {
+        "event": custom_builds(NavigationalEventField, old=st.just(0), new=st.just(1))
+    },
+}

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -4,27 +4,16 @@ import json
 from uuid import UUID, uuid5
 
 import pytest
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
+from hypothesis import provisional
 
 from ralph.models.converter import convert_dict_event
-from ralph.models.edx.base import BaseContextField
 from ralph.models.edx.converters.xapi.navigational import UIPageCloseToPageTerminated
 from ralph.models.edx.navigational.statements import UIPageClose
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIPageClose,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        context=st.builds(
-            BaseContextField, user_id=st.just("1"), path=st.just("https://fun-mooc.fr/")
-        ),
-    ),
-    provisional.urls(),
-)
+
+@custom_given(UIPageClose, provisional.urls())
 @pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 def test_navigational_ui_page_close_to_page_terminated(
     uuid_namespace, event, platform_url
@@ -33,6 +22,9 @@ def test_navigational_ui_page_close_to_page_terminated(
     constant UUID.
     """
 
+    event.context.course_id = ""
+    event.context.org_id = ""
+    event.context.user_id = "1"
     event_str = event.json()
     event = json.loads(event_str)
     xapi_event = convert_dict_event(

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -48,4 +48,5 @@ def test_navigational_ui_page_close_to_page_terminated(
             "display": {"en-US": "terminated"},
             "id": "http://adlnet.gov/expapi/verbs/terminated",
         },
+        "version": "1.0.0",
     }

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -46,14 +46,14 @@ def test_navigational_ui_page_close_to_page_terminated(
         },
         "object": {
             "definition": {
-                "name": {"en": "page"},
+                "name": {"en-US": "page"},
                 "type": "http://activitystrea.ms/schema/1.0/page",
             },
             "id": event["page"],
         },
         "timestamp": event["time"],
         "verb": {
-            "display": {"en": "terminated"},
+            "display": {"en-US": "terminated"},
             "id": "http://adlnet.gov/expapi/verbs/terminated",
         },
     }

--- a/tests/models/edx/converters/xapi/test_server.py
+++ b/tests/models/edx/converters/xapi/test_server.py
@@ -72,14 +72,14 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_val
         },
         "object": {
             "definition": {
-                "name": {"en": "page"},
+                "name": {"en-US": "page"},
                 "type": "http://activitystrea.ms/schema/1.0/page",
             },
             "id": platform_url + "/main/blog",
         },
         "timestamp": event["time"],
         "verb": {
-            "display": {"en": "viewed"},
+            "display": {"en-US": "viewed"},
             "id": "http://id.tincanapi.com/verb/viewed",
         },
     }

--- a/tests/models/edx/converters/xapi/test_server.py
+++ b/tests/models/edx/converters/xapi/test_server.py
@@ -70,6 +70,7 @@ def test_models_edx_converters_xapi_server_server_event_to_xapi_convert_with_val
             "display": {"en-US": "viewed"},
             "id": "http://id.tincanapi.com/verb/viewed",
         },
+        "version": "1.0.0",
     }
 
 

--- a/tests/models/edx/problem_interaction/test_events.py
+++ b/tests/models/edx/problem_interaction/test_events.py
@@ -541,7 +541,7 @@ def test_models_edx_reset_problem_fail_event_field_with_valid_field(field):
         ),
         field.problem_id,
     )
-    assert field.failure in ("closed", "not_closed")
+    assert field.failure in ("closed", "not_done")
 
 
 @pytest.mark.parametrize(

--- a/tests/models/edx/problem_interaction/test_events.py
+++ b/tests/models/edx/problem_interaction/test_events.py
@@ -4,8 +4,6 @@ import json
 import re
 
 import pytest
-from hypothesis import given, settings
-from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
 from ralph.models.edx.problem_interaction.fields.events import (
@@ -19,12 +17,12 @@ from ralph.models.edx.problem_interaction.fields.events import (
     ResetProblemFailEventField,
     SaveProblemFailEventField,
     SaveProblemSuccessEventField,
-    State,
 )
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(st.builds(CorrectMap))
+
+@custom_given(CorrectMap)
 def test_models_edx_correct_map_with_valid_content(subfield):
     """Tests that a valid `CorrectMap` does not raise a `ValidationError`."""
 
@@ -33,8 +31,7 @@ def test_models_edx_correct_map_with_valid_content(subfield):
 
 
 @pytest.mark.parametrize("correctness", ["corect", "incorect"])
-@settings(max_examples=1)
-@given(st.builds(CorrectMap))
+@custom_given(CorrectMap)
 def test_models_edx_correct_map_with_invalid_correctness_value(correctness, subfield):
     """Tests that an invalid `correctness` value in `CorrectMap` raises a
     `ValidationError`.
@@ -48,8 +45,7 @@ def test_models_edx_correct_map_with_invalid_correctness_value(correctness, subf
 
 
 @pytest.mark.parametrize("hintmode", ["onrequest", "alway"])
-@settings(max_examples=1)
-@given(st.builds(CorrectMap))
+@custom_given(CorrectMap)
 def test_models_edx_correct_map_with_invalid_hintmode_value(hintmode, subfield):
     """Tests that an invalid `hintmode` value in `CorrectMap` raises a
     `ValidationError`.
@@ -62,8 +58,7 @@ def test_models_edx_correct_map_with_invalid_hintmode_value(hintmode, subfield):
         CorrectMap(**invalid_subfield)
 
 
-@settings(max_examples=1)
-@given(st.builds(EdxProblemHintFeedbackDisplayedEventField))
+@custom_given(EdxProblemHintFeedbackDisplayedEventField)
 def test_models_edx_problem_hint_feedback_displayed_event_field_with_valid_field(field):
     """Tests that a valid `EdxProblemHintFeedbackDisplayedEventField` does not raise a
     `ValidationError`.
@@ -90,8 +85,7 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_valid_field
         "optionrespons",
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(EdxProblemHintFeedbackDisplayedEventField))
+@custom_given(EdxProblemHintFeedbackDisplayedEventField)
 def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_question_type_value(  # noqa
     question_type, field
 ):
@@ -108,8 +102,7 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_que
 
 # pylint: disable=line-too-long
 @pytest.mark.parametrize("trigger_type", ["jingle", "compund"])
-@settings(max_examples=1)
-@given(st.builds(EdxProblemHintFeedbackDisplayedEventField))
+@custom_given(EdxProblemHintFeedbackDisplayedEventField)
 def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_trigger_type_value(  # noqa
     trigger_type, field
 ):
@@ -124,8 +117,7 @@ def test_models_edx_problem_hint_feedback_displayed_event_field_with_invalid_tri
         EdxProblemHintFeedbackDisplayedEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(ProblemCheckEventField, state=st.builds(State)))
+@custom_given(ProblemCheckEventField)
 def test_models_edx_problem_check_event_field_with_valid_field(field):
     """Tests that a valid `ProblemCheckEventField` does not raise a
     `ValidationError`.
@@ -168,8 +160,7 @@ def test_models_edx_problem_check_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(ProblemCheckEventField, state=st.builds(State)))
+@custom_given(ProblemCheckEventField)
 def test_models_edx_problem_check_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -187,8 +178,7 @@ def test_models_edx_problem_check_event_field_with_invalid_problem_id_value(
 
 
 @pytest.mark.parametrize("success", ["corect", "incorect"])
-@settings(max_examples=1)
-@given(st.builds(ProblemCheckEventField, state=st.builds(State)))
+@custom_given(ProblemCheckEventField)
 def test_models_edx_problem_check_event_field_with_invalid_success_value(
     success, field
 ):
@@ -203,8 +193,7 @@ def test_models_edx_problem_check_event_field_with_invalid_success_value(
         ProblemCheckEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(ProblemCheckFailEventField, state=st.builds(State)))
+@custom_given(ProblemCheckFailEventField)
 def test_models_edx_problem_check_fail_event_field_with_valid_field(field):
     """Tests that a valid `ProblemCheckFailEventField` does not raise a
     `ValidationError`.
@@ -247,8 +236,7 @@ def test_models_edx_problem_check_fail_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(ProblemCheckFailEventField, state=st.builds(State)))
+@custom_given(ProblemCheckFailEventField)
 def test_models_edx_problem_check_fail_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -266,8 +254,7 @@ def test_models_edx_problem_check_fail_event_field_with_invalid_problem_id_value
 
 
 @pytest.mark.parametrize("failure", ["close", "unresit"])
-@settings(max_examples=1)
-@given(st.builds(ProblemCheckFailEventField, state=st.builds(State)))
+@custom_given(ProblemCheckFailEventField)
 def test_models_edx_problem_check_fail_event_field_with_invalid_failure_value(
     failure, field
 ):
@@ -282,14 +269,7 @@ def test_models_edx_problem_check_fail_event_field_with_invalid_failure_value(
         ProblemCheckFailEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescoreEventField,
-        state=st.builds(State),
-        correct_map=st.builds(CorrectMap),
-    )
-)
+@custom_given(ProblemRescoreEventField)
 def test_models_edx_problem_rescore_event_field_with_valid_field(field):
     """Tests that a valid `ProblemRescoreEventField` does not raise a
     `ValidationError`.
@@ -332,14 +312,7 @@ def test_models_edx_problem_rescore_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescoreEventField,
-        state=st.builds(State),
-        correct_map=st.builds(CorrectMap),
-    ),
-)
+@custom_given(ProblemRescoreEventField)
 def test_models_edx_problem_rescore_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -357,14 +330,7 @@ def test_models_edx_problem_rescore_event_field_with_invalid_problem_id_value(
 
 
 @pytest.mark.parametrize("success", ["corect", "incorect"])
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescoreEventField,
-        state=st.builds(State),
-        correct_map=st.builds(CorrectMap),
-    ),
-)
+@custom_given(ProblemRescoreEventField)
 def test_models_edx_problem_rescore_event_field_with_invalid_success_value(
     success, field
 ):
@@ -379,8 +345,7 @@ def test_models_edx_problem_rescore_event_field_with_invalid_success_value(
         ProblemRescoreEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(ProblemRescoreFailEventField, state=st.builds(State)))
+@custom_given(ProblemRescoreFailEventField)
 def test_models_edx_problem_rescore_fail_event_field_with_valid_field(field):
     """Tests that a valid `ProblemRescoreFailEventField` does not raise a
     `ValidationError`.
@@ -423,8 +388,7 @@ def test_models_edx_problem_rescore_fail_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(ProblemRescoreFailEventField, state=st.builds(State)))
+@custom_given(ProblemRescoreFailEventField)
 def test_models_edx_problem_rescore_fail_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -442,8 +406,7 @@ def test_models_edx_problem_rescore_fail_event_field_with_invalid_problem_id_val
 
 
 @pytest.mark.parametrize("failure", ["close", "unresit"])
-@settings(max_examples=1)
-@given(st.builds(ProblemRescoreFailEventField, state=st.builds(State)))
+@custom_given(ProblemRescoreFailEventField)
 def test_models_edx_problem_rescore_fail_event_field_with_invalid_failure_value(
     failure, field
 ):
@@ -458,12 +421,7 @@ def test_models_edx_problem_rescore_fail_event_field_with_invalid_failure_value(
         ProblemRescoreFailEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ResetProblemEventField, old_state=st.builds(State), new_state=st.builds(State)
-    )
-)
+@custom_given(ResetProblemEventField)
 def test_models_edx_reset_problem_event_field_with_valid_field(field):
     """Tests that a valid `ResetProblemEventField` does not raise a
     `ValidationError`.
@@ -505,12 +463,7 @@ def test_models_edx_reset_problem_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ResetProblemEventField, old_state=st.builds(State), new_state=st.builds(State)
-    )
-)
+@custom_given(ResetProblemEventField)
 def test_models_edx_reset_problem_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -527,8 +480,7 @@ def test_models_edx_reset_problem_event_field_with_invalid_problem_id_value(
         ResetProblemEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(ResetProblemFailEventField, old_state=st.builds(State)))
+@custom_given(ResetProblemFailEventField)
 def test_models_edx_reset_problem_fail_event_field_with_valid_field(field):
     """Tests that a valid `ResetProblemFailEventField` does not raise a
     `ValidationError`.
@@ -571,8 +523,7 @@ def test_models_edx_reset_problem_fail_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(ResetProblemFailEventField, old_state=st.builds(State)))
+@custom_given(ResetProblemFailEventField)
 def test_models_edx_reset_problem_fail_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -590,8 +541,7 @@ def test_models_edx_reset_problem_fail_event_field_with_invalid_problem_id_value
 
 
 @pytest.mark.parametrize("failure", ["close", "not_close"])
-@settings(max_examples=1)
-@given(st.builds(ResetProblemFailEventField, old_state=st.builds(State)))
+@custom_given(ResetProblemFailEventField)
 def test_models_edx_reset_problem_fail_event_field_with_invalid_failure_value(
     failure, field
 ):
@@ -606,8 +556,7 @@ def test_models_edx_reset_problem_fail_event_field_with_invalid_failure_value(
         ResetProblemFailEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(SaveProblemFailEventField, state=st.builds(State)))
+@custom_given(SaveProblemFailEventField)
 def test_models_edx_save_problem_fail_event_field_with_valid_field(field):
     """Tests that a valid `SaveProblemFailEventField` does not raise a
     `ValidationError`.
@@ -650,8 +599,7 @@ def test_models_edx_save_problem_fail_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(SaveProblemFailEventField, state=st.builds(State)))
+@custom_given(SaveProblemFailEventField)
 def test_models_edx_save_problem_fail_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):
@@ -669,8 +617,7 @@ def test_models_edx_save_problem_fail_event_field_with_invalid_problem_id_value(
 
 
 @pytest.mark.parametrize("failure", ["close", "doned"])
-@settings(max_examples=1)
-@given(st.builds(SaveProblemFailEventField, state=st.builds(State)))
+@custom_given(SaveProblemFailEventField)
 def test_models_edx_save_problem_fail_event_field_with_invalid_failure_value(
     failure, field
 ):
@@ -685,8 +632,7 @@ def test_models_edx_save_problem_fail_event_field_with_invalid_failure_value(
         SaveProblemFailEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(SaveProblemSuccessEventField, state=st.builds(State)))
+@custom_given(SaveProblemSuccessEventField)
 def test_models_edx_save_problem_success_event_field_with_valid_field(field):
     """Tests that a valid `SaveProblemFailEventField` does not raise a
     `ValidationError`.
@@ -728,8 +674,7 @@ def test_models_edx_save_problem_success_event_field_with_valid_field(field):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(SaveProblemSuccessEventField, state=st.builds(State)))
+@custom_given(SaveProblemSuccessEventField)
 def test_models_edx_save_problem_success_event_field_with_invalid_problem_id_value(
     problem_id, field
 ):

--- a/tests/models/edx/problem_interaction/test_statements.py
+++ b/tests/models/edx/problem_interaction/test_statements.py
@@ -2,26 +2,6 @@
 
 import json
 
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
-
-from ralph.models.edx.problem_interaction.fields.events import (
-    CorrectMap,
-    EdxProblemHintDemandhintDisplayedEventField,
-    EdxProblemHintFeedbackDisplayedEventField,
-    ProblemCheckEventField,
-    ProblemCheckFailEventField,
-    ProblemRescoreEventField,
-    ProblemRescoreFailEventField,
-    ResetProblemEventField,
-    ResetProblemFailEventField,
-    SaveProblemFailEventField,
-    SaveProblemSuccessEventField,
-    ShowAnswerEventField,
-    State,
-    UIProblemResetEventField,
-    UIProblemShowEventField,
-)
 from ralph.models.edx.problem_interaction.statements import (
     EdxProblemHintDemandhintDisplayed,
     EdxProblemHintFeedbackDisplayed,
@@ -42,15 +22,10 @@ from ralph.models.edx.problem_interaction.statements import (
 )
 from ralph.models.selector import ModelSelector
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxProblemHintDemandhintDisplayed,
-        referer=provisional.urls(),
-        event=st.builds(EdxProblemHintDemandhintDisplayedEventField),
-    )
-)
+
+@custom_given(EdxProblemHintDemandhintDisplayed)
 def test_models_edx_edx_problem_hint_demandhint_displayed_with_valid_statement(
     statement,
 ):
@@ -62,14 +37,7 @@ def test_models_edx_edx_problem_hint_demandhint_displayed_with_valid_statement(
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxProblemHintDemandhintDisplayed,
-        referer=provisional.urls(),
-        event=st.builds(EdxProblemHintDemandhintDisplayedEventField),
-    )
-)
+@custom_given(EdxProblemHintDemandhintDisplayed)
 def test_models_edx_edx_problem_hint_demandhint_displayed_selector_with_valid_statement(
     statement,
 ):
@@ -84,14 +52,7 @@ def test_models_edx_edx_problem_hint_demandhint_displayed_selector_with_valid_st
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxProblemHintFeedbackDisplayed,
-        referer=provisional.urls(),
-        event=st.builds(EdxProblemHintFeedbackDisplayedEventField),
-    )
-)
+@custom_given(EdxProblemHintFeedbackDisplayed)
 def test_models_edx_edx_problem_hint_feedback_displayed_with_valid_statement(statement):
     """Tests that a `edx.problem.hint.feedback_displayed` statement has the expected
     `event_type` and `page`.
@@ -101,14 +62,7 @@ def test_models_edx_edx_problem_hint_feedback_displayed_with_valid_statement(sta
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxProblemHintFeedbackDisplayed,
-        referer=provisional.urls(),
-        event=st.builds(EdxProblemHintFeedbackDisplayedEventField),
-    )
-)
+@custom_given(EdxProblemHintFeedbackDisplayed)
 def test_models_edx_edx_problem_hint_feedback_displayed_selector_with_valid_statement(
     statement,
 ):
@@ -123,14 +77,7 @@ def test_models_edx_edx_problem_hint_feedback_displayed_selector_with_valid_stat
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIProblemCheck,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-    )
-)
+@custom_given(UIProblemCheck)
 def test_models_edx_ui_problem_check_with_valid_statement(statement):
     """Tests that a `problem_check` browser statement has the expected `event_type` and
     `name`.
@@ -140,14 +87,7 @@ def test_models_edx_ui_problem_check_with_valid_statement(statement):
     assert statement.name == "problem_check"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIProblemCheck,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-    )
-)
+@custom_given(UIProblemCheck)
 def test_models_edx_ui_problem_check_selector_with_valid_statement(statement):
     """Tests given a `problem_check` statement the selector `get_model`
     method should return `UIProblemCheck` model.
@@ -159,17 +99,7 @@ def test_models_edx_ui_problem_check_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemCheck,
-        referer=provisional.urls(),
-        event=st.builds(
-            ProblemCheckEventField,
-            state=st.builds(State),
-        ),
-    )
-)
+@custom_given(ProblemCheck)
 def test_models_edx_problem_check_with_valid_statement(statement):
     """Tests that a `problem_check` server statement has the expected `event_type` and
     `page`.
@@ -179,17 +109,7 @@ def test_models_edx_problem_check_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemCheck,
-        referer=provisional.urls(),
-        event=st.builds(
-            ProblemCheckEventField,
-            state=st.builds(State),
-        ),
-    )
-)
+@custom_given(ProblemCheck)
 def test_models_edx_problem_check_selector_with_valid_statement(statement):
     """Tests given a `problem_check` statement the selector `get_model` method should
     return `ProblemCheck` model.
@@ -199,17 +119,7 @@ def test_models_edx_problem_check_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.edx").get_model(statement) is ProblemCheck
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemCheckFail,
-        referer=provisional.urls(),
-        event=st.builds(
-            ProblemCheckFailEventField,
-            state=st.builds(State),
-        ),
-    )
-)
+@custom_given(ProblemCheckFail)
 def test_models_edx_problem_check_fail_with_valid_statement(statement):
     """Tests that a `problem_check_fail` server statement has the expected `event_type`
     and `page`.
@@ -219,17 +129,7 @@ def test_models_edx_problem_check_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemCheckFail,
-        referer=provisional.urls(),
-        event=st.builds(
-            ProblemCheckFailEventField,
-            state=st.builds(State),
-        ),
-    )
-)
+@custom_given(ProblemCheckFail)
 def test_models_edx_problem_check_fail_selector_with_valid_statement(statement):
     """Tests given a `problem_check_fail` statement the selector `get_model` method
     should return `ProblemCheckFail` model.
@@ -242,8 +142,7 @@ def test_models_edx_problem_check_fail_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(st.builds(UIProblemGraded, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIProblemGraded)
 def test_models_edx_ui_problem_graded_with_valid_statement(statement):
     """Tests that a `problem_graded` browser statement has the expected `event_type` and
     `name`."""
@@ -252,8 +151,7 @@ def test_models_edx_ui_problem_graded_with_valid_statement(statement):
     assert statement.name == "problem_graded"
 
 
-@settings(max_examples=1)
-@given(st.builds(UIProblemGraded, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIProblemGraded)
 def test_models_edx_ui_problem_graded_selector_with_valid_statement(statement):
     """Tests given a `problem_graded` statement the selector `get_model`
     method should return `ProblemGraded` model.
@@ -265,18 +163,7 @@ def test_models_edx_ui_problem_graded_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescore,
-        referer=provisional.urls(),
-        event=st.builds(
-            ProblemRescoreEventField,
-            state=st.builds(State),
-            correct_map=st.builds(CorrectMap),
-        ),
-    )
-)
+@custom_given(ProblemRescore)
 def test_models_edx_problem_rescore_with_valid_statement(statement):
     """Tests that a `problem_rescore` server statement has the expected `event_type` and
     `page`."""
@@ -285,18 +172,7 @@ def test_models_edx_problem_rescore_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescore,
-        referer=provisional.urls(),
-        event=st.builds(
-            ProblemRescoreEventField,
-            state=st.builds(State),
-            correct_map=st.builds(CorrectMap),
-        ),
-    )
-)
+@custom_given(ProblemRescore)
 def test_models_edx_problem_rescore_selector_with_valid_statement(statement):
     """Tests given a `problem_rescore` statement the selector `get_model` method should
     return `ProblemRescore` model.
@@ -308,14 +184,7 @@ def test_models_edx_problem_rescore_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescoreFail,
-        referer=provisional.urls(),
-        event=st.builds(ProblemRescoreFailEventField, state=st.builds(State)),
-    )
-)
+@custom_given(ProblemRescoreFail)
 def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
     """Tests that a `problem_rescore` server statement has the expected `event_type` and
     `page`."""
@@ -324,14 +193,7 @@ def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ProblemRescoreFail,
-        referer=provisional.urls(),
-        event=st.builds(ProblemRescoreFailEventField, state=st.builds(State)),
-    )
-)
+@custom_given(ProblemRescoreFail)
 def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement):
     """Tests given a `problem_rescore_fail` statement the selector `get_model` method
     should return `ProblemRescoreFail` model.
@@ -344,15 +206,7 @@ def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIProblemReset,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(UIProblemResetEventField),
-    )
-)
+@custom_given(UIProblemReset)
 def test_models_edx_ui_problem_reset_with_valid_statement(statement):
     """Tests that a `problem_reset` browser statement has the expected `event_type` and
     `name`."""
@@ -361,15 +215,7 @@ def test_models_edx_ui_problem_reset_with_valid_statement(statement):
     assert statement.name == "problem_reset"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIProblemReset,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(UIProblemResetEventField),
-    )
-)
+@custom_given(UIProblemReset)
 def test_models_edx_ui_problem_reset_selector_with_valid_statement(statement):
     """Tests given a `problem_reset` statement the selector `get_model` method should
     return `ProblemReset` model.
@@ -381,8 +227,7 @@ def test_models_edx_ui_problem_reset_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(st.builds(UIProblemSave, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIProblemSave)
 def test_models_edx_ui_problem_save_with_valid_statement(statement):
     """Tests that a `problem_save` browser statement has the expected `event_type` and
     `name`.
@@ -392,8 +237,7 @@ def test_models_edx_ui_problem_save_with_valid_statement(statement):
     assert statement.name == "problem_save"
 
 
-@settings(max_examples=1)
-@given(st.builds(UIProblemSave, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIProblemSave)
 def test_models_edx_ui_problem_save_selector_with_valid_statement(statement):
     """Tests given a `problem_save` statement the selector `get_model` method should
     return `ProblemSave` model.
@@ -405,15 +249,7 @@ def test_models_edx_ui_problem_save_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIProblemShow,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(UIProblemShowEventField),
-    )
-)
+@custom_given(UIProblemShow)
 def test_models_edx_ui_problem_show_with_valid_statement(statement):
     """Tests that a `problem_show` browser statement has the expected `event_type` and
     `name`.
@@ -423,15 +259,7 @@ def test_models_edx_ui_problem_show_with_valid_statement(statement):
     assert statement.name == "problem_show"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIProblemShow,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(UIProblemShowEventField),
-    )
-)
+@custom_given(UIProblemShow)
 def test_models_edx_ui_problem_show_selector_with_valid_statement(statement):
     """Tests given a `problem_show` statement the selector `get_model` method should
     return `ProblemShow` model.
@@ -443,18 +271,7 @@ def test_models_edx_ui_problem_show_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ResetProblem,
-        referer=provisional.urls(),
-        event=st.builds(
-            ResetProblemEventField,
-            old_state=st.builds(State),
-            new_state=st.builds(State),
-        ),
-    )
-)
+@custom_given(ResetProblem)
 def test_models_edx_reset_problem_with_valid_statement(statement):
     """Tests that a `reset_problem` server statement has the expected `event_type` and
     `page`.
@@ -464,18 +281,7 @@ def test_models_edx_reset_problem_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ResetProblem,
-        referer=provisional.urls(),
-        event=st.builds(
-            ResetProblemEventField,
-            old_state=st.builds(State),
-            new_state=st.builds(State),
-        ),
-    )
-)
+@custom_given(ResetProblem)
 def test_models_edx_reset_problem_selector_with_valid_statement(statement):
     """Tests given a `reset_problem` statement the selector `get_model` method should
     return `ResetProblem` model.
@@ -485,14 +291,7 @@ def test_models_edx_reset_problem_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.edx").get_model(statement) is ResetProblem
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ResetProblemFail,
-        referer=provisional.urls(),
-        event=st.builds(ResetProblemFailEventField, old_state=st.builds(State)),
-    )
-)
+@custom_given(ResetProblemFail)
 def test_models_edx_reset_problem_fail_with_valid_statement(statement):
     """Tests that a `reset_problem_fail` server statement has the expected `event_type`
     and `page`.
@@ -502,14 +301,7 @@ def test_models_edx_reset_problem_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ResetProblemFail,
-        referer=provisional.urls(),
-        event=st.builds(ResetProblemFailEventField, old_state=st.builds(State)),
-    )
-)
+@custom_given(ResetProblemFail)
 def test_models_edx_reset_problem_fail_selector_with_valid_statement(statement):
     """Tests given a `reset_problem_fail` statement the selector `get_model` method
     should return `ResetProblemFail` model.
@@ -522,14 +314,7 @@ def test_models_edx_reset_problem_fail_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        SaveProblemFail,
-        referer=provisional.urls(),
-        event=st.builds(SaveProblemFailEventField, state=st.builds(State)),
-    )
-)
+@custom_given(SaveProblemFail)
 def test_models_edx_save_problem_fail_with_valid_statement(statement):
     """Tests that a `save_problem_fail` server statement has the expected `event_type`
     and `page`.
@@ -539,14 +324,7 @@ def test_models_edx_save_problem_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        SaveProblemFail,
-        referer=provisional.urls(),
-        event=st.builds(SaveProblemFailEventField, state=st.builds(State)),
-    )
-)
+@custom_given(SaveProblemFail)
 def test_models_edx_save_problem_fail_selector_with_valid_statement(statement):
     """Tests given a `reset_problem_fail` statement the selector `get_model` method
     should return `SaveProblemFail` model.
@@ -558,14 +336,7 @@ def test_models_edx_save_problem_fail_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        SaveProblemSuccess,
-        referer=provisional.urls(),
-        event=st.builds(SaveProblemSuccessEventField, state=st.builds(State)),
-    )
-)
+@custom_given(SaveProblemSuccess)
 def test_models_edx_save_problem_success_with_valid_statement(statement):
     """Tests that a `save_problem_success` server statement has the expected
     `event_type` and `page`.
@@ -575,14 +346,7 @@ def test_models_edx_save_problem_success_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        SaveProblemSuccess,
-        referer=provisional.urls(),
-        event=st.builds(SaveProblemSuccessEventField, state=st.builds(State)),
-    )
-)
+@custom_given(SaveProblemSuccess)
 def test_models_edx_save_problem_success_selector_with_valid_statement(statement):
     """Tests given a `reset_problem_success` statement the selector `get_model` method
     should return `SaveProblemSuccess` model.
@@ -595,12 +359,7 @@ def test_models_edx_save_problem_success_selector_with_valid_statement(statement
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ShowAnswer, referer=provisional.urls(), event=st.builds(ShowAnswerEventField)
-    )
-)
+@custom_given(ShowAnswer)
 def test_models_edx_show_answer_with_valid_statement(statement):
     """Tests that a `showanswer` server statement has the expected `event_type` and
     `page`.
@@ -610,12 +369,7 @@ def test_models_edx_show_answer_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ShowAnswer, referer=provisional.urls(), event=st.builds(ShowAnswerEventField)
-    )
-)
+@custom_given(ShowAnswer)
 def test_models_edx_show_answer_selector_with_valid_statement(statement):
     """Tests given a `show_answer` statement the selector `get_model` method should
     return `ShowAnswer` model.

--- a/tests/models/edx/test_base.py
+++ b/tests/models/edx/test_base.py
@@ -4,19 +4,14 @@ import json
 import re
 
 import pytest
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
-from ralph.models.edx.base import BaseContextField, BaseEdxModel
+from ralph.models.edx.base import BaseEdxModel
+
+from tests.fixtures.hypothesis_strategies import custom_given
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        BaseEdxModel, context=st.builds(BaseContextField), referer=provisional.urls()
-    )
-)
+@custom_given(BaseEdxModel)
 def test_models_edx_base_edx_model_with_valid_statement(statement):
     """Tests that a valid base `Edx` statement does not raise a `ValidationError`."""
 
@@ -48,12 +43,7 @@ def test_models_edx_base_edx_model_with_valid_statement(statement):
         ),
     ],
 )
-@settings(max_examples=1)
-@given(
-    st.builds(
-        BaseEdxModel, context=st.builds(BaseContextField), referer=provisional.urls()
-    )
-)
+@custom_given(BaseEdxModel)
 def test_models_edx_base_edx_model_with_invalid_statement(course_id, error, statement):
     """Tests that a invalid base `Edx` statement raises a `ValidationError`."""
 

--- a/tests/models/edx/test_browser.py
+++ b/tests/models/edx/test_browser.py
@@ -4,15 +4,14 @@ import json
 import re
 
 import pytest
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
 from ralph.models.edx.browser import BaseBrowserModel
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(st.builds(BaseBrowserModel, referer=provisional.urls(), page=provisional.urls()))
+
+@custom_given(BaseBrowserModel)
 def test_models_edx_base_browser_model_with_valid_statement(statement):
     """Tests that a valid base browser statement does not raise a `ValidationError`."""
 
@@ -30,8 +29,7 @@ def test_models_edx_base_browser_model_with_valid_statement(statement):
         ("abcdef0123456789_abcdef012345678", "string does not match regex"),
     ],
 )
-@settings(max_examples=1)
-@given(st.builds(BaseBrowserModel, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(BaseBrowserModel)
 def test_models_edx_base_browser_model_with_invalid_statement(
     session, error, statement
 ):

--- a/tests/models/edx/test_enrollment.py
+++ b/tests/models/edx/test_enrollment.py
@@ -2,14 +2,6 @@
 
 import json
 
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
-
-from ralph.models.edx.enrollment.fields.contexts import (
-    EdxCourseEnrollmentUpgradeClickedContextField,
-    EdxCourseEnrollmentUpgradeSucceededContextField,
-)
-from ralph.models.edx.enrollment.fields.events import EnrollmentEventField
 from ralph.models.edx.enrollment.statements import (
     EdxCourseEnrollmentActivated,
     EdxCourseEnrollmentDeactivated,
@@ -19,15 +11,10 @@ from ralph.models.edx.enrollment.statements import (
 )
 from ralph.models.selector import ModelSelector
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentActivated,
-        referer=provisional.urls(),
-        event=st.builds(EnrollmentEventField),
-    )
-)
+
+@custom_given(EdxCourseEnrollmentActivated)
 def test_models_edx_edx_course_enrollment_activated_with_valid_statement(
     statement,
 ):
@@ -39,14 +26,7 @@ def test_models_edx_edx_course_enrollment_activated_with_valid_statement(
     assert statement.name == "edx.course.enrollment.activated"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentActivated,
-        referer=provisional.urls(),
-        event=st.builds(EnrollmentEventField),
-    )
-)
+@custom_given(EdxCourseEnrollmentActivated)
 def test_models_edx_edx_course_enrollment_activated_selector_with_valid_statement(
     statement,
 ):
@@ -61,14 +41,7 @@ def test_models_edx_edx_course_enrollment_activated_selector_with_valid_statemen
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentDeactivated,
-        referer=provisional.urls(),
-        event=st.builds(EnrollmentEventField),
-    )
-)
+@custom_given(EdxCourseEnrollmentDeactivated)
 def test_models_edx_edx_course_enrollment_deactivated_with_valid_statement(
     statement,
 ):
@@ -80,14 +53,7 @@ def test_models_edx_edx_course_enrollment_deactivated_with_valid_statement(
     assert statement.name == "edx.course.enrollment.deactivated"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentDeactivated,
-        referer=provisional.urls(),
-        event=st.builds(EnrollmentEventField),
-    )
-)
+@custom_given(EdxCourseEnrollmentDeactivated)
 def test_models_edx_edx_course_enrollment_deactivated_selector_with_valid_statement(
     statement,
 ):
@@ -102,14 +68,7 @@ def test_models_edx_edx_course_enrollment_deactivated_selector_with_valid_statem
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentModeChanged,
-        referer=provisional.urls(),
-        event=st.builds(EnrollmentEventField),
-    )
-)
+@custom_given(EdxCourseEnrollmentModeChanged)
 def test_models_edx_edx_course_enrollment_mode_changed_with_valid_statement(
     statement,
 ):
@@ -121,14 +80,7 @@ def test_models_edx_edx_course_enrollment_mode_changed_with_valid_statement(
     assert statement.name == "edx.course.enrollment.mode_changed"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentModeChanged,
-        referer=provisional.urls(),
-        event=st.builds(EnrollmentEventField),
-    )
-)
+@custom_given(EdxCourseEnrollmentModeChanged)
 def test_models_edx_edx_course_enrollment_mode_changed_selector_with_valid_statement(
     statement,
 ):
@@ -143,15 +95,7 @@ def test_models_edx_edx_course_enrollment_mode_changed_selector_with_valid_state
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIEdxCourseEnrollmentUpgradeClicked,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        context=st.builds(EdxCourseEnrollmentUpgradeClickedContextField),
-    )
-)
+@custom_given(UIEdxCourseEnrollmentUpgradeClicked)
 def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_with_valid_statement(
     statement,
 ):
@@ -164,15 +108,7 @@ def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_with_valid_statemen
 
 
 # pylint: disable=line-too-long
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIEdxCourseEnrollmentUpgradeClicked,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        context=st.builds(EdxCourseEnrollmentUpgradeClickedContextField),
-    )
-)
+@custom_given(UIEdxCourseEnrollmentUpgradeClicked)
 def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_selector_with_valid_statement(  # noqa
     statement,
 ):
@@ -187,14 +123,7 @@ def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_selector_with_valid
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentUpgradeSucceeded,
-        referer=provisional.urls(),
-        context=st.builds(EdxCourseEnrollmentUpgradeSucceededContextField),
-    )
-)
+@custom_given(EdxCourseEnrollmentUpgradeSucceeded)
 def test_models_edx_edx_course_enrollment_upgrade_succeeded_with_valid_statement(
     statement,
 ):
@@ -207,14 +136,7 @@ def test_models_edx_edx_course_enrollment_upgrade_succeeded_with_valid_statement
 
 
 # pylint: disable=line-too-long
-@settings(max_examples=1)
-@given(
-    st.builds(
-        EdxCourseEnrollmentUpgradeSucceeded,
-        referer=provisional.urls(),
-        context=st.builds(EdxCourseEnrollmentUpgradeSucceededContextField),
-    )
-)
+@custom_given(EdxCourseEnrollmentUpgradeSucceeded)
 def test_models_edx_edx_course_enrollment_upgrade_succeeded_selector_with_valid_statement(  # noqa
     statement,
 ):

--- a/tests/models/edx/test_navigational.py
+++ b/tests/models/edx/test_navigational.py
@@ -4,11 +4,8 @@ import json
 import re
 
 import pytest
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
-from ralph.models.edx.base import BaseContextField
 from ralph.models.edx.navigational.fields.events import NavigationalEventField
 from ralph.models.edx.navigational.statements import (
     UIPageClose,
@@ -18,9 +15,10 @@ from ralph.models.edx.navigational.statements import (
 )
 from ralph.models.selector import ModelSelector
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(st.builds(NavigationalEventField))
+
+@custom_given(NavigationalEventField)
 def test_fields_edx_navigational_events_event_field_with_valid_content(field):
     """Tests that a valid `NavigationalEventField` does not raise a
     `ValidationError`.
@@ -62,8 +60,7 @@ def test_fields_edx_navigational_events_event_field_with_valid_content(field):
         ),
     ],  # pylint: disable=invalid-name
 )
-@settings(max_examples=1)
-@given(st.builds(NavigationalEventField))
+@custom_given(NavigationalEventField)
 def test_fields_edx_navigational_events_event_field_with_invalid_content(
     id, field  # pylint: disable=redefined-builtin, invalid-name
 ):
@@ -76,8 +73,7 @@ def test_fields_edx_navigational_events_event_field_with_invalid_content(
         NavigationalEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIPageClose)
 def test_models_edx_ui_page_close_with_valid_statement(statement):
     """Tests that a `page_close` statement has the expected `event`, `event_type` and
     `name`.
@@ -88,8 +84,7 @@ def test_models_edx_ui_page_close_with_valid_statement(statement):
     assert statement.name == "page_close"
 
 
-@settings(max_examples=1)
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIPageClose)
 def test_models_edx_ui_page_close_selector_with_valid_statement(statement):
     """Tests given a `page_close` statement the selector `get_model` method should
     return `UIPageClose` model.
@@ -99,16 +94,7 @@ def test_models_edx_ui_page_close_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.edx").get_model(statement) is UIPageClose
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqGoto,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(NavigationalEventField),
-    )
-)
+@custom_given(UISeqGoto)
 def test_models_edx_ui_seq_goto_with_valid_statement(statement):
     """Tests that a `seq_goto` statement has the expected `event_type` and `name`."""
 
@@ -116,16 +102,7 @@ def test_models_edx_ui_seq_goto_with_valid_statement(statement):
     assert statement.name == "seq_goto"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqGoto,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(NavigationalEventField),
-    )
-)
+@custom_given(UISeqGoto)
 def test_models_edx_ui_seq_goto_selector_with_valid_statement(statement):
     """Tests given a `seq_goto` statement the selector `get_model` method should return
     `UISeqGoto` model.
@@ -135,18 +112,7 @@ def test_models_edx_ui_seq_goto_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.edx").get_model(statement) is UISeqGoto
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqNext,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(
-            NavigationalEventField, old=st.integers(0, 0), new=st.integers(1, 1)
-        ),
-    )
-)
+@custom_given(UISeqNext)
 def test_models_edx_ui_seq_next_with_valid_statement(statement):
     """Tests that a `seq_next` statement has the expected `event_type` and `name`."""
 
@@ -154,18 +120,7 @@ def test_models_edx_ui_seq_next_with_valid_statement(statement):
     assert statement.name == "seq_next"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqNext,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(
-            NavigationalEventField, old=st.integers(0, 0), new=st.integers(1, 1)
-        ),
-    )
-)
+@custom_given(UISeqNext)
 def test_models_edx_ui_seq_next_selector_with_valid_statement(statement):
     """Tests given a `seq_next` event the selector `get_model` method should return
     `UISeqNext` model.
@@ -176,18 +131,7 @@ def test_models_edx_ui_seq_next_selector_with_valid_statement(statement):
 
 
 @pytest.mark.parametrize("old,new", [("0", "10"), ("10", "0")])
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqNext,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(
-            NavigationalEventField, old=st.integers(0, 0), new=st.integers(1, 1)
-        ),
-    )
-)
+@custom_given(UISeqNext)
 def test_models_edx_ui_seq_next_with_invalid_statement(old, new, event):
     """Tests that an invalid `seq_next` event raises a ValidationError."""
 
@@ -202,18 +146,7 @@ def test_models_edx_ui_seq_next_with_invalid_statement(old, new, event):
         UISeqNext(**invalid_event)
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqPrev,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(
-            NavigationalEventField, old=st.integers(1, 1), new=st.integers(0, 0)
-        ),
-    )
-)
+@custom_given(UISeqPrev)
 def test_models_edx_ui_seq_prev_with_valid_statement(statement):
     """Tests that a `seq_prev` statement has the expected `event_type` and `name`."""
 
@@ -222,18 +155,7 @@ def test_models_edx_ui_seq_prev_with_valid_statement(statement):
 
 
 @pytest.mark.parametrize("old,new", [("0", "10"), ("10", "0")])
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqPrev,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(
-            NavigationalEventField, old=st.integers(1, 1), new=st.integers(0, 0)
-        ),
-    )
-)
+@custom_given(UISeqPrev)
 def test_models_edx_ui_seq_prev_with_invalid_statement(old, new, event):
     """Tests that an invalid `seq_prev` event raises a ValidationError."""
 
@@ -247,18 +169,7 @@ def test_models_edx_ui_seq_prev_with_invalid_statement(old, new, event):
         UISeqPrev(**invalid_event)
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UISeqPrev,
-        context=st.builds(BaseContextField),
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(
-            NavigationalEventField, old=st.integers(1, 1), new=st.integers(0, 0)
-        ),
-    )
-)
+@custom_given(UISeqPrev)
 def test_models_edx_ui_seq_prev_selector_with_valid_statement(statement):
     """Tests given a `seq_prev` statement the selector `get_model` method should return
     `UISeqPrev` model.

--- a/tests/models/edx/test_server.py
+++ b/tests/models/edx/test_server.py
@@ -3,16 +3,15 @@
 import json
 
 import pytest
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
 
 from ralph.exceptions import UnknownEventException
-from ralph.models.edx.server import Server, ServerEventField
+from ralph.models.edx.server import Server
 from ralph.models.selector import ModelSelector
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(st.builds(Server, referer=provisional.urls(), event=st.builds(ServerEventField)))
+
+@custom_given(Server)
 def test_model_selector_server_get_model_with_valid_event(event):
     """Tests given a server statement, the get_model method should return the
     corresponding model.

--- a/tests/models/edx/test_textbook_interaction.py
+++ b/tests/models/edx/test_textbook_interaction.py
@@ -4,26 +4,11 @@ import json
 import re
 
 import pytest
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
 from ralph.models.edx.textbook_interaction.fields.events import (
-    BookEventField,
     TextbookInteractionBaseEventField,
     TextbookPdfChapterNavigatedEventField,
-    TextbookPdfDisplayScaledEventField,
-    TextbookPdfOutlineToggledEventField,
-    TextbookPdfPageNavigatedEventField,
-    TextbookPdfPageScrolledEventField,
-    TextbookPdfSearchCaseSensitivityToggledEventField,
-    TextbookPdfSearchExecutedEventField,
-    TextbookPdfSearchHighlightToggledEventField,
-    TextbookPdfSearchNavigatedNextEventField,
-    TextbookPdfThumbnailNavigatedEventField,
-    TextbookPdfThumbnailsToggledEventField,
-    TextbookPdfZoomButtonsChangedEventField,
-    TextbookPdfZoomMenuChangedEventField,
 )
 from ralph.models.edx.textbook_interaction.statements import (
     UIBook,
@@ -43,9 +28,10 @@ from ralph.models.edx.textbook_interaction.statements import (
 )
 from ralph.models.selector import ModelSelector
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(st.builds(TextbookInteractionBaseEventField))
+
+@custom_given(TextbookInteractionBaseEventField)
 def test_fields_edx_textbook_interaction_base_event_field_with_valid_content(field):
     """Tests that a valid `TextbookInteractionBaseEventField` does not raise
     a `ValidationError`.
@@ -92,8 +78,7 @@ def test_fields_edx_textbook_interaction_base_event_field_with_valid_content(fie
         ),
     ),
 )
-@settings(max_examples=1)
-@given(st.builds(TextbookInteractionBaseEventField))
+@custom_given(TextbookInteractionBaseEventField)
 def test_fields_edx_textbook_interaction_base_event_field_with_invalid_content(
     chapter, field
 ):
@@ -108,8 +93,7 @@ def test_fields_edx_textbook_interaction_base_event_field_with_invalid_content(
         TextbookInteractionBaseEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(st.builds(TextbookPdfChapterNavigatedEventField))
+@custom_given(TextbookPdfChapterNavigatedEventField)
 def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_valid_content(
     field,
 ):
@@ -154,8 +138,7 @@ def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_valid_conten
         ),
     ),
 )
-@settings(max_examples=1)
-@given(st.builds(TextbookPdfChapterNavigatedEventField))
+@custom_given(TextbookPdfChapterNavigatedEventField)
 def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_invalid_content(
     chapter, field
 ):
@@ -170,15 +153,7 @@ def test_fields_edx_textbook_pdf_chapter_navigated_event_field_with_invalid_cont
         TextbookPdfChapterNavigatedEventField(**invalid_field)
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIBook,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(BookEventField),
-    )
-)
+@custom_given(UIBook)
 def test_models_edx_ui_book_with_valid_statement(statement):
     """Tests that a `book` statement has the expected `event_type` and `name`."""
 
@@ -186,15 +161,7 @@ def test_models_edx_ui_book_with_valid_statement(statement):
     assert statement.name == "book"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UIBook,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(BookEventField),
-    )
-)
+@custom_given(UIBook)
 def test_models_edx_ui_book_selector_with_valid_statement(statement):
     """Tests given a `book` statement the selector `get_model` method should return
     `UIBook` model.
@@ -204,15 +171,7 @@ def test_models_edx_ui_book_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.edx").get_model(statement) is UIBook
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfThumbnailsToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfThumbnailsToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfThumbnailsToggled)
 def test_models_edx_ui_textbook_pdf_thumbnails_toggled_with_valid_statement(statement):
     """Tests that a `textbook.pdf.thumbnails.toggled` statement has the expected
     `event_type` and `name`.
@@ -222,15 +181,7 @@ def test_models_edx_ui_textbook_pdf_thumbnails_toggled_with_valid_statement(stat
     assert statement.name == "textbook.pdf.thumbnails.toggled"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfThumbnailsToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfThumbnailsToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfThumbnailsToggled)
 def test_models_edx_ui_textbook_pdf_thumbnails_toggled_selector_with_valid_statement(
     statement,
 ):
@@ -245,15 +196,7 @@ def test_models_edx_ui_textbook_pdf_thumbnails_toggled_selector_with_valid_state
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfThumbnailNavigated,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfThumbnailNavigatedEventField),
-    )
-)
+@custom_given(UITextbookPdfThumbnailNavigated)
 def test_models_edx_ui_textbook_pdf_thumbnail_navigated_with_valid_statement(
     statement,
 ):
@@ -265,15 +208,7 @@ def test_models_edx_ui_textbook_pdf_thumbnail_navigated_with_valid_statement(
     assert statement.name == "textbook.pdf.thumbnail.navigated"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfThumbnailNavigated,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfThumbnailNavigatedEventField),
-    )
-)
+@custom_given(UITextbookPdfThumbnailNavigated)
 def test_models_edx_ui_textbook_pdf_thumbnail_navigated_selector_with_valid_statement(
     statement,
 ):
@@ -288,15 +223,7 @@ def test_models_edx_ui_textbook_pdf_thumbnail_navigated_selector_with_valid_stat
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfOutlineToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfOutlineToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfOutlineToggled)
 def test_models_edx_ui_textbook_pdf_outline_toggled_with_valid_statement(
     statement,
 ):
@@ -308,15 +235,7 @@ def test_models_edx_ui_textbook_pdf_outline_toggled_with_valid_statement(
     assert statement.name == "textbook.pdf.outline.toggled"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfOutlineToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfOutlineToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfOutlineToggled)
 def test_models_edx_ui_textbook_pdf_outline_toggled_selector_with_valid_statement(
     statement,
 ):
@@ -331,15 +250,7 @@ def test_models_edx_ui_textbook_pdf_outline_toggled_selector_with_valid_statemen
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfChapterNavigated,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfChapterNavigatedEventField),
-    )
-)
+@custom_given(UITextbookPdfChapterNavigated)
 def test_models_edx_ui_textbook_pdf_chapter_navigated_with_valid_statement(
     statement,
 ):
@@ -351,15 +262,7 @@ def test_models_edx_ui_textbook_pdf_chapter_navigated_with_valid_statement(
     assert statement.name == "textbook.pdf.chapter.navigated"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfChapterNavigated,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfChapterNavigatedEventField),
-    )
-)
+@custom_given(UITextbookPdfChapterNavigated)
 def test_models_edx_ui_textbook_pdf_chapter_navigated_selector_with_valid_statement(
     statement,
 ):
@@ -374,15 +277,7 @@ def test_models_edx_ui_textbook_pdf_chapter_navigated_selector_with_valid_statem
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfPageNavigated,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfPageNavigatedEventField),
-    )
-)
+@custom_given(UITextbookPdfPageNavigated)
 def test_models_edx_ui_textbook_pdf_page_navigated_with_valid_statement(
     statement,
 ):
@@ -394,15 +289,7 @@ def test_models_edx_ui_textbook_pdf_page_navigated_with_valid_statement(
     assert statement.name == "textbook.pdf.page.navigated"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfPageNavigated,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfPageNavigatedEventField),
-    )
-)
+@custom_given(UITextbookPdfPageNavigated)
 def test_models_edx_ui_textbook_pdf_page_navigated_selector_with_valid_statement(
     statement,
 ):
@@ -417,15 +304,7 @@ def test_models_edx_ui_textbook_pdf_page_navigated_selector_with_valid_statement
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfZoomButtonsChanged,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfZoomButtonsChangedEventField),
-    )
-)
+@custom_given(UITextbookPdfZoomButtonsChanged)
 def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_with_valid_statement(
     statement,
 ):
@@ -437,15 +316,7 @@ def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_with_valid_statement(
     assert statement.name == "textbook.pdf.zoom.buttons.changed"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfZoomButtonsChanged,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfZoomButtonsChangedEventField),
-    )
-)
+@custom_given(UITextbookPdfZoomButtonsChanged)
 def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_selector_with_valid_statement(
     statement,
 ):
@@ -460,15 +331,7 @@ def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_selector_with_valid_sta
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfZoomMenuChanged,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfZoomMenuChangedEventField),
-    )
-)
+@custom_given(UITextbookPdfZoomMenuChanged)
 def test_models_edx_ui_textbook_pdf_zoom_menu_changed_with_valid_statement(statement):
     """Tests that a `textbook.pdf.zoom.menu.changed` has the expected `event_type` and
     `name`.
@@ -478,15 +341,7 @@ def test_models_edx_ui_textbook_pdf_zoom_menu_changed_with_valid_statement(state
     assert statement.name == "textbook.pdf.zoom.menu.changed"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfZoomMenuChanged,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfZoomMenuChangedEventField),
-    )
-)
+@custom_given(UITextbookPdfZoomMenuChanged)
 def test_models_edx_ui_textbook_pdf_zoom_menu_changed_selector_with_valid_statement(
     statement,
 ):
@@ -501,15 +356,7 @@ def test_models_edx_ui_textbook_pdf_zoom_menu_changed_selector_with_valid_statem
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfDisplayScaled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfDisplayScaledEventField),
-    )
-)
+@custom_given(UITextbookPdfDisplayScaled)
 def test_models_edx_ui_textbook_pdf_display_scaled_with_valid_statement(statement):
     """Tests that a `textbook.pdf.display.scaled` statement has the expected
     `event_type` and `name`.
@@ -519,15 +366,7 @@ def test_models_edx_ui_textbook_pdf_display_scaled_with_valid_statement(statemen
     assert statement.name == "textbook.pdf.display.scaled"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfDisplayScaled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfDisplayScaledEventField),
-    )
-)
+@custom_given(UITextbookPdfDisplayScaled)
 def test_models_edx_ui_textbook_pdf_display_scaled_selector_with_valid_statement(
     statement,
 ):
@@ -542,15 +381,7 @@ def test_models_edx_ui_textbook_pdf_display_scaled_selector_with_valid_statement
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfPageScrolled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfPageScrolledEventField),
-    )
-)
+@custom_given(UITextbookPdfPageScrolled)
 def test_models_edx_ui_textbook_pdf_page_scrolled_with_valid_statement(statement):
     """Tests that a `textbook.pdf.page.scrolled` statement has the expected `event_type`
     and `name`.
@@ -560,15 +391,7 @@ def test_models_edx_ui_textbook_pdf_page_scrolled_with_valid_statement(statement
     assert statement.name == "textbook.pdf.page.scrolled"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfPageScrolled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfPageScrolledEventField),
-    )
-)
+@custom_given(UITextbookPdfPageScrolled)
 def test_models_edx_ui_textbook_pdf_page_scrolled_selector_with_valid_statement(
     statement,
 ):
@@ -583,15 +406,7 @@ def test_models_edx_ui_textbook_pdf_page_scrolled_selector_with_valid_statement(
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchExecuted,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchExecutedEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchExecuted)
 def test_models_edx_ui_textbook_pdf_search_executed_with_valid_statement(statement):
     """Tests that a `textbook.pdf.search.executed` statement has the expected
     `event_type` and `name`.
@@ -601,15 +416,7 @@ def test_models_edx_ui_textbook_pdf_search_executed_with_valid_statement(stateme
     assert statement.name == "textbook.pdf.search.executed"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchExecuted,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchExecutedEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchExecuted)
 def test_models_edx_ui_textbook_pdf_search_executed_selector_with_valid_statement(
     statement,
 ):
@@ -624,15 +431,7 @@ def test_models_edx_ui_textbook_pdf_search_executed_selector_with_valid_statemen
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchNavigatedNext,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchNavigatedNextEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchNavigatedNext)
 def test_models_edx_ui_textbook_pdf_search_navigated_next_with_valid_statement(
     statement,
 ):
@@ -644,15 +443,7 @@ def test_models_edx_ui_textbook_pdf_search_navigated_next_with_valid_statement(
     assert statement.name == "textbook.pdf.search.navigatednext"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchNavigatedNext,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchNavigatedNextEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchNavigatedNext)
 def test_models_edx_ui_textbook_pdf_search_navigated_next_selector_with_valid_statement(
     statement,
 ):
@@ -667,15 +458,7 @@ def test_models_edx_ui_textbook_pdf_search_navigated_next_selector_with_valid_st
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchHighlightToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchHighlightToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchHighlightToggled)
 def test_models_edx_ui_textbook_pdf_search_highlight_toggled_with_valid_statement(
     statement,
 ):
@@ -688,15 +471,7 @@ def test_models_edx_ui_textbook_pdf_search_highlight_toggled_with_valid_statemen
 
 
 # pylint: disable=line-too-long
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchHighlightToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchHighlightToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchHighlightToggled)
 def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid_statement(  # noqa
     statement,
 ):
@@ -712,15 +487,7 @@ def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid
 
 
 # pylint: disable=line-too-long
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchCaseSensitivityToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchCaseSensitivityToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchCaseSensitivityToggled)
 def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_statement(  # noqa
     statement,
 ):
@@ -733,15 +500,7 @@ def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_s
 
 
 # pylint: disable=line-too-long
-@settings(max_examples=1)
-@given(
-    st.builds(
-        UITextbookPdfSearchCaseSensitivityToggled,
-        referer=provisional.urls(),
-        page=provisional.urls(),
-        event=st.builds(TextbookPdfSearchCaseSensitivityToggledEventField),
-    )
-)
+@custom_given(UITextbookPdfSearchCaseSensitivityToggled)
 def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_selector_with_valid_statement(  # noqa
     statement,
 ):

--- a/tests/models/test_converter.py
+++ b/tests/models/test_converter.py
@@ -5,8 +5,7 @@ import logging
 from typing import Any, Optional
 
 import pytest
-from hypothesis import HealthCheck, given, provisional, settings
-from hypothesis import strategies as st
+from hypothesis import HealthCheck, settings
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
 
@@ -25,6 +24,8 @@ from ralph.models.converter import (
 from ralph.models.edx.converters.xapi.base import BaseConversionSet
 from ralph.models.edx.navigational.statements import UIPageClose
 from ralph.models.xapi.constants import VERB_TERMINATED_ID
+
+from tests.fixtures.hypothesis_strategies import custom_given
 
 
 @pytest.mark.parametrize(
@@ -386,10 +387,10 @@ def test_converter_convert_with_invalid_page_close_event_raises_an_exception(
             list(result)
 
 
-@settings(max_examples=1, suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 @pytest.mark.parametrize("invalid_platform_url", ["", "not an URL"])
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIPageClose)
 def test_converter_convert_with_invalid_arguments_writes_an_error_message(
     valid_uuid, invalid_platform_url, caplog, event
 ):
@@ -408,10 +409,10 @@ def test_converter_convert_with_invalid_arguments_writes_an_error_message(
     assert errors == [message for _, _, message in caplog.record_tuples]
 
 
-@settings(max_examples=1, suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 @pytest.mark.parametrize("invalid_platform_url", ["", "not an URL"])
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIPageClose)
 def test_converter_convert_with_invalid_arguments_raises_an_exception(
     valid_uuid, invalid_platform_url, caplog, event
 ):
@@ -428,11 +429,10 @@ def test_converter_convert_with_invalid_arguments_raises_an_exception(
             list(result)
 
 
-@settings(max_examples=1)
 @pytest.mark.parametrize("ignore_errors", [True, False])
 @pytest.mark.parametrize("fail_on_unknown", [True, False])
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIPageClose)
 def test_converter_convert_with_valid_events(
     ignore_errors, fail_on_unknown, valid_uuid, event
 ):
@@ -445,8 +445,8 @@ def test_converter_convert_with_valid_events(
     assert json.loads(next(result))["verb"]["id"] == VERB_TERMINATED_ID.__args__[0]
 
 
-@settings(max_examples=1, suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@custom_given(UIPageClose)
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 def test_converter_convert_counter(valid_uuid, caplog, event):
     """Tests given multiple events the convert method should log the total and invalid

--- a/tests/models/test_converter.py
+++ b/tests/models/test_converter.py
@@ -405,8 +405,9 @@ def test_converter_convert_with_invalid_arguments_writes_an_error_message(
     with caplog.at_level(logging.ERROR):
         assert not list(result)
     model_name = "<class 'ralph.models.xapi.navigation.statements.PageTerminated'>"
-    errors = [f"Converted event is not a valid ({model_name}) model"]
-    assert errors == [message for _, _, message in caplog.record_tuples]
+    errors = f"Converted event is not a valid ({model_name}) model"
+    for _, _, message in caplog.record_tuples:
+        assert errors == message
 
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))

--- a/tests/models/test_validator.py
+++ b/tests/models/test_validator.py
@@ -5,14 +5,15 @@ import json
 import logging
 
 import pytest
-from hypothesis import HealthCheck, given, provisional, settings
-from hypothesis import strategies as st
+from hypothesis import HealthCheck, settings
 
 from ralph.exceptions import BadFormatException, UnknownEventException
 from ralph.models.edx.navigational.statements import UIPageClose
-from ralph.models.edx.server import Server, ServerEventField
+from ralph.models.edx.server import Server
 from ralph.models.selector import ModelSelector
 from ralph.models.validator import Validator
+
+from tests.fixtures.hypothesis_strategies import custom_given
 
 
 def test_models_validator_validate_with_no_events(caplog):
@@ -146,10 +147,9 @@ def test_models_validator_validate_with_invalid_page_close_event_raises_an_excep
             list(result)
 
 
-@settings(max_examples=1)
 @pytest.mark.parametrize("ignore_errors", [True, False])
 @pytest.mark.parametrize("fail_on_unknown", [True, False])
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@custom_given(UIPageClose)
 def test_models_validator_validate_with_valid_events(
     ignore_errors, fail_on_unknown, event
 ):
@@ -162,8 +162,8 @@ def test_models_validator_validate_with_valid_events(
     assert json.loads(next(result)) == event_dict
 
 
-@settings(max_examples=1, suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(st.builds(UIPageClose, referer=provisional.urls(), page=provisional.urls()))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@custom_given(UIPageClose)
 def test_models_validator_validate_counter(caplog, event):
     """Tests given multiple events the validate method
     should log the total and invalid events."""
@@ -184,8 +184,7 @@ def test_models_validator_validate_counter(caplog, event):
     ) in caplog.record_tuples
 
 
-@settings(max_examples=1)
-@given(st.builds(Server, referer=provisional.urls(), event=st.builds(ServerEventField)))
+@custom_given(Server)
 def test_models_validator_validate_typing_cleanup(event):
     """Tests given a valid event with wrong field types, the validate method should fix
     them.

--- a/tests/models/xapi/fields/test_actors.py
+++ b/tests/models/xapi/fields/test_actors.py
@@ -1,11 +1,11 @@
 """Tests for the xAPI actor fields"""
 
-from ralph.models.xapi.fields.actors import ActorField
+from ralph.models.xapi.fields.actors import AccountActorField
 
 from tests.fixtures.hypothesis_strategies import custom_given
 
 
-@custom_given(ActorField)
+@custom_given(AccountActorField)
 def test_models_xapi_fields_actor_account_field_with_valid_content(actor):
     """Tests that an actor field contains an account field."""
 

--- a/tests/models/xapi/fields/test_actors.py
+++ b/tests/models/xapi/fields/test_actors.py
@@ -1,20 +1,11 @@
 """Tests for the xAPI actor fields"""
 
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
+from ralph.models.xapi.fields.actors import ActorField
 
-from ralph.models.xapi.fields.actors import ActorAccountField, ActorField
+from tests.fixtures.hypothesis_strategies import custom_given
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        ActorField,
-        account=st.builds(
-            ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-        ),
-    )
-)
+@custom_given(ActorField)
 def test_models_xapi_fields_actor_account_field_with_valid_content(actor):
     """Tests that an actor field contains an account field."""
 

--- a/tests/models/xapi/fields/test_actors.py
+++ b/tests/models/xapi/fields/test_actors.py
@@ -15,7 +15,7 @@ from ralph.models.xapi.fields.actors import ActorAccountField, ActorField
         ),
     )
 )
-def test_models_xapi_fields_actor_actor_field_with_valid_content(actor):
+def test_models_xapi_fields_actor_account_field_with_valid_content(actor):
     """Tests that an actor field contains an account field."""
 
     assert hasattr(actor.account, "name")

--- a/tests/models/xapi/fields/test_common.py
+++ b/tests/models/xapi/fields/test_common.py
@@ -1,0 +1,128 @@
+"""Tests for common xAPI fields"""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from ralph.models.xapi.fields.common import IRI, LanguageMap, LanguageTag
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        ({"iri": "http://localhost/foo/bar"}),
+        ({"iri": "http://www.greek-one-half-sign-alternate-form.org/\U00010176"}),
+    ],
+)
+def test_models_xapi_fields_common_field_iri_with_valid_data(values):
+    """Tests that a valid verb field does not raise a `ValidationError`."""
+
+    class DummyIRIModel(BaseModel):
+        """A dummy pydantic model with an IRI field."""
+
+        iri: IRI
+
+    try:
+        DummyIRIModel(**values)
+    except ValidationError as err:
+        pytest.fail(f"Valid IRI should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize(
+    "values,error",
+    [
+        ({"iri": None}, "none is not an allowed value"),
+        ({"iri": {}}, "expected string"),
+        ({"iri": ""}, "not a valid 'IRI'"),
+        ({"iri": "localhost/foo/bar"}, "not a valid 'IRI'"),
+        ({"iri": "http://foo/<bar>"}, "not a valid 'IRI'"),
+    ],
+)
+def test_models_xapi_fields_common_field_iri_with_invalid_data(values, error):
+    """Tests that an invalid verb field raises a `ValidationError`."""
+
+    class DummyIRIModel(BaseModel):
+        """A dummy pydantic model with an IRI field."""
+
+        iri: IRI
+
+    with pytest.raises(ValidationError, match=error):
+        DummyIRIModel(**values)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        ({"tag": "en"}),
+        ({"tag": "fr"}),
+        ({"tag": "en-US"}),
+    ],
+)
+def test_models_xapi_fields_common_field_language_tag_with_valid_data(values):
+    """Tests that a valid verb field does not raise a `ValidationError`."""
+
+    class DummyLanguageTagModel(BaseModel):
+        """A dummy pydantic model with a LanguageTag field."""
+
+        tag: LanguageTag
+
+    try:
+        DummyLanguageTagModel(**values)
+    except ValidationError as err:
+        pytest.fail(f"Valid IRI should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize(
+    "values,error",
+    [
+        ({"tag": None}, "none is not an allowed value"),
+        ({"tag": {}}, "unhashable type: 'dict'"),
+        ({"tag": ""}, "Invalid RFC 5646 Language tag"),
+        ({"tag": "en-US-en"}, "Invalid RFC 5646 Language tag"),
+    ],
+)
+def test_models_xapi_fields_common_field_language_tag_with_invalid_data(values, error):
+    """Tests that an invalid verb field raises a `ValidationError`."""
+
+    class DummyLanguageTagModel(BaseModel):
+        """A dummy pydantic model with a LanguageTag field."""
+
+        tag: LanguageTag
+
+    with pytest.raises(ValidationError, match=error):
+        DummyLanguageTagModel(**values)
+
+
+@pytest.mark.parametrize("values", [({"map": {"en": "Hello"}})])
+def test_models_xapi_fields_common_field_language_map_with_valid_data(values):
+    """Tests that a valid verb field does not raise a `ValidationError`."""
+
+    class DummyLanguageMapModel(BaseModel):
+        """A dummy pydantic model with a LanguageTag field."""
+
+        map: LanguageMap
+
+    try:
+        DummyLanguageMapModel(**values)
+    except ValidationError as err:
+        pytest.fail(f"Valid LanguageMap should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize(
+    "values,error",
+    [
+        ({"map": None}, "none is not an allowed value"),
+        ({"map": "en-US-en"}, "value is not a valid dict"),
+        ({"map": {"en-US-en": 1}}, "Invalid RFC 5646 Language tag"),
+        ({"map": {"en-US": []}}, "en-US\n  str type expected"),
+    ],
+)
+def test_models_xapi_fields_common_field_language_map_with_invalid_data(values, error):
+    """Tests that an invalid verb field raises a `ValidationError`."""
+
+    class DummyLanguageTagModel(BaseModel):
+        """A dummy pydantic model with a LanguageTag field."""
+
+        map: LanguageMap
+
+    with pytest.raises(ValidationError, match=error):
+        DummyLanguageTagModel(**values)

--- a/tests/models/xapi/fields/test_objects.py
+++ b/tests/models/xapi/fields/test_objects.py
@@ -1,13 +1,11 @@
 """Tests for the xAPI object fields"""
 
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
-
 from ralph.models.xapi.navigation.fields.objects import PageObjectField
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(st.builds(PageObjectField, id=provisional.urls()))
+
+@custom_given(PageObjectField)
 def test_models_xapi_fields_object_page_object_field(field):
     """Tests that a page object field contains a definition with the expected values."""
 

--- a/tests/models/xapi/fields/test_objects.py
+++ b/tests/models/xapi/fields/test_objects.py
@@ -12,4 +12,4 @@ def test_models_xapi_fields_object_page_object_field(field):
     """Tests that a page object field contains a definition with the expected values."""
 
     assert field.definition.type == "http://activitystrea.ms/schema/1.0/page"
-    assert field.definition.name == {"en": "page"}
+    assert field.definition.name == {"en-US": "page"}

--- a/tests/models/xapi/fields/test_verbs.py
+++ b/tests/models/xapi/fields/test_verbs.py
@@ -5,19 +5,19 @@ import json
 from ralph.models.xapi.fields.verbs import TerminatedVerbField, ViewedVerbField
 
 
-def test_models_xapi_fields_verb_page_viewed_verb_field():
-    """Tests that the PageViewedVerbField returns the expected dictionary."""
+def test_models_xapi_fields_verb_viewed_verb_field():
+    """Tests that the ViewedVerbField returns the expected dictionary."""
 
     assert json.loads(ViewedVerbField().json()) == {
         "id": "http://id.tincanapi.com/verb/viewed",
-        "display": {"en": "viewed"},
+        "display": {"en-US": "viewed"},
     }
 
 
-def test_models_xapi_fields_verb_page_terminated_verb_field():
-    """Tests that the PageTerminatedVerbField returns the expected dictionary."""
+def test_models_xapi_fields_verb_terminated_verb_field():
+    """Tests that the TerminatedVerbField returns the expected dictionary."""
 
     assert json.loads(TerminatedVerbField().json()) == {
         "id": "http://adlnet.gov/expapi/verbs/terminated",
-        "display": {"en": "terminated"},
+        "display": {"en-US": "terminated"},
     }

--- a/tests/models/xapi/test_base.py
+++ b/tests/models/xapi/test_base.py
@@ -1,0 +1,510 @@
+"""Tests for the BaseXapiModel"""
+
+import pytest
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from ralph.models.selector import ModelSelector
+from ralph.models.xapi.base import BaseXapiModel
+from ralph.models.xapi.fields.actors import (
+    AccountActorField,
+    AccountGroupActorField,
+    AnonymousGroupActorField,
+    MboxGroupActorField,
+    MboxSha1SumGroupActorField,
+    OpenIdGroupActorField,
+)
+from ralph.models.xapi.fields.objects import SubStatementObjectField
+from ralph.models.xapi.fields.unnested_objects import (
+    ActivityObjectField,
+    InteractionObjectDefinitionField,
+    StatementRefObjectField,
+)
+from ralph.models.xapi.video.statements import BaseVideoStatement
+from ralph.utils import set_dict_value_from_path
+
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["id", "stored", "verb__display", "context__contextActivities__parent"],
+)
+@pytest.mark.parametrize("value", [None, "", {}])
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_with_invalid_null_values(path, value, statement):
+    """Tests that the statement does not accept any null values.
+
+    XAPI-00001
+    An LRS rejects with error code 400 Bad Request any Statement having a property whose
+    value is set to "null", an empty object, or has no value, except in an "extensions"
+    property
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    with pytest.raises(ValidationError, match="invalid empty value"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "object__definition__extensions__https://w3id.org/xapi/video",
+        "result__extensions__https://w3id.org/xapi/video",
+        "context__extensions__https://w3id.org/xapi/video",
+    ],
+)
+@pytest.mark.parametrize("value", [None, "", {}])
+@custom_given(custom_builds(BaseXapiModel, object=custom_builds(ActivityObjectField)))
+def test_models_xapi_base_statement_with_valid_null_values(path, value, statement):
+    """Tests that the statement does accept valid null values in extensions fields.
+
+    XAPI-00001
+    An LRS rejects with error code 400 Bad Request any Statement having a property whose
+    value is set to "null", an empty object, or has no value, except in an "extensions"
+    property
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    try:
+        BaseXapiModel(**statement)
+    except ValidationError as err:
+        pytest.fail(f"Valid statement should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize("path", ["object__definition__correctResponsesPattern"])
+@custom_given(
+    custom_builds(
+        BaseXapiModel,
+        object=custom_builds(
+            ActivityObjectField,
+            definition=custom_builds(InteractionObjectDefinitionField),
+        ),
+    )
+)
+def test_models_xapi_base_statement_with_valid_empty_array(path, statement):
+    """Tests that the statement does accept a valid empty array.
+
+    Where the Correct Responses Pattern contains an empty array, the meaning of this is
+    that there is no correct answer.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), [])
+    try:
+        BaseXapiModel(**statement)
+    except ValidationError as err:
+        pytest.fail(f"Valid statement should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["actor", "verb", "object"],
+)
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_must_use_actor_verb_and_object(field, statement):
+    """Tests that the statement raises an exception if required fields are missing.
+
+    XAPI-00003
+    An LRS rejects with error code 400 Bad Request a Statement which does not contain an
+    "actor" property
+    XAPI-00004
+    An LRS rejects with error code 400 Bad Request a Statement which does not contain a
+    "verb" property
+    XAPI-00005
+    An LRS rejects with error code 400 Bad Request a Statement which does not contain an
+    "object" property
+    """
+
+    statement = statement.dict(exclude_none=True)
+    del statement[field]
+    with pytest.raises(ValidationError, match="field required"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        ("actor__name", 1),  # Should be a string
+        ("actor__account__name", 1),  # Should be a string
+        ("actor__account__homePage", 1),  # Should be an IRI
+        ("actor__account", ["foo", "bar"]),  # Should be a dictionary
+        ("verb__display", ["foo"]),  # Should be a dictionary
+        ("verb__display", {"en": 1}),  # Should have string values
+        ("object__id", ["foo"]),  # Should be an IRI
+    ],
+)
+@custom_given(custom_builds(BaseXapiModel, actor=custom_builds(AccountActorField)))
+def test_models_xapi_base_statement_with_invalid_data_types(path, value, statement):
+    """Tests that the statement does not accept values with wrong types.
+
+    XAPI-00006
+    An LRS rejects with error code 400 Bad Request a Statement which uses the wrong data
+    type
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    err = "(type expected|not a valid dict|expected string )"
+    with pytest.raises(ValidationError, match=err):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        ("id", "0545fe73-1bbd-4f84-9c9a"),  # Should be a valid UUID
+        ("actor", {"mbox": "example@mail.com"}),  # Should be a Mailto IRI
+        ("verb__display", {"bad language tag": "foo"}),  # Should be a valid LanguageTag
+        ("object__id", ["This is not an IRI"]),  # Should be an IRI
+    ],
+)
+@custom_given(custom_builds(BaseXapiModel, actor=custom_builds(AccountActorField)))
+def test_models_xapi_base_statement_with_invalid_data_format(path, value, statement):
+    """Tests that the statement does not accept values having a wrong format.
+
+    XAPI-00007
+    An LRS rejects with error code 400 Bad Request a Statement which uses any
+    non-format-following key or value, including the empty string, where a string with a
+    particular format (such as mailto IRI, UUID, or IRI) is required.
+    (Empty strings are covered by XAPI-00001)
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    err = "(Invalid `mailto:email`|Invalid RFC 5646 Language tag|not a valid uuid)"
+    with pytest.raises(ValidationError, match=err):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize("path,value", [("actor__objecttype", "Agent")])
+@custom_given(custom_builds(BaseXapiModel, actor=custom_builds(AccountActorField)))
+def test_models_xapi_base_statement_with_invalid_letter_cases(path, value, statement):
+    """Tests that the statement does not accept keys having invalid letter cases.
+
+    XAPI-00008
+    An LRS rejects with error code 400 Bad Request a Statement where the case of a key
+    does not match the case specified in this specification.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    if statement["actor"].get("objectType", None):
+        del statement["actor"]["objectType"]
+    set_dict_value_from_path(statement, path.split("__"), value)
+    err = "(unexpected value|extra fields not permitted)"
+    with pytest.raises(ValidationError, match=err):
+        BaseXapiModel(**statement)
+
+
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_should_not_accept_additional_properies(statement):
+    """Tests that the statement does not accept additional properties.
+
+    XAPI-00010
+    An LRS rejects with error code 400 Bad Request a Statement where a key or value is
+    not allowed by this specification.
+    """
+
+    invalid_statement = statement.dict(exclude_none=True)
+    invalid_statement["NEW_INVALID_FIELD"] = "some value"
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
+        BaseXapiModel(**invalid_statement)
+
+
+@pytest.mark.parametrize("path,value", [("object__id", "w3id.org/xapi/video")])
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_with_iri_wihout_scheme(path, value, statement):
+    """Tests that the statement does not accept IRIs without a scheme.
+
+    XAPI-00011
+    An LRS rejects with error code 400 Bad Request a Statement containing IRL or IRI
+    values without a scheme.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    with pytest.raises(ValidationError, match="is not a valid 'IRI'"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "object__definition__extensions__foo",
+        "result__extensions__1",
+        "context__extensions__w3id.org/xapi/video",
+    ],
+)
+@custom_given(custom_builds(BaseXapiModel, object=custom_builds(ActivityObjectField)))
+def test_models_xapi_base_statement_with_invalid_extensions(path, statement):
+    """Tests that the statement does not accept extensions keys with invalid IRIs.
+
+    XAPI-00118
+    An Extension "key" is an IRI. The LRS rejects with 400 a statement which has an
+    extension key which is not a valid IRI, if an extension object is present.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), "")
+    with pytest.raises(ValidationError, match="is not a valid 'IRI'"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize("path,value", [("actor__mbox", "mailto:example@mail.com")])
+@custom_given(custom_builds(BaseXapiModel, actor=custom_builds(AccountActorField)))
+def test_models_xapi_base_statement_with_two_agent_types(path, value, statement):
+    """Tests that the statement does not accept multiple agent types.
+
+    An Agent MUST NOT include more than one Inverse Functional Identifier.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
+        BaseXapiModel(**statement)
+
+
+@custom_given(
+    custom_builds(BaseXapiModel, actor=custom_builds(AnonymousGroupActorField))
+)
+def test_models_xapi_base_statement_missing_member_property(statement):
+    """Tests that the statement does not accept group agents with missing members.
+
+    An Anonymous Group MUST include a "member" property listing constituent Agents.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    del statement["actor"]["member"]
+    with pytest.raises(ValidationError, match="member\n  field required"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        AnonymousGroupActorField,
+        MboxGroupActorField,
+        MboxSha1SumGroupActorField,
+        OpenIdGroupActorField,
+        AccountGroupActorField,
+    ],
+)
+@custom_given(
+    st.one_of(
+        custom_builds(BaseXapiModel, actor=custom_builds(AnonymousGroupActorField)),
+        custom_builds(BaseXapiModel, actor=custom_builds(MboxGroupActorField)),
+        custom_builds(BaseXapiModel, actor=custom_builds(MboxSha1SumGroupActorField)),
+        custom_builds(BaseXapiModel, actor=custom_builds(OpenIdGroupActorField)),
+        custom_builds(BaseXapiModel, actor=custom_builds(AccountGroupActorField)),
+    ),
+    st.data(),
+)
+def test_models_xapi_base_statement_with_invalid_group_objects(value, statement, data):
+    """Tests that the statement does not accept group agents with group members.
+
+    An Anonymous Group MUST NOT contain Group Objects in the "member" identifiers.
+    An Identified Group MUST NOT contain Group Objects in the "member" property.
+    """
+
+    kwargs = {"exclude_none": True}
+    statement = statement.dict(**kwargs)
+    statement["actor"]["member"] = [data.draw(custom_builds(value)).dict(**kwargs)]
+    err = "actor -> member -> 0 -> objectType\n  unexpected value; permitted: 'Agent'"
+    with pytest.raises(ValidationError, match=err):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize("path,value", [("actor__mbox", "mailto:example@mail.com")])
+@custom_given(custom_builds(BaseXapiModel, actor=custom_builds(AccountGroupActorField)))
+def test_models_xapi_base_statement_with_two_group_identifiers(path, value, statement):
+    """Tests that the statement does not accept multiple group identifiers.
+
+    An Identified Group MUST include exactly one Inverse Functional Identifier.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        ("object__id", "156e3f9f-4b56-4cba-ad52-1bd19e461d65"),
+        ("object__stored", "2013-05-18T05:32:34.804+00:00"),
+        ("object__version", "1.0.0"),
+        ("object__authority", {"mbox": "mailto:example@mail.com"}),
+    ],
+)
+@custom_given(
+    custom_builds(BaseXapiModel, object=custom_builds(SubStatementObjectField))
+)
+def test_models_xapi_base_statement_with_sub_statement_ref(path, value, statement):
+    """Tests that the sub-statement does not accept invalid properties.
+
+    A SubStatement MUST NOT have the "id", "stored", "version" or "authority"
+    properties.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [{"id": "invalid whitespace"}],
+        [{"id": "valid"}, {"id": "invalid whitespace"}],
+        [{"id": "invalid_dublicate"}, {"id": "invalid_dublicate"}],
+    ],
+)
+@custom_given(
+    custom_builds(
+        BaseXapiModel,
+        object=custom_builds(
+            ActivityObjectField,
+            definition=custom_builds(InteractionObjectDefinitionField),
+        ),
+    )
+)
+def test_models_xapi_base_statement_with_invalid_interaction_object(value, statement):
+    """Tests that the statement does not accept invalid interaction fields.
+
+    An interaction component's id value SHOULD NOT have whitespace.
+    Within an array of interaction components, all id values MUST be distinct.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    path = "object.definition.scale".split(".")
+    set_dict_value_from_path(statement, path, value)
+    err = "(Duplicate InteractionComponents are not valid|string does not match regex)"
+    with pytest.raises(ValidationError, match=err):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        ("context__revision", "Format is free"),
+        ("context__platform", "FUN MOOC"),
+    ],
+)
+@custom_given(
+    st.one_of(
+        custom_builds(BaseXapiModel, object=custom_builds(SubStatementObjectField)),
+        custom_builds(BaseXapiModel, object=custom_builds(StatementRefObjectField)),
+    ),
+)
+def test_models_xapi_base_statement_with_invalid_context_value(path, value, statement):
+    """Tests that the statement does not accept an invalid revision/platform value.
+
+    The "revision" property MUST only be used if the Statement's Object is an Activity.
+    The "platform" property MUST only be used if the Statement's Object is an Activity.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("__"), value)
+    err = "properties can only be used if the Statement's Object is an Activity"
+    with pytest.raises(ValidationError, match=err):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize("path", [("context.contextActivities.not_parent")])
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_with_invalid_context_activities(path, statement):
+    """Tests that the statement does not accept invalid context activity properties.
+
+    Every key in the contextActivities Object MUST be one of parent, grouping, category,
+    or other.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, path.split("."), {"id": "http://w3id.org/xapi"})
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
+        BaseXapiModel(**statement)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"id": "http://w3id.org/xapi"},
+        [{"id": "http://w3id.org/xapi"}],
+        [{"id": "http://w3id.org/xapi"}, {"id": "http://w3id.org/xapi/video"}],
+    ],
+)
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_with_valid_context_activities(value, statement):
+    """Tests that the statement does accept valid context activities fields.
+
+    Every value in the contextActivities Object MUST be either a single Activity Object
+    or an array of Activity Objects.
+    """
+
+    statement = statement.dict(exclude_none=True)
+    path = ["context", "contextActivities"]
+    for activity in ["parent", "grouping", "category", "other"]:
+        set_dict_value_from_path(statement, path + [activity], value)
+    try:
+        BaseXapiModel(**statement)
+    except ValidationError as err:
+        pytest.fail(f"Valid statement should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize("value", ["0.0.0", "1.1.0", "1", "2", "1.10.1", "1.0.1.1"])
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_with_invalid_version(value, statement):
+    """Tests that the statement does not accept an invalid version field.
+
+    An LRS MUST reject all Statements with a version specified that does not start with
+    1.0..
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, ["version"], value)
+    with pytest.raises(ValidationError, match="version\n  string does not match regex"):
+        BaseXapiModel(**statement)
+
+
+@custom_given(BaseXapiModel)
+def test_models_xapi_base_statement_with_valid_version(statement):
+    """Tests that the statement does accept a valid version field.
+
+    Statements returned by an LRS MUST retain the version they are accepted with.
+    If they lack a version, the version MUST be set to 1.0.0
+    """
+
+    statement = statement.dict(exclude_none=True)
+    set_dict_value_from_path(statement, ["version"], "1.0.3")
+    assert "1.0.3" == BaseXapiModel(**statement).dict()["version"]
+    del statement["version"]
+    assert "1.0.0" == BaseXapiModel(**statement).dict()["version"]
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        model
+        for model in ModelSelector("ralph.models.xapi").model_rules.keys()
+        # We have to bypass Video Statements in this test because we want to support
+        # invalid values (non IRI keys) in their extension fields.
+        if not issubclass(model, BaseVideoStatement)
+    ],
+)
+@custom_given(st.data())
+def test_models_xapi_base_statement_should_consider_valid_all_defined_xapi_models(
+    model, data
+):
+    """Tests that all defined xAPI models in the ModelSelector make valid statements."""
+
+    # All specific xAPI models should inherit BaseXapiModel
+    assert issubclass(model, BaseXapiModel)
+    statement = data.draw(custom_builds(model)).dict(exclude_none=True)
+    try:
+        BaseXapiModel(**statement)
+    except ValidationError as err:
+        pytest.fail(f"Specific xAPI models should be valid BaseXapiModels: {err}")

--- a/tests/models/xapi/test_navigation.py
+++ b/tests/models/xapi/test_navigation.py
@@ -2,28 +2,13 @@
 
 import json
 
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
-
 from ralph.models.selector import ModelSelector
-from ralph.models.xapi.fields.actors import ActorAccountField, ActorField
-from ralph.models.xapi.navigation.fields.objects import PageObjectField
 from ralph.models.xapi.navigation.statements import PageTerminated, PageViewed
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        PageTerminated,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(PageObjectField, id=provisional.urls()),
-    )
-)
+
+@custom_given(PageTerminated)
 def test_models_xapi_page_terminated_statement(statement):
     """Tests that a page_terminated statement has the expected verb.id and
     object.definition.
@@ -33,19 +18,7 @@ def test_models_xapi_page_terminated_statement(statement):
     assert statement.object.definition.type == "http://activitystrea.ms/schema/1.0/page"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        PageTerminated,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(PageObjectField, id=provisional.urls()),
-    )
-)
+@custom_given(PageTerminated)
 def test_models_xapi_page_terminated_selector_with_valid_statement(statement):
     """Tests given a page terminated statement, the get_model method should return
     PageTerminated model.
@@ -57,19 +30,7 @@ def test_models_xapi_page_terminated_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        PageViewed,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(PageObjectField, id=provisional.urls()),
-    )
-)
+@custom_given(PageViewed)
 def test_models_xapi_page_viewed_statement(statement):
     """Tests that a page_viewed statement has the expected verb.id and
     object.definition.
@@ -79,19 +40,7 @@ def test_models_xapi_page_viewed_statement(statement):
     assert statement.object.definition.type == "http://activitystrea.ms/schema/1.0/page"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        PageViewed,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(PageObjectField, id=provisional.urls()),
-    )
-)
+@custom_given(PageViewed)
 def test_models_xapi_page_viewed_selector_with_valid_statement(statement):
     """Tests given a page viewed statement, the get_model method should return
     PageViewed model.

--- a/tests/models/xapi/test_video.py
+++ b/tests/models/xapi/test_video.py
@@ -2,41 +2,7 @@
 
 import json
 
-from hypothesis import given, provisional, settings
-from hypothesis import strategies as st
-
 from ralph.models.selector import ModelSelector
-from ralph.models.xapi.fields.actors import ActorAccountField, ActorField
-from ralph.models.xapi.video.fields.contexts import (
-    VideoCompletedContextField,
-    VideoInitializedContextField,
-    VideoInteractedContextField,
-    VideoPausedContextField,
-    VideoPlayedContextField,
-    VideoSeekedContextField,
-    VideoTerminatedContextField,
-)
-from ralph.models.xapi.video.fields.objects import (
-    VideoObjectDefinitionField,
-    VideoObjectField,
-)
-from ralph.models.xapi.video.fields.results import (
-    VideoCompletedResultField,
-    VideoInteractedResultField,
-    VideoPausedResultField,
-    VideoPlayedResultField,
-    VideoSeekedResultField,
-    VideoTerminatedResultField,
-)
-from ralph.models.xapi.video.fields.verbs import (
-    VideoCompletedVerbField,
-    VideoInitializedVerbField,
-    VideoInteractedVerbField,
-    VideoPausedVerbField,
-    VideoPlayedVerbField,
-    VideoSeekedVerbField,
-    VideoTerminatedVerbField,
-)
 from ralph.models.xapi.video.statements import (
     VideoCompleted,
     VideoInitialized,
@@ -47,51 +13,17 @@ from ralph.models.xapi.video.statements import (
     VideoTerminated,
 )
 
+from tests.fixtures.hypothesis_strategies import custom_given
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoInitialized,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoInitializedVerbField),
-        context=st.builds(VideoInitializedContextField),
-    )
-)
+
+@custom_given(VideoInitialized)
 def test_models_xapi_video_initialized_with_valid_statement(statement):
     """Tests that a video initialized statement has the expected verb.id."""
 
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/initialized"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoInitialized,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoInitializedVerbField),
-        context=st.builds(VideoInitializedContextField),
-    )
-)
+@custom_given(VideoInitialized)
 def test_models_xapi_video_initialized_selector_with_valid_statement(statement):
     """Tests given a video initialized event, the get_model method should return
     VideoInitialized model."""
@@ -103,52 +35,14 @@ def test_models_xapi_video_initialized_selector_with_valid_statement(statement):
     )
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoPlayed,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoPlayedVerbField),
-        context=st.builds(VideoPlayedContextField),
-        result=st.builds(VideoPlayedResultField),
-    )
-)
+@custom_given(VideoPlayed)
 def test_models_xapi_video_played_with_valid_statement(statement):
     """Tests that a video played statement has the expected verb.id."""
 
     assert statement.verb.id == "https://w3id.org/xapi/video/verbs/played"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoPlayed,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoPlayedVerbField),
-        context=st.builds(VideoPlayedContextField),
-        result=st.builds(VideoPlayedResultField),
-    )
-)
+@custom_given(VideoPlayed)
 def test_models_xapi_video_played_selector_with_valid_statement(statement):
     """Tests given a video played event, the get_model method should return
     VideoPlayed model.
@@ -158,52 +52,14 @@ def test_models_xapi_video_played_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoPlayed
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoPaused,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoPausedVerbField),
-        context=st.builds(VideoPausedContextField),
-        result=st.builds(VideoPausedResultField),
-    )
-)
+@custom_given(VideoPaused)
 def test_models_xapi_video_paused_with_valid_statement(statement):
     """Tests that a video paused statement has the expected verb.id."""
 
     assert statement.verb.id == "https://w3id.org/xapi/video/verbs/paused"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoPaused,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoPausedVerbField),
-        context=st.builds(VideoPausedContextField),
-        result=st.builds(VideoPausedResultField),
-    )
-)
+@custom_given(VideoPaused)
 def test_models_xapi_video_paused_selector_with_valid_statement(statement):
     """Tests given a video paused event, the get_model method should return VideoPaused
     model.
@@ -213,52 +69,14 @@ def test_models_xapi_video_paused_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoPaused
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoSeeked,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoSeekedVerbField),
-        context=st.builds(VideoSeekedContextField),
-        result=st.builds(VideoSeekedResultField),
-    )
-)
+@custom_given(VideoSeeked)
 def test_models_xapi_video_seeked_with_valid_statement(statement):
     """Tests that a video seeked statement has the expected verb.id."""
 
     assert statement.verb.id == "https://w3id.org/xapi/video/verbs/seeked"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoSeeked,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoSeekedVerbField),
-        context=st.builds(VideoSeekedContextField),
-        result=st.builds(VideoSeekedResultField),
-    )
-)
+@custom_given(VideoSeeked)
 def test_models_xapi_video_seeked_selector_with_valid_statement(statement):
     """Tests given a video seeked event, the get_model method should return VideoSeeked
     model.
@@ -268,52 +86,14 @@ def test_models_xapi_video_seeked_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoSeeked
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoCompleted,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoCompletedVerbField),
-        context=st.builds(VideoCompletedContextField),
-        result=st.builds(VideoCompletedResultField),
-    )
-)
+@custom_given(VideoCompleted)
 def test_models_xapi_video_completed_with_valid_statement(statement):
     """Tests that a video completed statement has the expected verb.id."""
 
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/completed"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoCompleted,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoCompletedVerbField),
-        context=st.builds(VideoCompletedContextField),
-        result=st.builds(VideoCompletedResultField),
-    )
-)
+@custom_given(VideoCompleted)
 def test_models_xapi_video_completed_selector_with_valid_statement(statement):
     """Tests given a video completed event, the get_model method should return
     VideoCompleted model.
@@ -323,52 +103,14 @@ def test_models_xapi_video_completed_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoCompleted
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoTerminated,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoTerminatedVerbField),
-        context=st.builds(VideoTerminatedContextField),
-        result=st.builds(VideoTerminatedResultField),
-    )
-)
+@custom_given(VideoTerminated)
 def test_models_xapi_video_terminated_with_valid_statement(statement):
     """Tests that a video terminated statement has the expected verb.id."""
 
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/terminated"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoTerminated,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoTerminatedVerbField),
-        context=st.builds(VideoTerminatedContextField),
-        result=st.builds(VideoTerminatedResultField),
-    )
-)
+@custom_given(VideoTerminated)
 def test_models_xapi_video_terminated_selector_with_valid_statement(statement):
     """Tests given a video terminated event, the get_model method should return
     VideoTerminated model."""
@@ -377,52 +119,14 @@ def test_models_xapi_video_terminated_selector_with_valid_statement(statement):
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoTerminated
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoInteracted,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoInteractedVerbField),
-        context=st.builds(VideoInteractedContextField),
-        result=st.builds(VideoInteractedResultField),
-    )
-)
+@custom_given(VideoInteracted)
 def test_models_xapi_video_interacted_with_valid_statement(statement):
     """Tests that a video interacted statement has the expected verb.id."""
 
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/interacted"
 
 
-@settings(max_examples=1)
-@given(
-    st.builds(
-        VideoInteracted,
-        actor=st.builds(
-            ActorField,
-            account=st.builds(
-                ActorAccountField, name=st.just("username"), homePage=provisional.urls()
-            ),
-        ),
-        object=st.builds(
-            VideoObjectField,
-            definition=st.builds(VideoObjectDefinitionField),
-            id=provisional.urls(),
-        ),
-        verb=st.builds(VideoInteractedVerbField),
-        context=st.builds(VideoInteractedContextField),
-        result=st.builds(VideoInteractedResultField),
-    )
-)
+@custom_given(VideoInteracted)
 def test_models_xapi_video_interacted_selector_with_valid_statement(statement):
     """Tests given a video interacted event, the get_model method should return
     VideoInteracted model."""


### PR DESCRIPTION
## Purpose

We want to make our base xAPI model more usable by defining all optional fields it may contain.
We also want to avoid having to set hypothesis configuration values for each test.

## Proposal

- [x] Add optional fields to the base xAPI model.
- [x] Use a global hypothesis configuration profile.
- [x] Add tests.



