### PR TITLE
🔥(models) remove ModelRules constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Removed
+
+- ModelRules constraint
+
 ## [3.0.0] - 2022-10-19
 
 ### Added

--- a/bin/es
+++ b/bin/es
@@ -39,7 +39,10 @@ function index(){
 "
   done
 
-  curl -X PUT "${ES_URL}/_bulk?pretty" -H "Content-Type: application/json" -d "${data}"
+  declare json_content_type="Content-Type: application/json"
+  curl -X PUT "${ES_URL}/_bulk?pretty" -H "${json_content_type}" -d "${data}"
+  declare settings='{"index": {"number_of_replicas": 0}}'
+  curl -X PUT "${ES_URL}/${index}/_settings" -H "${json_content_type}" -d "${settings}"
 }
 
 declare action="${1:-usage}"

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -37,9 +37,3 @@ class UnknownEventException(Exception):
 
 class UnsupportedBackendException(Exception):
     """Raised when trying to use an unsupported backend type."""
-
-
-class ModelRulesException(Exception):
-    """Raised when a model rules list is a subset or superset of another model rules
-    list.
-    """

--- a/tests/models/edx/problem_interaction/test_statements.py
+++ b/tests/models/edx/problem_interaction/test_statements.py
@@ -2,6 +2,9 @@
 
 import json
 
+import pytest
+from hypothesis import strategies as st
+
 from ralph.models.edx.problem_interaction.statements import (
     EdxProblemHintDemandhintDisplayed,
     EdxProblemHintFeedbackDisplayed,
@@ -22,7 +25,41 @@ from ralph.models.edx.problem_interaction.statements import (
 )
 from ralph.models.selector import ModelSelector
 
-from tests.fixtures.hypothesis_strategies import custom_given
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize(
+    "class_",
+    [
+        EdxProblemHintDemandhintDisplayed,
+        EdxProblemHintFeedbackDisplayed,
+        ProblemCheck,
+        ProblemCheckFail,
+        ProblemRescore,
+        ProblemRescoreFail,
+        ResetProblem,
+        ResetProblemFail,
+        SaveProblemFail,
+        SaveProblemSuccess,
+        ShowAnswer,
+        UIProblemCheck,
+        UIProblemGraded,
+        UIProblemReset,
+        UIProblemSave,
+        UIProblemShow,
+    ],
+)
+@custom_given(st.data())
+def test_models_edx_edx_problem_interaction_selectors_with_valid_statements(
+    class_, data
+):
+    """Tests given a valid problem interaction edX statement the `get_first_model`
+    selector method should return the expected model.
+    """
+
+    statement = json.loads(data.draw(custom_builds(class_)).json())
+    model = ModelSelector(module="ralph.models.edx").get_first_model(statement)
+    assert model is class_
 
 
 @custom_given(EdxProblemHintDemandhintDisplayed)
@@ -37,21 +74,6 @@ def test_models_edx_edx_problem_hint_demandhint_displayed_with_valid_statement(
     assert statement.page == "x_module"
 
 
-@custom_given(EdxProblemHintDemandhintDisplayed)
-def test_models_edx_edx_problem_hint_demandhint_displayed_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `edx.problem.hint.demandhint_displayed` statement the selector
-    `get_model` method should return `EdxProblemHintDemandhintDisplayed` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is EdxProblemHintDemandhintDisplayed
-    )
-
-
 @custom_given(EdxProblemHintFeedbackDisplayed)
 def test_models_edx_edx_problem_hint_feedback_displayed_with_valid_statement(statement):
     """Tests that a `edx.problem.hint.feedback_displayed` statement has the expected
@@ -60,21 +82,6 @@ def test_models_edx_edx_problem_hint_feedback_displayed_with_valid_statement(sta
 
     assert statement.event_type == "edx.problem.hint.feedback_displayed"
     assert statement.page == "x_module"
-
-
-@custom_given(EdxProblemHintFeedbackDisplayed)
-def test_models_edx_edx_problem_hint_feedback_displayed_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `edx.problem.hint.feedback_displayed` statement the selector
-    `get_model` method should return `EdxProblemHintFeedbackDisplayed` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is EdxProblemHintFeedbackDisplayed
-    )
 
 
 @custom_given(UIProblemCheck)
@@ -87,18 +94,6 @@ def test_models_edx_ui_problem_check_with_valid_statement(statement):
     assert statement.name == "problem_check"
 
 
-@custom_given(UIProblemCheck)
-def test_models_edx_ui_problem_check_selector_with_valid_statement(statement):
-    """Tests given a `problem_check` statement the selector `get_model`
-    method should return `UIProblemCheck` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is UIProblemCheck
-    )
-
-
 @custom_given(ProblemCheck)
 def test_models_edx_problem_check_with_valid_statement(statement):
     """Tests that a `problem_check` server statement has the expected `event_type` and
@@ -107,16 +102,6 @@ def test_models_edx_problem_check_with_valid_statement(statement):
 
     assert statement.event_type == "problem_check"
     assert statement.page == "x_module"
-
-
-@custom_given(ProblemCheck)
-def test_models_edx_problem_check_selector_with_valid_statement(statement):
-    """Tests given a `problem_check` statement the selector `get_model` method should
-    return `ProblemCheck` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is ProblemCheck
 
 
 @custom_given(ProblemCheckFail)
@@ -129,19 +114,6 @@ def test_models_edx_problem_check_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@custom_given(ProblemCheckFail)
-def test_models_edx_problem_check_fail_selector_with_valid_statement(statement):
-    """Tests given a `problem_check_fail` statement the selector `get_model` method
-    should return `ProblemCheckFail` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is ProblemCheckFail
-    )
-
-
 @custom_given(UIProblemGraded)
 def test_models_edx_ui_problem_graded_with_valid_statement(statement):
     """Tests that a `problem_graded` browser statement has the expected `event_type` and
@@ -149,18 +121,6 @@ def test_models_edx_ui_problem_graded_with_valid_statement(statement):
 
     assert statement.event_type == "problem_graded"
     assert statement.name == "problem_graded"
-
-
-@custom_given(UIProblemGraded)
-def test_models_edx_ui_problem_graded_selector_with_valid_statement(statement):
-    """Tests given a `problem_graded` statement the selector `get_model`
-    method should return `ProblemGraded` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is UIProblemGraded
-    )
 
 
 @custom_given(ProblemRescore)
@@ -172,18 +132,6 @@ def test_models_edx_problem_rescore_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@custom_given(ProblemRescore)
-def test_models_edx_problem_rescore_selector_with_valid_statement(statement):
-    """Tests given a `problem_rescore` statement the selector `get_model` method should
-    return `ProblemRescore` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is ProblemRescore
-    )
-
-
 @custom_given(ProblemRescoreFail)
 def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
     """Tests that a `problem_rescore` server statement has the expected `event_type` and
@@ -193,19 +141,6 @@ def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@custom_given(ProblemRescoreFail)
-def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement):
-    """Tests given a `problem_rescore_fail` statement the selector `get_model` method
-    should return `ProblemRescoreFail` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is ProblemRescoreFail
-    )
-
-
 @custom_given(UIProblemReset)
 def test_models_edx_ui_problem_reset_with_valid_statement(statement):
     """Tests that a `problem_reset` browser statement has the expected `event_type` and
@@ -213,18 +148,6 @@ def test_models_edx_ui_problem_reset_with_valid_statement(statement):
 
     assert statement.event_type == "problem_reset"
     assert statement.name == "problem_reset"
-
-
-@custom_given(UIProblemReset)
-def test_models_edx_ui_problem_reset_selector_with_valid_statement(statement):
-    """Tests given a `problem_reset` statement the selector `get_model` method should
-    return `ProblemReset` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is UIProblemReset
-    )
 
 
 @custom_given(UIProblemSave)
@@ -237,18 +160,6 @@ def test_models_edx_ui_problem_save_with_valid_statement(statement):
     assert statement.name == "problem_save"
 
 
-@custom_given(UIProblemSave)
-def test_models_edx_ui_problem_save_selector_with_valid_statement(statement):
-    """Tests given a `problem_save` statement the selector `get_model` method should
-    return `ProblemSave` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is UIProblemSave
-    )
-
-
 @custom_given(UIProblemShow)
 def test_models_edx_ui_problem_show_with_valid_statement(statement):
     """Tests that a `problem_show` browser statement has the expected `event_type` and
@@ -257,18 +168,6 @@ def test_models_edx_ui_problem_show_with_valid_statement(statement):
 
     assert statement.event_type == "problem_show"
     assert statement.name == "problem_show"
-
-
-@custom_given(UIProblemShow)
-def test_models_edx_ui_problem_show_selector_with_valid_statement(statement):
-    """Tests given a `problem_show` statement the selector `get_model` method should
-    return `ProblemShow` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is UIProblemShow
-    )
 
 
 @custom_given(ResetProblem)
@@ -281,16 +180,6 @@ def test_models_edx_reset_problem_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@custom_given(ResetProblem)
-def test_models_edx_reset_problem_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem` statement the selector `get_model` method should
-    return `ResetProblem` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is ResetProblem
-
-
 @custom_given(ResetProblemFail)
 def test_models_edx_reset_problem_fail_with_valid_statement(statement):
     """Tests that a `reset_problem_fail` server statement has the expected `event_type`
@@ -299,19 +188,6 @@ def test_models_edx_reset_problem_fail_with_valid_statement(statement):
 
     assert statement.event_type == "reset_problem_fail"
     assert statement.page == "x_module"
-
-
-@custom_given(ResetProblemFail)
-def test_models_edx_reset_problem_fail_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem_fail` statement the selector `get_model` method
-    should return `ResetProblemFail` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is ResetProblemFail
-    )
 
 
 @custom_given(SaveProblemFail)
@@ -324,18 +200,6 @@ def test_models_edx_save_problem_fail_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@custom_given(SaveProblemFail)
-def test_models_edx_save_problem_fail_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem_fail` statement the selector `get_model` method
-    should return `SaveProblemFail` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement) is SaveProblemFail
-    )
-
-
 @custom_given(SaveProblemSuccess)
 def test_models_edx_save_problem_success_with_valid_statement(statement):
     """Tests that a `save_problem_success` server statement has the expected
@@ -346,19 +210,6 @@ def test_models_edx_save_problem_success_with_valid_statement(statement):
     assert statement.page == "x_module"
 
 
-@custom_given(SaveProblemSuccess)
-def test_models_edx_save_problem_success_selector_with_valid_statement(statement):
-    """Tests given a `reset_problem_success` statement the selector `get_model` method
-    should return `SaveProblemSuccess` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is SaveProblemSuccess
-    )
-
-
 @custom_given(ShowAnswer)
 def test_models_edx_show_answer_with_valid_statement(statement):
     """Tests that a `showanswer` server statement has the expected `event_type` and
@@ -367,13 +218,3 @@ def test_models_edx_show_answer_with_valid_statement(statement):
 
     assert statement.event_type == "showanswer"
     assert statement.page == "x_module"
-
-
-@custom_given(ShowAnswer)
-def test_models_edx_show_answer_selector_with_valid_statement(statement):
-    """Tests given a `show_answer` statement the selector `get_model` method should
-    return `ShowAnswer` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is ShowAnswer

--- a/tests/models/edx/test_enrollment.py
+++ b/tests/models/edx/test_enrollment.py
@@ -2,6 +2,9 @@
 
 import json
 
+import pytest
+from hypothesis import strategies as st
+
 from ralph.models.edx.enrollment.statements import (
     EdxCourseEnrollmentActivated,
     EdxCourseEnrollmentDeactivated,
@@ -11,7 +14,28 @@ from ralph.models.edx.enrollment.statements import (
 )
 from ralph.models.selector import ModelSelector
 
-from tests.fixtures.hypothesis_strategies import custom_given
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize(
+    "class_",
+    [
+        EdxCourseEnrollmentActivated,
+        EdxCourseEnrollmentDeactivated,
+        EdxCourseEnrollmentModeChanged,
+        EdxCourseEnrollmentUpgradeSucceeded,
+        UIEdxCourseEnrollmentUpgradeClicked,
+    ],
+)
+@custom_given(st.data())
+def test_models_edx_edx_course_enrollment_selectors_with_valid_statements(class_, data):
+    """Tests given a valid course enrollment edX statement the `get_first_model`
+    selector method should return the expected model.
+    """
+
+    statement = json.loads(data.draw(custom_builds(class_)).json())
+    model = ModelSelector(module="ralph.models.edx").get_first_model(statement)
+    assert model is class_
 
 
 @custom_given(EdxCourseEnrollmentActivated)
@@ -26,21 +50,6 @@ def test_models_edx_edx_course_enrollment_activated_with_valid_statement(
     assert statement.name == "edx.course.enrollment.activated"
 
 
-@custom_given(EdxCourseEnrollmentActivated)
-def test_models_edx_edx_course_enrollment_activated_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `edx.course.enrollment.activated` statement the `get_model`
-    selector method should return `EdxCourseEnrollmentActivated` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is EdxCourseEnrollmentActivated
-    )
-
-
 @custom_given(EdxCourseEnrollmentDeactivated)
 def test_models_edx_edx_course_enrollment_deactivated_with_valid_statement(
     statement,
@@ -51,21 +60,6 @@ def test_models_edx_edx_course_enrollment_deactivated_with_valid_statement(
 
     assert statement.event_type == "edx.course.enrollment.deactivated"
     assert statement.name == "edx.course.enrollment.deactivated"
-
-
-@custom_given(EdxCourseEnrollmentDeactivated)
-def test_models_edx_edx_course_enrollment_deactivated_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `edx.course.enrollment.deactivated` statement the `get_model`
-    selector method should return `EdxCourseEnrollmentDeactivated` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is EdxCourseEnrollmentDeactivated
-    )
 
 
 @custom_given(EdxCourseEnrollmentModeChanged)
@@ -80,21 +74,6 @@ def test_models_edx_edx_course_enrollment_mode_changed_with_valid_statement(
     assert statement.name == "edx.course.enrollment.mode_changed"
 
 
-@custom_given(EdxCourseEnrollmentModeChanged)
-def test_models_edx_edx_course_enrollment_mode_changed_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `edx.course.enrollment.mode_changed` statement the `get_model`
-    selector method should return `EdxCourseEnrollmentModeChanged` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is EdxCourseEnrollmentModeChanged
-    )
-
-
 @custom_given(UIEdxCourseEnrollmentUpgradeClicked)
 def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_with_valid_statement(
     statement,
@@ -107,22 +86,6 @@ def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_with_valid_statemen
     assert statement.name == "edx.course.enrollment.upgrade_clicked"
 
 
-# pylint: disable=line-too-long
-@custom_given(UIEdxCourseEnrollmentUpgradeClicked)
-def test_models_edx_ui_edx_course_enrollment_upgrade_clicked_selector_with_valid_statement(  # noqa
-    statement,
-):
-    """Tests given a `edx.course.enrollment.upgrade_clicked` statement the `get_model`
-    selector method should return `UIEdxCourseEnrollmentUpgradeClicked` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UIEdxCourseEnrollmentUpgradeClicked
-    )
-
-
 @custom_given(EdxCourseEnrollmentUpgradeSucceeded)
 def test_models_edx_edx_course_enrollment_upgrade_succeeded_with_valid_statement(
     statement,
@@ -133,19 +96,3 @@ def test_models_edx_edx_course_enrollment_upgrade_succeeded_with_valid_statement
 
     assert statement.event_type == "edx.course.enrollment.upgrade.succeeded"
     assert statement.name == "edx.course.enrollment.upgrade.succeeded"
-
-
-# pylint: disable=line-too-long
-@custom_given(EdxCourseEnrollmentUpgradeSucceeded)
-def test_models_edx_edx_course_enrollment_upgrade_succeeded_selector_with_valid_statement(  # noqa
-    statement,
-):
-    """Tests given a `edx.course.enrollment.upgrade.succeeded` statement the `get_model`
-    selector method should return `EdxCourseEnrollmentUpgradeSucceeded` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is EdxCourseEnrollmentUpgradeSucceeded
-    )

--- a/tests/models/edx/test_server.py
+++ b/tests/models/edx/test_server.py
@@ -18,7 +18,7 @@ def test_model_selector_server_get_model_with_valid_event(event):
     """
 
     event = json.loads(event.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(event) is Server
+    assert ModelSelector(module="ralph.models.edx").get_first_model(event) is Server
 
 
 def test_model_selector_server_get_model_with_invalid_event():
@@ -27,4 +27,4 @@ def test_model_selector_server_get_model_with_invalid_event():
     """
 
     with pytest.raises(UnknownEventException):
-        ModelSelector(module="ralph.models.edx").get_model({"invalid": "event"})
+        ModelSelector(module="ralph.models.edx").get_first_model({"invalid": "event"})

--- a/tests/models/edx/test_textbook_interaction.py
+++ b/tests/models/edx/test_textbook_interaction.py
@@ -4,6 +4,7 @@ import json
 import re
 
 import pytest
+from hypothesis import strategies as st
 from pydantic.error_wrappers import ValidationError
 
 from ralph.models.edx.textbook_interaction.fields.events import (
@@ -28,7 +29,39 @@ from ralph.models.edx.textbook_interaction.statements import (
 )
 from ralph.models.selector import ModelSelector
 
-from tests.fixtures.hypothesis_strategies import custom_given
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize(
+    "class_",
+    [
+        UIBook,
+        UITextbookPdfChapterNavigated,
+        UITextbookPdfDisplayScaled,
+        UITextbookPdfOutlineToggled,
+        UITextbookPdfPageNavigated,
+        UITextbookPdfPageScrolled,
+        UITextbookPdfSearchCaseSensitivityToggled,
+        UITextbookPdfSearchExecuted,
+        UITextbookPdfSearchHighlightToggled,
+        UITextbookPdfSearchNavigatedNext,
+        UITextbookPdfThumbnailNavigated,
+        UITextbookPdfThumbnailsToggled,
+        UITextbookPdfZoomButtonsChanged,
+        UITextbookPdfZoomMenuChanged,
+    ],
+)
+@custom_given(st.data())
+def test_models_edx_ui_textbook_interaction_selectors_with_valid_statements(
+    class_, data
+):
+    """Tests given a valid textbook interaction edX statement the `get_first_model`
+    selector method should return the expected model.
+    """
+
+    statement = json.loads(data.draw(custom_builds(class_)).json())
+    model = ModelSelector(module="ralph.models.edx").get_first_model(statement)
+    assert model is class_
 
 
 @custom_given(TextbookInteractionBaseEventField)
@@ -161,16 +194,6 @@ def test_models_edx_ui_book_with_valid_statement(statement):
     assert statement.name == "book"
 
 
-@custom_given(UIBook)
-def test_models_edx_ui_book_selector_with_valid_statement(statement):
-    """Tests given a `book` statement the selector `get_model` method should return
-    `UIBook` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is UIBook
-
-
 @custom_given(UITextbookPdfThumbnailsToggled)
 def test_models_edx_ui_textbook_pdf_thumbnails_toggled_with_valid_statement(statement):
     """Tests that a `textbook.pdf.thumbnails.toggled` statement has the expected
@@ -179,21 +202,6 @@ def test_models_edx_ui_textbook_pdf_thumbnails_toggled_with_valid_statement(stat
 
     assert statement.event_type == "textbook.pdf.thumbnails.toggled"
     assert statement.name == "textbook.pdf.thumbnails.toggled"
-
-
-@custom_given(UITextbookPdfThumbnailsToggled)
-def test_models_edx_ui_textbook_pdf_thumbnails_toggled_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.thumbnails.toggled` event the selector `get_model`
-    method should return `UITextbookPdfThumbnailsToggled` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfThumbnailsToggled
-    )
 
 
 @custom_given(UITextbookPdfThumbnailNavigated)
@@ -208,21 +216,6 @@ def test_models_edx_ui_textbook_pdf_thumbnail_navigated_with_valid_statement(
     assert statement.name == "textbook.pdf.thumbnail.navigated"
 
 
-@custom_given(UITextbookPdfThumbnailNavigated)
-def test_models_edx_ui_textbook_pdf_thumbnail_navigated_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.thumbnail.navigated` statement the selector
-    `get_model` method should return `UITextbookPdfThumbnailNavigated` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfThumbnailNavigated
-    )
-
-
 @custom_given(UITextbookPdfOutlineToggled)
 def test_models_edx_ui_textbook_pdf_outline_toggled_with_valid_statement(
     statement,
@@ -233,21 +226,6 @@ def test_models_edx_ui_textbook_pdf_outline_toggled_with_valid_statement(
 
     assert statement.event_type == "textbook.pdf.outline.toggled"
     assert statement.name == "textbook.pdf.outline.toggled"
-
-
-@custom_given(UITextbookPdfOutlineToggled)
-def test_models_edx_ui_textbook_pdf_outline_toggled_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.outline.toggled` statement the selector `get_model`
-    method should return `UITextbookPdfOutlineToggled` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfOutlineToggled
-    )
 
 
 @custom_given(UITextbookPdfChapterNavigated)
@@ -262,21 +240,6 @@ def test_models_edx_ui_textbook_pdf_chapter_navigated_with_valid_statement(
     assert statement.name == "textbook.pdf.chapter.navigated"
 
 
-@custom_given(UITextbookPdfChapterNavigated)
-def test_models_edx_ui_textbook_pdf_chapter_navigated_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.chapter.navigated` statement the selector `get_model`
-    method should return `UITextbookPdfChapterNavigated` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfChapterNavigated
-    )
-
-
 @custom_given(UITextbookPdfPageNavigated)
 def test_models_edx_ui_textbook_pdf_page_navigated_with_valid_statement(
     statement,
@@ -287,21 +250,6 @@ def test_models_edx_ui_textbook_pdf_page_navigated_with_valid_statement(
 
     assert statement.event_type == "textbook.pdf.page.navigated"
     assert statement.name == "textbook.pdf.page.navigated"
-
-
-@custom_given(UITextbookPdfPageNavigated)
-def test_models_edx_ui_textbook_pdf_page_navigated_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.page.navigated` statement the selector `get_model`
-    method should return `UITextbookPdfPageNavigated` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfPageNavigated
-    )
 
 
 @custom_given(UITextbookPdfZoomButtonsChanged)
@@ -316,21 +264,6 @@ def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_with_valid_statement(
     assert statement.name == "textbook.pdf.zoom.buttons.changed"
 
 
-@custom_given(UITextbookPdfZoomButtonsChanged)
-def test_models_edx_ui_textbook_pdf_zoom_buttons_changed_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.zoom.buttons.changed` statement the selector
-    `get_model` method should return `UITextbookPdfZoomButtonsChanged` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfZoomButtonsChanged
-    )
-
-
 @custom_given(UITextbookPdfZoomMenuChanged)
 def test_models_edx_ui_textbook_pdf_zoom_menu_changed_with_valid_statement(statement):
     """Tests that a `textbook.pdf.zoom.menu.changed` has the expected `event_type` and
@@ -339,21 +272,6 @@ def test_models_edx_ui_textbook_pdf_zoom_menu_changed_with_valid_statement(state
 
     assert statement.event_type == "textbook.pdf.zoom.menu.changed"
     assert statement.name == "textbook.pdf.zoom.menu.changed"
-
-
-@custom_given(UITextbookPdfZoomMenuChanged)
-def test_models_edx_ui_textbook_pdf_zoom_menu_changed_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.zoom.menu.changed` statement the selector `get_model`
-    method should return `UITextbookPdfZoomMenuChanged` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfZoomMenuChanged
-    )
 
 
 @custom_given(UITextbookPdfDisplayScaled)
@@ -366,21 +284,6 @@ def test_models_edx_ui_textbook_pdf_display_scaled_with_valid_statement(statemen
     assert statement.name == "textbook.pdf.display.scaled"
 
 
-@custom_given(UITextbookPdfDisplayScaled)
-def test_models_edx_ui_textbook_pdf_display_scaled_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.display.scaled` statement the selector `get_model`
-    method should return `UITextbookPdfDisplayScaled` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfDisplayScaled
-    )
-
-
 @custom_given(UITextbookPdfPageScrolled)
 def test_models_edx_ui_textbook_pdf_page_scrolled_with_valid_statement(statement):
     """Tests that a `textbook.pdf.page.scrolled` statement has the expected `event_type`
@@ -389,21 +292,6 @@ def test_models_edx_ui_textbook_pdf_page_scrolled_with_valid_statement(statement
 
     assert statement.event_type == "textbook.pdf.page.scrolled"
     assert statement.name == "textbook.pdf.page.scrolled"
-
-
-@custom_given(UITextbookPdfPageScrolled)
-def test_models_edx_ui_textbook_pdf_page_scrolled_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.page.scrolled` statement the selector `get_model`
-    method should return `UITextbookPdfPageScrolled` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfPageScrolled
-    )
 
 
 @custom_given(UITextbookPdfSearchExecuted)
@@ -416,21 +304,6 @@ def test_models_edx_ui_textbook_pdf_search_executed_with_valid_statement(stateme
     assert statement.name == "textbook.pdf.search.executed"
 
 
-@custom_given(UITextbookPdfSearchExecuted)
-def test_models_edx_ui_textbook_pdf_search_executed_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.search.executed` statement the selector `get_model`
-    method should return `UITextbookPdfSearchExecuted` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfSearchExecuted
-    )
-
-
 @custom_given(UITextbookPdfSearchNavigatedNext)
 def test_models_edx_ui_textbook_pdf_search_navigated_next_with_valid_statement(
     statement,
@@ -441,21 +314,6 @@ def test_models_edx_ui_textbook_pdf_search_navigated_next_with_valid_statement(
 
     assert statement.event_type == "textbook.pdf.search.navigatednext"
     assert statement.name == "textbook.pdf.search.navigatednext"
-
-
-@custom_given(UITextbookPdfSearchNavigatedNext)
-def test_models_edx_ui_textbook_pdf_search_navigated_next_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `textbook.pdf.search.navigatednext` statement the selector
-    `get_model` method should return `UITextbookPdfSearchNavigatedNext` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfSearchNavigatedNext
-    )
 
 
 @custom_given(UITextbookPdfSearchHighlightToggled)
@@ -471,22 +329,6 @@ def test_models_edx_ui_textbook_pdf_search_highlight_toggled_with_valid_statemen
 
 
 # pylint: disable=line-too-long
-@custom_given(UITextbookPdfSearchHighlightToggled)
-def test_models_edx_ui_textbook_pdf_search_highlight_toggled_selector_with_valid_statement(  # noqa
-    statement,
-):
-    """Tests given a `textbook.pdf.search.highlight.toggled` statement the selector
-    `get_model` method should return `UITextbookPdfSearchHighlightToggled` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfSearchHighlightToggled
-    )
-
-
-# pylint: disable=line-too-long
 @custom_given(UITextbookPdfSearchCaseSensitivityToggled)
 def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_statement(  # noqa
     statement,
@@ -497,19 +339,3 @@ def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_with_valid_s
 
     assert statement.event_type == "textbook.pdf.searchcasesensitivity.toggled"
     assert statement.name == "textbook.pdf.searchcasesensitivity.toggled"
-
-
-# pylint: disable=line-too-long
-@custom_given(UITextbookPdfSearchCaseSensitivityToggled)
-def test_models_edx_ui_textbook_pdf_search_case_sensitivity_toggled_selector_with_valid_statement(  # noqa
-    statement,
-):
-    """Tests given a `textbook.pdf.searchcasesensitivity.toggled` statement the selector
-    `get_model` method should return `UITextbookPdfSearchCaseSensitivityToggled` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UITextbookPdfSearchCaseSensitivityToggled
-    )

--- a/tests/models/edx/video/test_statements.py
+++ b/tests/models/edx/video/test_statements.py
@@ -2,6 +2,9 @@
 
 import json
 
+import pytest
+from hypothesis import strategies as st
+
 from ralph.models.edx.video.statements import (
     UIHideTranscript,
     UILoadVideo,
@@ -16,7 +19,33 @@ from ralph.models.edx.video.statements import (
 )
 from ralph.models.selector import ModelSelector
 
-from tests.fixtures.hypothesis_strategies import custom_given
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize(
+    "class_",
+    [
+        UIHideTranscript,
+        UILoadVideo,
+        UIPauseVideo,
+        UIPlayVideo,
+        UISeekVideo,
+        UIShowTranscript,
+        UISpeedChangeVideo,
+        UIStopVideo,
+        UIVideoHideCCMenu,
+        UIVideoShowCCMenu,
+    ],
+)
+@custom_given(st.data())
+def test_models_edx_video_selectors_with_valid_statements(class_, data):
+    """Tests given a valid video edX statement the `get_first_model`
+    selector method should return the expected model.
+    """
+
+    statement = json.loads(data.draw(custom_builds(class_)).json())
+    model = ModelSelector(module="ralph.models.edx").get_first_model(statement)
+    assert model is class_
 
 
 @custom_given(UIPlayVideo)
@@ -28,18 +57,6 @@ def test_models_edx_ui_play_video_with_valid_statement(
     assert statement.event_type == "play_video"
 
 
-@custom_given(UIPlayVideo)
-def test_models_edx_ui_play_video_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `play_video` statement the `get_model`
-    selector method should return `UIPlayVideo` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is UIPlayVideo
-
-
 @custom_given(UIPauseVideo)
 def test_models_edx_ui_pause_video_with_valid_statement(
     statement,
@@ -47,18 +64,6 @@ def test_models_edx_ui_pause_video_with_valid_statement(
     """Tests that a `pause_video` statement has the expected `event_type`."""
 
     assert statement.event_type == "pause_video"
-
-
-@custom_given(UIPauseVideo)
-def test_models_edx_ui_pause_video_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `pause_video` statement the `get_model`
-    selector method should return `UIPauseVideo` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is UIPauseVideo
 
 
 @custom_given(UILoadVideo)
@@ -71,18 +76,6 @@ def test_models_edx_ui_load_video_with_valid_statement(
     assert statement.name in {"load_video", "edx.video.loaded"}
 
 
-@custom_given(UILoadVideo)
-def test_models_edx_ui_load_video_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `load_video` statement the `get_model`
-    selector method should return `UILoadVideo` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is UILoadVideo
-
-
 @custom_given(UISeekVideo)
 def test_models_edx_ui_seek_video_with_valid_statement(
     statement,
@@ -92,18 +85,6 @@ def test_models_edx_ui_seek_video_with_valid_statement(
     assert statement.event_type == "seek_video"
 
 
-@custom_given(UISeekVideo)
-def test_models_edx_ui_seek_video_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `seek_video` statement the `get_model`
-    selector method should return `UISeekVideo` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is UISeekVideo
-
-
 @custom_given(UIStopVideo)
 def test_models_edx_ui_stop_video_with_valid_statement(
     statement,
@@ -111,18 +92,6 @@ def test_models_edx_ui_stop_video_with_valid_statement(
     """Tests that a `stop_video` statement has the expected `event_type`."""
 
     assert statement.event_type == "stop_video"
-
-
-@custom_given(UIStopVideo)
-def test_models_edx_ui_stop_video_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `stop_video` statement the `get_model`
-    selector method should return `UIStopVideo` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.edx").get_model(statement) is UIStopVideo
 
 
 @custom_given(UIHideTranscript)
@@ -137,21 +106,6 @@ def test_models_edx_ui_hide_transcript_with_valid_statement(
     assert statement.name in {"hide_transcript", "edx.video.transcript.hidden"}
 
 
-@custom_given(UIHideTranscript)
-def test_models_edx_ui_hide_transcript_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `hide_transcript` statement the `get_model`
-    selector method should return `UIHideTranscript` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UIHideTranscript
-    )
-
-
 @custom_given(UIShowTranscript)
 def test_models_edx_ui_show_transcript_with_valid_statement(
     statement,
@@ -164,21 +118,6 @@ def test_models_edx_ui_show_transcript_with_valid_statement(
     assert statement.name in {"show_transcript", "edx.video.transcript.shown"}
 
 
-@custom_given(UIShowTranscript)
-def test_models_edx_ui_show_transcript_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `show_transcript` statement the `get_model`
-    selector method should return `UISHowTranscript` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UIShowTranscript
-    )
-
-
 @custom_given(UISpeedChangeVideo)
 def test_models_edx_ui_speed_change_video_with_valid_statement(
     statement,
@@ -186,21 +125,6 @@ def test_models_edx_ui_speed_change_video_with_valid_statement(
     """Tests that a `speed_change_video` statement has the expected `event_type`."""
 
     assert statement.event_type == "speed_change_video"
-
-
-@custom_given(UISpeedChangeVideo)
-def test_models_edx_ui_speed_change_video_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `speed_change_video` statement the `get_model`
-    selector method should return a `UISpeedChangeVideo` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UISpeedChangeVideo
-    )
 
 
 @custom_given(UIVideoHideCCMenu)
@@ -212,21 +136,6 @@ def test_models_edx_ui_vide_hide_cc_menu_with_valid_statement(
     assert statement.event_type == "video_hide_cc_menu"
 
 
-@custom_given(UIVideoHideCCMenu)
-def test_models_edx_ui_video_hide_cc_menu_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `video_hide_cc_menu` statement the `get_model`
-    selector method should return a `UIVideoHideCCMenu` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UIVideoHideCCMenu
-    )
-
-
 @custom_given(UIVideoShowCCMenu)
 def test_models_edx_ui_video_show_cc_menu_with_valid_statement(
     statement,
@@ -234,18 +143,3 @@ def test_models_edx_ui_video_show_cc_menu_with_valid_statement(
     """Tests that a `video_show_cc_menu` statement has the expected `event_type`."""
 
     assert statement.event_type == "video_show_cc_menu"
-
-
-@custom_given(UIVideoShowCCMenu)
-def test_models_edx_ui_video_show_cc_menu_selector_with_valid_statement(
-    statement,
-):
-    """Tests given a `video_show_cc_menu` statement the `get_model`
-    selector method should return a `UIVideoShowCCMenu` model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.edx").get_model(statement)
-        is UIVideoShowCCMenu
-    )

--- a/tests/models/xapi/test_base.py
+++ b/tests/models/xapi/test_base.py
@@ -491,7 +491,7 @@ def test_models_xapi_base_statement_with_valid_version(statement):
     "model",
     [
         model
-        for model in ModelSelector("ralph.models.xapi").model_rules.keys()
+        for model in ModelSelector("ralph.models.xapi").model_rules
         # We have to bypass Video Statements in this test because we want to support
         # invalid values (non IRI keys) in their extension fields.
         if not issubclass(model, BaseVideoStatement)

--- a/tests/models/xapi/test_navigation.py
+++ b/tests/models/xapi/test_navigation.py
@@ -2,10 +2,25 @@
 
 import json
 
+import pytest
+from hypothesis import strategies as st
+
 from ralph.models.selector import ModelSelector
 from ralph.models.xapi.navigation.statements import PageTerminated, PageViewed
 
-from tests.fixtures.hypothesis_strategies import custom_given
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize("class_", [PageTerminated, PageViewed])
+@custom_given(st.data())
+def test_models_xapi_navigational_selectors_with_valid_statements(class_, data):
+    """Tests given a valid navigational xAPI statement the `get_first_model`
+    selector method should return the expected model.
+    """
+
+    statement = json.loads(data.draw(custom_builds(class_)).json())
+    model = ModelSelector(module="ralph.models.xapi").get_first_model(statement)
+    assert model is class_
 
 
 @custom_given(PageTerminated)
@@ -18,18 +33,6 @@ def test_models_xapi_page_terminated_statement(statement):
     assert statement.object.definition.type == "http://activitystrea.ms/schema/1.0/page"
 
 
-@custom_given(PageTerminated)
-def test_models_xapi_page_terminated_selector_with_valid_statement(statement):
-    """Tests given a page terminated statement, the get_model method should return
-    PageTerminated model.
-    """
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.xapi").get_model(statement) is PageTerminated
-    )
-
-
 @custom_given(PageViewed)
 def test_models_xapi_page_viewed_statement(statement):
     """Tests that a page_viewed statement has the expected verb.id and
@@ -38,13 +41,3 @@ def test_models_xapi_page_viewed_statement(statement):
 
     assert statement.verb.id == "http://id.tincanapi.com/verb/viewed"
     assert statement.object.definition.type == "http://activitystrea.ms/schema/1.0/page"
-
-
-@custom_given(PageViewed)
-def test_models_xapi_page_viewed_selector_with_valid_statement(statement):
-    """Tests given a page viewed statement, the get_model method should return
-    PageViewed model.
-    """
-
-    statement = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(statement) is PageViewed

--- a/tests/models/xapi/test_video.py
+++ b/tests/models/xapi/test_video.py
@@ -2,6 +2,9 @@
 
 import json
 
+import pytest
+from hypothesis import strategies as st
+
 from ralph.models.selector import ModelSelector
 from ralph.models.xapi.video.statements import (
     VideoCompleted,
@@ -13,7 +16,30 @@ from ralph.models.xapi.video.statements import (
     VideoTerminated,
 )
 
-from tests.fixtures.hypothesis_strategies import custom_given
+from tests.fixtures.hypothesis_strategies import custom_builds, custom_given
+
+
+@pytest.mark.parametrize(
+    "class_",
+    [
+        VideoCompleted,
+        VideoInitialized,
+        VideoInteracted,
+        VideoPaused,
+        VideoPlayed,
+        VideoSeeked,
+        VideoTerminated,
+    ],
+)
+@custom_given(st.data())
+def test_models_xapi_video_selectors_with_valid_statements(class_, data):
+    """Tests given a valid video xAPI statement the `get_first_model`
+    selector method should return the expected model.
+    """
+
+    statement = json.loads(data.draw(custom_builds(class_)).json())
+    model = ModelSelector(module="ralph.models.xapi").get_first_model(statement)
+    assert model is class_
 
 
 @custom_given(VideoInitialized)
@@ -23,33 +49,11 @@ def test_models_xapi_video_initialized_with_valid_statement(statement):
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/initialized"
 
 
-@custom_given(VideoInitialized)
-def test_models_xapi_video_initialized_selector_with_valid_statement(statement):
-    """Tests given a video initialized event, the get_model method should return
-    VideoInitialized model."""
-
-    statement = json.loads(statement.json())
-    assert (
-        ModelSelector(module="ralph.models.xapi").get_model(statement)
-        is VideoInitialized
-    )
-
-
 @custom_given(VideoPlayed)
 def test_models_xapi_video_played_with_valid_statement(statement):
     """Tests that a video played statement has the expected verb.id."""
 
     assert statement.verb.id == "https://w3id.org/xapi/video/verbs/played"
-
-
-@custom_given(VideoPlayed)
-def test_models_xapi_video_played_selector_with_valid_statement(statement):
-    """Tests given a video played event, the get_model method should return
-    VideoPlayed model.
-    """
-
-    event = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoPlayed
 
 
 @custom_given(VideoPaused)
@@ -59,31 +63,11 @@ def test_models_xapi_video_paused_with_valid_statement(statement):
     assert statement.verb.id == "https://w3id.org/xapi/video/verbs/paused"
 
 
-@custom_given(VideoPaused)
-def test_models_xapi_video_paused_selector_with_valid_statement(statement):
-    """Tests given a video paused event, the get_model method should return VideoPaused
-    model.
-    """
-
-    event = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoPaused
-
-
 @custom_given(VideoSeeked)
 def test_models_xapi_video_seeked_with_valid_statement(statement):
     """Tests that a video seeked statement has the expected verb.id."""
 
     assert statement.verb.id == "https://w3id.org/xapi/video/verbs/seeked"
-
-
-@custom_given(VideoSeeked)
-def test_models_xapi_video_seeked_selector_with_valid_statement(statement):
-    """Tests given a video seeked event, the get_model method should return VideoSeeked
-    model.
-    """
-
-    event = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoSeeked
 
 
 @custom_given(VideoCompleted)
@@ -93,16 +77,6 @@ def test_models_xapi_video_completed_with_valid_statement(statement):
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/completed"
 
 
-@custom_given(VideoCompleted)
-def test_models_xapi_video_completed_selector_with_valid_statement(statement):
-    """Tests given a video completed event, the get_model method should return
-    VideoCompleted model.
-    """
-
-    event = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoCompleted
-
-
 @custom_given(VideoTerminated)
 def test_models_xapi_video_terminated_with_valid_statement(statement):
     """Tests that a video terminated statement has the expected verb.id."""
@@ -110,26 +84,8 @@ def test_models_xapi_video_terminated_with_valid_statement(statement):
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/terminated"
 
 
-@custom_given(VideoTerminated)
-def test_models_xapi_video_terminated_selector_with_valid_statement(statement):
-    """Tests given a video terminated event, the get_model method should return
-    VideoTerminated model."""
-
-    event = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoTerminated
-
-
 @custom_given(VideoInteracted)
 def test_models_xapi_video_interacted_with_valid_statement(statement):
     """Tests that a video interacted statement has the expected verb.id."""
 
     assert statement.verb.id == "http://adlnet.gov/expapi/verbs/interacted"
-
-
-@custom_given(VideoInteracted)
-def test_models_xapi_video_interacted_selector_with_valid_statement(statement):
-    """Tests given a video interacted event, the get_model method should return
-    VideoInteracted model."""
-
-    event = json.loads(statement.json())
-    assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoInteracted


### PR DESCRIPTION
## Purpose

The model rules constraint limited the validation & conversion logic to work only with disjoint rule sets, thus avoiding the case where a matching ruleset could lead to multiple results.
In the future, we intend to support xAPI profile validation.
However, xAPI profile template selection constraints are not always disjoint rulesets.

## Proposal

- [x] remove model rules
- [x] update validator & convertor to support the case where multiple models match an event.

