### PR TITLE
🐛(backends) fix history mixin logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to
 ### Fixed
 
 - Tray: do not create a cronjobs list when no cronjob has been defined
+- Restore history mixin logger
 
 ## [2.1.0] - 2022-04-13
 

--- a/src/ralph/backends/mixins.py
+++ b/src/ralph/backends/mixins.py
@@ -16,7 +16,7 @@ class HistoryMixin:
     def history(self):
         """Get backend history"""
 
-        logging.debug("Loading history file: %s", str(settings.HISTORY_FILE))
+        logger.debug("Loading history file: %s", str(settings.HISTORY_FILE))
 
         if not hasattr(self, "_history"):
             try:
@@ -32,7 +32,7 @@ class HistoryMixin:
     def write_history(self, history):
         """Write given history as a JSON file"""
 
-        logging.debug("Writing history file: %s", str(settings.HISTORY_FILE))
+        logger.debug("Writing history file: %s", str(settings.HISTORY_FILE))
 
         if not settings.HISTORY_FILE.parent.exists():
             settings.HISTORY_FILE.parent.mkdir(parents=True)


### PR DESCRIPTION
## Purpose

Mixins logger is not used for the history mixin, droping all messages to the root logger.

## Proposal

- [x] target the appropriate logger
