### PR TITLE
🐛(tray) do not create a cronjobs list when no cronjob has been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to
 - Upgrade `uvicorn` to `0.17.6`
 - Upgrade `websockets` to `10.3`
 
+### Fixed
+
+- Tray: do not create a cronjobs list when no cronjob has been defined
+
 ## [2.1.0] - 2022-04-13
 
 ### Added

--- a/src/tray/templates/services/app/cronjob_pipeline.yml.j2
+++ b/src/tray/templates/services/app/cronjob_pipeline.yml.j2
@@ -1,3 +1,4 @@
+{% if ralph_cronjobs | length > 0 %}
 apiVersion: batch/v1beta1
 kind: CronJobList
 items:
@@ -60,3 +61,4 @@ items:
                 runAsGroup: {{ container_gid }}
               restartPolicy: Never
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
## Purpose

An empty ralph_cronjobs list generates an empty CronJobList template leading to a deployment failure, k8s refusing submitted manifest.

## Proposal

- [x] only create the CronJobList object when the ralph_cronjobs list contains items
