### PR TITLE
✨(backends) allow database backends custom get queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Create a `post` endpoint for statements implementing the LRS spec
 - Implement support for the MongoDB database backend
+- Implement support for custom queries when using database backends `get`
+  method (used in the `fetch` command)
 
 ### Changed
 

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -1,17 +1,69 @@
 """Base storage backend for Ralph"""
 
+import functools
+import logging
 from abc import ABC, abstractmethod
 from typing import BinaryIO, TextIO, Union
+
+from pydantic import BaseModel
+
+from ralph.exceptions import BackendParameterException
+
+logger = logging.getLogger(__name__)
+
+
+class BaseQuery(BaseModel):
+    """Base query model"""
+
+    class Config:
+        """Base query model configuration."""
+
+        extra = "forbid"
+
+
+def enforce_query_checks(method):
+    """Enforce query argument type checking for methods using it."""
+
+    @functools.wraps(method)
+    def wrapper(*args, **kwargs):
+        """Wrap method execution."""
+
+        query = kwargs.pop("query", None)
+        self_ = args[0]
+
+        return method(*args, query=self_.validate_query(query), **kwargs)
+
+    return wrapper
 
 
 class BaseDatabase(ABC):
     """Base database backend interface."""
 
     name = "base"
+    query_model = BaseQuery
+
+    def validate_query(self, query: BaseQuery = None):
+        """Validate database query"""
+
+        if query is None:
+            query = self.query_model()
+
+        if not isinstance(query, self.query_model):
+            raise BackendParameterException(
+                "'query' argument is expected to be a "
+                f"{self.query_model().__class__.__name__} instance."
+            )
+
+        logger.debug("Query: %s", str(query))
+
+        return query
 
     @abstractmethod
-    def get(self, chunk_size: int = 10):
-        """Reads `chunk_size` records from the database and yields them."""
+    @enforce_query_checks
+    def get(self, query: BaseQuery = None, chunk_size: int = 10):
+        """Reads `chunk_size` records from the database query results and yields
+        them.
+        """
 
     @abstractmethod
     def put(


### PR DESCRIPTION
## Purpose

We need more flexibility to fetch learning events from database backends. Allow backend-specific-queries for filtering and aggregations seems required to achieve such task.

## Proposal

Each database backend `get` method now supports an optionnal `query` field that will be injected in the backend's request. This `query` field accepts a query model instance as an argument. Each backend is responsible to define its own model, and check that passed arguments are valid and respect backend-specific API.

Consequently, the `fetch` command now supports a new `-q` or `--query` option with a JSON string argument. As query objects may be complex for some backends, we haven't found a more user-friendly alternative for this option in a CLI context.

- [x] add database backend `get` method `query` support
- [x] add `fetch` command `query` support
- [x] test database backends query field
- [x] test CLI `fetch` command `--query` option
