### PR TITLE
✨(project) addition of pydocstyle as a docstring linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,9 @@ jobs:
       - run:
           name: Lint code with bandit
           command: ~/.local/bin/bandit -qr src/ralph
+      - run:
+          name: Lint code with pydocstyle
+          command: ~/.local/bin/pydocstyle
 
   test:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - Add `host` and `port` options for the `runserver` cli command
 - Add support for database selection when running the Ralph LRS server
 - Implement support for xAPI statement forwarding
+- Implement pydocstyle config for docstring check
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ lint: \
   lint-black \
   lint-flake8 \
   lint-pylint \
-  lint-bandit
+  lint-bandit \
+  lint-pydocstyle
 .PHONY: lint
 
 lint-black: ## lint back-end python sources with black
@@ -101,6 +102,10 @@ lint-bandit: ## lint back-end python sources with bandit
 	@echo 'lint:bandit started…'
 	@$(COMPOSE_TEST_RUN_APP) bandit -qr src/ralph
 .PHONY: lint-bandit
+
+lint-pydocstyle: ## Lint Python docstrings with pydocstyle
+	@echo 'lint:pydocstyle started…'
+	@$(COMPOSE_TEST_RUN_APP) pydocstyle
 
 logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app

--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -1,6 +1,5 @@
-"""
-Gitlint extra rule to validate that the message title is of the form
-"<gitmoji>(<scope>) <subject>"
+"""Gitlint extra rule to validate that the message title is of the form
+"<gitmoji>(<scope>) <subject>".
 """
 from __future__ import unicode_literals
 
@@ -12,11 +11,10 @@ from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
 
 
 class GitmojiTitle(LineRule):
-    """
-    This rule will enforce that each commit title is of the form
+    """The rule will enforce that each commit title is of the form
     "<gitmoji>(<scope>) <subject>" where gitmoji is an emoji from the list
     defined in https://gitmoji.carloscuesta.me and subject should be all
-    lowercase
+    lowercase.
     """
 
     id = "UC1"
@@ -24,8 +22,7 @@ class GitmojiTitle(LineRule):
     target = CommitMessageTitle
 
     def validate(self, title, _commit):
-        """
-        Download the list possible gitmojis from the project's github
+        """Download the list possible gitmojis from the project's github
         repository and check that title contains one of them.
         """
         gitmojis = requests.get(

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ dev =
     mkdocs-click==0.8.0
     mkdocs-material==8.4.1
     mkdocstrings[python-legacy]==0.19.0
+    pydocstyle==6.1.1
     pyfakefs==4.5.6
     pylint==2.14.5
     pytest==7.1.2
@@ -104,6 +105,11 @@ exclude =
     __pycache__,
     node_modules,
     */migrations/*
+
+[pydocstyle]
+convention = numpy
+add-ignore = D100, D104, D105, D106, D202, D205, D400, D401, D406, D407
+match = .*\.py
 
 [isort]
 known_ralph=ralph

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,8 +108,8 @@ exclude =
 
 [pydocstyle]
 convention = numpy
-add-ignore = D100, D104, D105, D106, D202, D205, D400, D401, D406, D407
-match = .*\.py
+add-ignore = D104, D105, D106, D202, D205, D400, D406, D407
+match = ^(?!(setup)\.(py)$).*\.(py)$
 
 [isort]
 known_ralph=ralph

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
-"""Ralph module"""
+"""Ralph module."""
 
 __version__ = "2.1.0"

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -12,5 +12,4 @@ app.include_router(statements.router)
 @app.get("/whoami")
 async def whoami(user: AuthenticatedUser = Depends(authenticated_user)):
     """Return the current user's username along with their scopes."""
-
     return {"username": user.username, "scopes": user.scopes}

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,6 +1,5 @@
-"""
-Main module for Ralph's LRS API.
-"""
+"""Main module for Ralph's LRS API."""
+
 from fastapi import Depends, FastAPI
 
 from .auth import AuthenticatedUser, authenticated_user
@@ -12,7 +11,6 @@ app.include_router(statements.router)
 
 @app.get("/whoami")
 async def whoami(user: AuthenticatedUser = Depends(authenticated_user)):
-    """
-    Return the current user's username along with their scopes.
-    """
+    """Return the current user's username along with their scopes."""
+
     return {"username": user.username, "scopes": user.scopes}

--- a/src/ralph/api/auth.py
+++ b/src/ralph/api/auth.py
@@ -32,7 +32,7 @@ class AuthenticatedUser(BaseModel):
 @lru_cache()
 def get_stored_credentials(auth_file):
     """
-    Helper to read the credentials/scopes file to JSON and memoize it so we do not
+    Retrieve credentials/scopes file to JSON and memorize it so we do not
     reload it with every request.
     """
     try:

--- a/src/ralph/api/auth.py
+++ b/src/ralph/api/auth.py
@@ -1,6 +1,4 @@
-"""
-Authentication & authorization related tools for the Ralph API.
-"""
+"""Authentication & authorization related tools for the Ralph API."""
 import json
 from functools import lru_cache
 

--- a/src/ralph/api/forwarding.py
+++ b/src/ralph/api/forwarding.py
@@ -1,4 +1,4 @@
-"""xAPI statement forwarding background task"""
+"""xAPI statement forwarding background task."""
 
 import logging
 from functools import lru_cache
@@ -12,8 +12,7 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 def get_active_xapi_forwardings() -> list[XapiForwardingConfigurationSettings]:
-    """Returns a list of active xAPI forwarding configuration settings."""
-
+    """Return a list of active xAPI forwarding configuration settings."""
     active_forwardings = []
     if not settings.XAPI_FORWARDINGS:
         logger.info("No xAPI forwarding configured; forwarding is disabled.")
@@ -33,8 +32,7 @@ def get_active_xapi_forwardings() -> list[XapiForwardingConfigurationSettings]:
 
 
 async def forward_xapi_statements(statements: list[dict]):
-    """Forwards xAPI statements."""
-
+    """Forward xAPI statements."""
     for forwarding in get_active_xapi_forwardings():
         transport = AsyncHTTPTransport(retries=forwarding.max_retries)
         async with AsyncClient(transport=transport) as client:

--- a/src/ralph/api/models.py
+++ b/src/ralph/api/models.py
@@ -24,7 +24,7 @@ class BaseModelWithLaxConfig(BaseModel):
     """
 
     class Config:
-        """Enable extra properties so we do not have to perform comprehensive 
+        """Enable extra properties so we do not have to perform comprehensive
         validation.
         """
 

--- a/src/ralph/api/models.py
+++ b/src/ralph/api/models.py
@@ -1,5 +1,4 @@
-"""
-Define API-specific data models so we can be exactly as lax as we want
+"""Define API-specific data models so we can be exactly as lax as we want
 when it comes to exact object shape and validation.
 """
 from typing import Optional
@@ -20,31 +19,26 @@ class ErrorDetail(BaseModel):
 
 
 class BaseModelWithLaxConfig(BaseModel):
-    """
-    Common base lax model to perform light input validation as
+    """Common base lax model to perform light input validation as
     we receive statements through the API.
     """
 
     class Config:
-        """
-        Enable extra properties so we do not have to perform comprehensive validation.
+        """Enable extra properties so we do not have to perform comprehensive 
+        validation.
         """
 
         extra = Extra.allow
 
 
 class LaxObjectField(BaseModelWithLaxConfig):
-    """
-    Lightest definition of an object field compliant to the specification.
-    """
+    """Lightest definition of an object field compliant to the specification."""
 
     id: AnyUrl
 
 
 class LaxVerbField(BaseModelWithLaxConfig):
-    """
-    Lightest definition of a verb field compliant to the specification.
-    """
+    """Lightest definition of a verb field compliant to the specification."""
 
     id: AnyUrl
 

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -1,4 +1,4 @@
-"""API routes related to statements"""
+"""API routes related to statements."""
 
 import logging
 from datetime import datetime
@@ -171,7 +171,7 @@ async def get(
         ),
     ),
 ):
-    """Fetches a single xAPI Statement or multiple xAPI Statements.
+    """Fetch a single xAPI Statement or multiple xAPI Statements.
 
     LRS Specification:
     https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md#213-get-statements
@@ -230,7 +230,7 @@ async def post(
     statements: Union[LaxStatement, list[LaxStatement]],
     background_tasks: BackgroundTasks,
 ):
-    """Stores a set of statements (or a single statement as a single member of a set).
+    """Store a set of statements (or a single statement as a single member of a set).
 
     NB: at this time, using POST to make a GET request, is not supported.
     LRS Specification:

--- a/src/ralph/backends/database/__init__.py
+++ b/src/ralph/backends/database/__init__.py
@@ -1,4 +1,4 @@
-"""Database backends for Ralph"""
+"""Database backends for Ralph."""
 
 from .base import BaseDatabase  # noqa: F401
 from .es import ESDatabase  # noqa: F401

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -1,4 +1,4 @@
-"""Base database backend for Ralph"""
+"""Base database backend for Ralph."""
 
 import functools
 import logging
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseQuery(BaseModel):
-    """Base query model"""
+    """Base query model."""
 
     class Config:
         """Base query model configuration."""
@@ -63,7 +63,6 @@ def enforce_query_checks(method):
     @functools.wraps(method)
     def wrapper(*args, **kwargs):
         """Wrap method execution."""
-
         query = kwargs.pop("query", None)
         self_ = args[0]
 
@@ -79,8 +78,7 @@ class BaseDatabase(ABC):
     query_model = BaseQuery
 
     def validate_query(self, query: BaseQuery = None):
-        """Validate database query"""
-
+        """Validate database query."""
         if query is None:
             query = self.query_model()
 
@@ -97,7 +95,7 @@ class BaseDatabase(ABC):
     @abstractmethod
     @enforce_query_checks
     def get(self, query: BaseQuery = None, chunk_size: int = 10):
-        """Reads `chunk_size` records from the database query results and yields
+        """Read `chunk_size` records from the database query results and yields
         them.
         """
 
@@ -108,7 +106,7 @@ class BaseDatabase(ABC):
         chunk_size: int = 10,
         ignore_errors: bool = False,
     ) -> int:
-        """Writes `chunk_size` records from the `stream` to the database.
+        """Write `chunk_size` records from the `stream` to the database.
 
         Returns:
             int: The count of successfully written records.
@@ -116,8 +114,8 @@ class BaseDatabase(ABC):
 
     @abstractmethod
     def query_statements(self, params: StatementParameters) -> StatementQueryResult:
-        """Returns the statements query payload using xAPI parameters."""
+        """Return the statements query payload using xAPI parameters."""
 
     @abstractmethod
     def query_statements_by_ids(self, ids: list[str]) -> list:
-        """Returns the list of matching statement IDs from the database."""
+        """Return the list of matching statement IDs from the database."""

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -1,4 +1,4 @@
-"""Elasticsearch database backend for Ralph"""
+"""Elasticsearch database backend for Ralph."""
 
 import json
 import logging
@@ -51,9 +51,9 @@ class ESDatabase(BaseDatabase):
         client_options: dict = es_settings.CLIENT_OPTIONS,
         op_type: str = es_settings.OP_TYPE,
     ):
-        """Instantiates the Elasticsearch client.
+        """Instantiate the Elasticsearch client.
 
-        Args:
+        Parameters:
             hosts (list): List of Elasticsearch nodes we should connect to.
             index (str): The Elasticsearch index name.
             client_options (dict): A dictionary of valid options for the
@@ -75,7 +75,7 @@ class ESDatabase(BaseDatabase):
 
     @enforce_query_checks
     def get(self, query: ESQuery = None, chunk_size: int = 500):
-        """Gets index documents and yields them.
+        """Get index documents and yields them.
 
         The `query` dictionary should only contains kwargs compatible with the
         elasticsearch.helpers.scan function signature (API reference
@@ -91,7 +91,7 @@ class ESDatabase(BaseDatabase):
     def to_documents(
         self, stream: TextIO, get_id: Callable[[dict], str]
     ) -> Generator[dict, None, None]:
-        """Converts `stream` lines to ES documents."""
+        """Convert `stream` lines to ES documents."""
 
         for line in stream:
             item = json.loads(line) if isinstance(line, str) else line
@@ -109,7 +109,7 @@ class ESDatabase(BaseDatabase):
     def put(
         self, stream: TextIO, chunk_size: int = 500, ignore_errors: bool = False
     ) -> int:
-        """Writes documents from the `stream` to the instance index."""
+        """Write documents from the `stream` to the instance index."""
 
         logger.debug(
             "Start writing to the %s index (chunk size: %d)", self.index, chunk_size
@@ -134,7 +134,7 @@ class ESDatabase(BaseDatabase):
         return documents
 
     def query_statements(self, params: StatementParameters) -> StatementQueryResult:
-        """Returns the results of a statements query using xAPI parameters."""
+        """Return the results of a statements query using xAPI parameters."""
 
         es_query_filters = []
 
@@ -203,13 +203,13 @@ class ESDatabase(BaseDatabase):
         )
 
     def query_statements_by_ids(self, ids: list[str]) -> list:
-        """Returns the list of matching statement IDs from the database."""
+        """Return the list of matching statement IDs from the database."""
 
         body = {"query": {"terms": {"_id": ids}}}
         return self._search(index=self.index, body=body)["hits"]["hits"]
 
     def _search(self, **kwargs):
-        """Wraps the ElasticSearch.search method to raise a BackendException in case
+        """Wrap the ElasticSearch.search method to raise a BackendException in case
         of any failure.
         """
 
@@ -221,7 +221,7 @@ class ESDatabase(BaseDatabase):
             raise BackendException(msg, *error.args) from error
 
     def _open_point_in_time(self, **kwargs):
-        """Wraps the ElasticSearch.open_point_in_time method to raise a BackendException
+        """Wrap the ElasticSearch.open_point_in_time method to raise a BackendException
         in case of any failure.
         """
 

--- a/src/ralph/backends/mixins.py
+++ b/src/ralph/backends/mixins.py
@@ -1,4 +1,4 @@
-"""Backend mixins for Ralph"""
+"""Backend mixins for Ralph."""
 
 import json
 import logging
@@ -15,8 +15,7 @@ class HistoryMixin:
 
     @property
     def history(self):
-        """Get backend history"""
-
+        """Get backend history."""
         logger.debug("Loading history file: %s", str(settings.HISTORY_FILE))
 
         if not hasattr(self, "_history"):
@@ -31,8 +30,7 @@ class HistoryMixin:
 
     # pylint: disable=no-self-use
     def write_history(self, history):
-        """Write given history as a JSON file"""
-
+        """Write given history as a JSON file."""
         logger.debug("Writing history file: %s", str(settings.HISTORY_FILE))
 
         if not settings.HISTORY_FILE.parent.exists():
@@ -55,13 +53,11 @@ class HistoryMixin:
         self.write_history(self._history)
 
     def append_to_history(self, event):
-        """Append event to history"""
-
+        """Append event to history."""
         self.write_history(self.history + [event])
 
     def get_command_history(self, backend_name, command):
-        """Returns a set of entry ids from the history for a command and backend_name"""
-
+        """Return a set of entry ids from the history for a command and backend_name."""
         return [
             entry["id"]
             for entry in filter(

--- a/src/ralph/backends/mixins.py
+++ b/src/ralph/backends/mixins.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 
 class HistoryMixin:
     """Handle backend download history to avoid fetching same files multiple
-    times if they are already available."""
+    times if they are already available.
+    """
 
     @property
     def history(self):

--- a/src/ralph/backends/storage/base.py
+++ b/src/ralph/backends/storage/base.py
@@ -1,4 +1,4 @@
-"""Base storage backend for Ralph"""
+"""Base storage backend for Ralph."""
 
 from abc import ABC, abstractmethod
 from typing import Iterable
@@ -11,16 +11,16 @@ class BaseStorage(ABC):
 
     @abstractmethod
     def list(self, details=False, new=False):
-        """Lists files in the storage backend."""
+        """List files in the storage backend."""
 
     @abstractmethod
     def url(self, name):
-        """Gets `name` file absolute URL."""
+        """Get `name` file absolute URL."""
 
     @abstractmethod
     def read(self, name, chunk_size: int = 4096):
-        """Reads `name` file and yields its content by chunks of a given size."""
+        """Read `name` file and yields its content by chunks of a given size."""
 
     @abstractmethod
     def write(self, stream: Iterable, name, overwrite=False):
-        """Writes content to the `name` target."""
+        """Write content to the `name` target."""

--- a/src/ralph/backends/storage/fs.py
+++ b/src/ralph/backends/storage/fs.py
@@ -1,4 +1,4 @@
-"""FileSystem storage backend for Ralph"""
+"""FileSystem storage backend for Ralph."""
 
 import datetime
 import logging
@@ -19,8 +19,7 @@ class FSStorage(HistoryMixin, BaseStorage):
     name = "fs"
 
     def __init__(self, path: str = settings.BACKENDS.STORAGE.FS.PATH):
-        """Creates the path directory if it does not exist."""
-
+        """Create the path directory if it does not exist."""
         self._path = Path(path)
         if not self._path.is_dir():
             logger.info("FS storage directory doesn't exist, creating: %s", self._path)
@@ -29,10 +28,9 @@ class FSStorage(HistoryMixin, BaseStorage):
         logger.debug("File system storage path: %s", self._path)
 
     def _get_filepath(self, name, strict=False):
-        """Returns path of the archive in the FS storage, or throws an exception if
+        """Return path of the archive in the FS storage, or throws an exception if
         not found.
         """
-
         file_path = self._path / Path(name)
         if strict and not file_path.exists():
             msg = "%s file does not exist"
@@ -41,8 +39,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         return file_path
 
     def _details(self, name):
-        """Gets `name` archive details."""
-
+        """Get `name` archive details."""
         file_path = self._get_filepath(name)
         stats = file_path.stat()
 
@@ -55,8 +52,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         }
 
     def list(self, details=False, new=False):
-        """Lists files in the storage backend."""
-
+        """List files in the storage backend."""
         archives = [archive.name for archive in self._path.iterdir()]
         logger.debug("Found %d archives", len(archives))
 
@@ -68,13 +64,11 @@ class FSStorage(HistoryMixin, BaseStorage):
             yield self._details(archive) if details else archive
 
     def url(self, name):
-        """Gets `name` file absolute URL."""
-
+        """Get `name` file absolute URL."""
         return str(self._get_filepath(name).resolve(strict=True))
 
     def read(self, name, chunk_size: int = 4096):
-        """Reads `name` file and yields its content by chunks of a given size."""
-
+        """Read `name` file and yields its content by chunks of a given size."""
         logger.debug("Getting archive: %s", name)
 
         with self._get_filepath(name).open("rb") as file:
@@ -96,8 +90,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         )
 
     def write(self, stream, name, overwrite=False):
-        """Writes content to the `name` target."""
-
+        """Write content to the `name` target."""
         logger.debug("Creating archive: %s", name)
 
         file_path = self._get_filepath(name)

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -1,4 +1,4 @@
-"""OVH's LDP storage backend for Ralph"""
+"""OVH's LDP storage backend for Ralph."""
 
 import logging
 
@@ -32,8 +32,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         service_name: str = ldp_settings.SERVICE_NAME,
         stream_id: str = ldp_settings.STREAM_ID,
     ):
-        """Instantiates the OVH's LDP client."""
-
+        """Instantiate the OVH's LDP client."""
         self._endpoint = endpoint
         self._application_key = application_key
         self._application_secret = application_secret
@@ -63,7 +62,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         )
 
     def _details(self, name):
-        """Returns `name` archive details.
+        """Return `name` archive details.
 
         Expected JSON response looks like:
 
@@ -81,8 +80,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         return self.client.get(f"{self._archive_endpoint}/{name}")
 
     def url(self, name):
-        """Gets archive absolute URL."""
-
+        """Get archive absolute URL."""
         download_url_endpoint = f"{self._archive_endpoint}/{name}/url"
 
         response = self.client.post(download_url_endpoint)
@@ -92,13 +90,12 @@ class LDPStorage(HistoryMixin, BaseStorage):
         return download_url
 
     def list(self, details=False, new=False):
-        """Lists archives for a given stream.
+        """List archives for a given stream.
 
-        Args:
+        Parameters:
             details (bool): Get detailed archive information instead of just ids.
             new (bool): Given the history, list only not already fetched archives.
         """
-
         list_archives_endpoint = self._archive_endpoint
         logger.debug("List archives endpoint: %s", list_archives_endpoint)
         logger.debug("List archives details: %s", str(details))
@@ -114,8 +111,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
             yield self._details(archive) if details else archive
 
     def read(self, name, chunk_size=4096):
-        """Reads the `name` archive file and yields its content."""
-
+        """Read the `name` archive file and yields its content."""
         logger.debug("Getting archive: %s", name)
 
         # Get detailed information about the archive to fetch
@@ -141,8 +137,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         )
 
     def write(self, stream, name, overwrite=False):
-        """LDP storage backend is read-only, calling this method will raise an error"""
-
+        """LDP storage backend is read-only, calling this method will raise an error."""
         msg = "LDP storage backend is read-only, cannot write to %s"
         logger.error(msg, name)
         raise NotImplementedError(msg % name)

--- a/src/ralph/backends/storage/swift.py
+++ b/src/ralph/backends/storage/swift.py
@@ -1,4 +1,4 @@
-"""Swift storage backend for Ralph"""
+"""Swift storage backend for Ralph."""
 
 import logging
 from functools import cached_property
@@ -39,7 +39,7 @@ class SwiftStorage(
         os_auth_url: str = swift_settings.OS_AUTH_URL,
         os_identity_api_version: str = swift_settings.OS_IDENTITY_API_VERSION,
     ):
-        """Prepares the options for the SwiftService."""
+        """Prepare the options for the SwiftService."""
 
         self.os_tenant_id = os_tenant_id
         self.os_tenant_name = os_tenant_name
@@ -62,8 +62,7 @@ class SwiftStorage(
 
     @cached_property
     def options(self):
-        """Returns the required options for the SwiftService."""
-
+        """Return the required options for the SwiftService."""
         return {
             "os_auth_url": self.os_auth_url,
             "os_identity_api_version": self.os_identity_api_version,
@@ -78,8 +77,7 @@ class SwiftStorage(
         }
 
     def list(self, details=False, new=False):
-        """Lists files in the storage backend."""
-
+        """List files in the storage backend."""
         archives_to_skip = set()
         if new:
             archives_to_skip = set(self.get_command_history(self.name, "fetch"))
@@ -95,13 +93,13 @@ class SwiftStorage(
                     yield archive if details else archive["name"]
 
     def url(self, name):
-        """Gets `name` file absolute URL."""
+        """Get `name` file absolute URL."""
 
         # What's the purpose of this function ? Seems not used anywhere.
         return f"{self.options.get('os_storage_url')}/{name}"
 
     def read(self, name, chunk_size=None):
-        """Reads `name` object and yields its content in chunks of (max) 2 ** 16.
+        """Read `name` object and yields its content in chunks of (max) 2 ** 16.
 
         Why chunks of (max) 2 ** 16 ?
             Because SwiftService opens a file to stream the object into:
@@ -137,7 +135,7 @@ class SwiftStorage(
         )
 
     def write(self, stream, name, overwrite=False):
-        """Writes data from `stream` to the `name` target in chunks of (max) 2 ** 16."""
+        """Write data from `stream` to the `name` target in chunks of (max) 2 ** 16."""
 
         if not overwrite and name in list(self.list()):
             msg = "%s already exists and overwrite is not allowed"

--- a/src/ralph/backends/stream/__init__.py
+++ b/src/ralph/backends/stream/__init__.py
@@ -1,4 +1,4 @@
-"""Stream backends for Ralph"""
+"""Stream backends for Ralph."""
 
 from .base import BaseStream  # noqa: F401
 from .ws import WSStream  # noqa: F401

--- a/src/ralph/backends/stream/base.py
+++ b/src/ralph/backends/stream/base.py
@@ -1,4 +1,4 @@
-"""Base Stream backend for Ralph"""
+"""Base Stream backend for Ralph."""
 
 from abc import ABC, abstractmethod
 from typing import BinaryIO
@@ -11,4 +11,4 @@ class BaseStream(ABC):
 
     @abstractmethod
     def stream(self, target: BinaryIO):
-        """Reads records and streams them to target."""
+        """Read records and streams them to target."""

--- a/src/ralph/backends/stream/ws.py
+++ b/src/ralph/backends/stream/ws.py
@@ -1,4 +1,4 @@
-"""Websocket stream backend for Ralph"""
+"""Websocket stream backend for Ralph."""
 
 import asyncio
 import logging
@@ -19,18 +19,16 @@ class WSStream(BaseStream):
     name = "ws"
 
     def __init__(self, uri: str = settings.BACKENDS.STREAM.WS.URI):
-        """Instantiates the websocket client.
+        """Instantiate the websocket client.
 
-        Args:
+        Parameters:
             uri (str): The URI to connect to.
         """
-
         self.uri = uri
 
     def stream(self, target: BinaryIO):
         """Streams websocket content to target."""
         # pylint: disable=no-member
-
         logger.debug("Streaming from websocket uri: %s", self.uri)
 
         async def _stream():

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -1,4 +1,4 @@
-"""Ralph CLI entrypoint"""
+"""Ralph CLI entrypoint."""
 
 import json
 import logging
@@ -29,8 +29,7 @@ class CommaSeparatedTupleParamType(click.ParamType):
     name = "value1,value2,value3"
 
     def convert(self, value, param, ctx):
-        """Splits the value by comma to return a tuple of values."""
-
+        """Split the value by comma to return a tuple of values."""
         if isinstance(value, str):
             return tuple(value.split(","))
 
@@ -50,10 +49,9 @@ class CommaSeparatedKeyValueParamType(click.ParamType):
     name = "key=value,key=value"
 
     def convert(self, value, param, ctx):
-        """Splits the values by comma and equal sign to return a dictionary build with
+        """Split the values by comma and equal sign to return a dictionary build with
         key/value pairs.
         """
-
         if isinstance(value, dict):
             return value
 
@@ -93,7 +91,6 @@ class JSONStringParamType(click.ParamType):
 
     def convert(self, value, param, ctx):
         """Load value as a json string and return a dict."""
-
         try:
             options = json.loads(value)
         except (json.JSONDecodeError, TypeError):
@@ -116,7 +113,6 @@ class JSONStringParamType(click.ParamType):
 )
 def cli(verbosity=None):
     """Ralph is a stream-based tool to play with your logs."""
-
     configure_logging()
     if verbosity is not None:
         level = getattr(logging, verbosity, None)
@@ -177,8 +173,7 @@ def backends_options(name=None, backend_types: list[BaseModel] = None):
     help="Container format parser used to extract events",
 )
 def extract(parser):
-    """Extracts input events from a container format using a dedicated parser."""
-
+    """Extract input events from a container format using a dedicated parser."""
     logger.info("Extracting events using the %s parser", parser)
 
     parser = getattr(settings.PARSERS, parser.upper()).get_instance()
@@ -211,8 +206,7 @@ def extract(parser):
     help="Stop validating at first unknown event",
 )
 def validate(format_, ignore_errors, fail_on_unknown):
-    """Validates input events of given format."""
-
+    """Validate input events of given format."""
     logger.info(
         "Validating %s events (ignore_errors=%s | fail-on-unknown=%s)",
         format_,
@@ -274,8 +268,7 @@ def validate(format_, ignore_errors, fail_on_unknown):
     help="Stop converting at first unknown event",
 )
 def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs):
-    """Converts input events to a given format."""
-
+    """Convert input events to a given format."""
     logger.info(
         "Converting %s events to %s format (ignore_errors=%s | fail-on-unknown=%s)",
         from_,
@@ -313,7 +306,6 @@ def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs)
 )
 def fetch(backend, archive, chunk_size, query, **options):
     """Fetch an archive or records from a configured backend."""
-
     logger.info(
         (
             "Fetching data from the configured %s backend "
@@ -376,7 +368,6 @@ def fetch(backend, archive, chunk_size, query, **options):
 )
 def push(backend, archive, chunk_size, force, ignore_errors, **options):
     """Push an archive to a configured backend."""
-
     logger.info("Pushing archive %s to the configured %s backend", archive, backend)
     logger.debug("Backend parameters: %s", options)
 
@@ -408,7 +399,6 @@ def push(backend, archive, chunk_size, force, ignore_errors, **options):
 )
 def list_(details, new, backend, **options):
     """List available archives from a configured storage backend."""
-
     logger.info("Listing archives for the configured %s backend", backend)
     logger.debug("Fetch details: %s", str(details))
     logger.debug("Backend parameters: %s", options)
@@ -444,11 +434,10 @@ def list_(details, new, backend, **options):
     help="LRS server port",
 )
 def runserver(backend: str, host: str, port: int, **options):
-    """Runs the API server for the development environment.
+    """Run the API server for the development environment.
 
     Starts uvicorn programmatically for convenience and documentation.
     """
-
     logger.info("Running API server on %s:%s with %s backend", host, port, backend)
     logger.info(
         (

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -1,4 +1,4 @@
-"""Configurations for Ralph"""
+"""Configurations for Ralph."""
 
 import io
 from pathlib import Path
@@ -21,7 +21,7 @@ class BaseSettingsConfig:
 
 
 class CoreSettings(BaseSettings):
-    """Represents Ralph's core settings."""
+    """Represent Ralph's core settings."""
 
     class Config(BaseSettingsConfig):
         """Pydantic Configuration."""
@@ -34,13 +34,12 @@ core_settings = CoreSettings()
 
 
 class CommaSeparatedTuple(str):
-    """Represents a pydantic field type validating comma separated strings or tuples."""
+    """Represent a pydantic field type validating comma separated strings or tuples."""
 
     @classmethod
     def __get_validators__(cls):
         def validate(value: Union[str, tuple[str]]) -> tuple[str]:
-            """Checks whether the value is a comma separated string or a tuple."""
-
+            """Check whether the value is a comma separated string or a tuple."""
             if isinstance(value, tuple):
                 return value
 
@@ -53,7 +52,7 @@ class CommaSeparatedTuple(str):
 
 
 class InstantiableSettingsItem(BaseModel):
-    """Represents a settings configuration item that can be instantiated."""
+    """Represent a settings configuration item that can be instantiated."""
 
     class Config:  # pylint: disable=missing-class-docstring
         underscore_attrs_are_private = True
@@ -61,8 +60,7 @@ class InstantiableSettingsItem(BaseModel):
     _class_path: str = None
 
     def get_instance(self, **init_parameters):
-        """Returns an instance of the settings item class using it's `_class_path`."""
-
+        """Return an instance of the settings item class using it's `_class_path`."""
         return import_string(self._class_path)(**init_parameters)
 
 
@@ -70,7 +68,7 @@ class InstantiableSettingsItem(BaseModel):
 
 
 class ESDatabaseBackendSettings(InstantiableSettingsItem):
-    """Represents the Elasticsearch database backend configuration settings."""
+    """Represent the Elasticsearch database backend configuration settings."""
 
     _class_path: str = "ralph.backends.database.es.ESDatabase"
 
@@ -81,7 +79,7 @@ class ESDatabaseBackendSettings(InstantiableSettingsItem):
 
 
 class MongoDatabaseBackendSettings(InstantiableSettingsItem):
-    """Represents the Mongo database backend configuration settings."""
+    """Represent the Mongo database backend configuration settings."""
 
     _class_path: str = "ralph.backends.database.mongo.MongoDatabase"
 
@@ -92,7 +90,7 @@ class MongoDatabaseBackendSettings(InstantiableSettingsItem):
 
 
 class DatabaseBackendSettings(BaseModel):
-    """Represents database backend configuration settings."""
+    """Represent database backend configuration settings."""
 
     ES: ESDatabaseBackendSettings = ESDatabaseBackendSettings()
     MONGO: MongoDatabaseBackendSettings = MongoDatabaseBackendSettings()
@@ -102,7 +100,7 @@ class DatabaseBackendSettings(BaseModel):
 
 
 class FSStorageBackendSettings(InstantiableSettingsItem):
-    """Represents the FileSystem storage backend configuration settings."""
+    """Represent the FileSystem storage backend configuration settings."""
 
     _class_path: str = "ralph.backends.storage.fs.FSStorage"
 
@@ -110,7 +108,7 @@ class FSStorageBackendSettings(InstantiableSettingsItem):
 
 
 class LDPStorageBackendSettings(InstantiableSettingsItem):
-    """Represents the LDP storage backend configuration settings."""
+    """Represent the LDP storage backend configuration settings."""
 
     _class_path: str = "ralph.backends.storage.ldp.LDPStorage"
 
@@ -123,7 +121,7 @@ class LDPStorageBackendSettings(InstantiableSettingsItem):
 
 
 class SWIFTStorageBackendSettings(InstantiableSettingsItem):
-    """Represents the SWIFT storage backend configuration settings."""
+    """Represent the SWIFT storage backend configuration settings."""
 
     _class_path: str = "ralph.backends.storage.swift.SwiftStorage"
 
@@ -140,7 +138,7 @@ class SWIFTStorageBackendSettings(InstantiableSettingsItem):
 
 
 class StorageBackendSettings(BaseModel):
-    """Represents storage backend configuration settings."""
+    """Represent storage backend configuration settings."""
 
     LDP: LDPStorageBackendSettings = LDPStorageBackendSettings()
     FS: FSStorageBackendSettings = FSStorageBackendSettings()
@@ -151,7 +149,7 @@ class StorageBackendSettings(BaseModel):
 
 
 class WSStreamBackendSettings(InstantiableSettingsItem):
-    """Represents the Websocket stream backend configuration settings."""
+    """Represent the Websocket stream backend configuration settings."""
 
     _class_path: str = "ralph.backends.stream.ws.WSStream"
 
@@ -159,7 +157,7 @@ class WSStreamBackendSettings(InstantiableSettingsItem):
 
 
 class StreamBackendSettings(BaseModel):
-    """Represents stream backend configuration settings."""
+    """Represent stream backend configuration settings."""
 
     WS: WSStreamBackendSettings = WSStreamBackendSettings()
 
@@ -168,7 +166,7 @@ class StreamBackendSettings(BaseModel):
 
 
 class BackendSettings(BaseModel):
-    """Represents backends configuration settings."""
+    """Represent backends configuration settings."""
 
     DATABASE: DatabaseBackendSettings = DatabaseBackendSettings()
     STORAGE: StorageBackendSettings = StorageBackendSettings()
@@ -179,26 +177,26 @@ class BackendSettings(BaseModel):
 
 
 class ESParserSettings(InstantiableSettingsItem):
-    """Represents the Elastisearch parser configuration settings."""
+    """Represent the Elastisearch parser configuration settings."""
 
     _class_path: str = "ralph.parsers.ElasticSearchParser"
 
 
 class GELFParserSettings(InstantiableSettingsItem):
-    """Represents the GELF parser configuration settings."""
+    """Represent the GELF parser configuration settings."""
 
     _class_path: str = "ralph.parsers.GELFParser"
 
 
 class ParserSettings(BaseModel):
-    """Represents parsers configuration settings."""
+    """Represent parsers configuration settings."""
 
     GELF: GELFParserSettings = GELFParserSettings()
     ES: ESParserSettings = ESParserSettings()
 
 
 class XapiForwardingConfigurationSettings(BaseModel):
-    """Represents an xAPI forwarding configuration item."""
+    """Represent an xAPI forwarding configuration item."""
 
     class Config:  # pylint: disable=missing-class-docstring
         min_anystr_length = 1
@@ -212,7 +210,7 @@ class XapiForwardingConfigurationSettings(BaseModel):
 
 
 class Settings(BaseSettings):
-    """Represents Ralph's global environment & configuration settings."""
+    """Represent Ralph's global environment & configuration settings."""
 
     class Config(BaseSettingsConfig):
         """Pydantic Configuration."""
@@ -269,14 +267,12 @@ class Settings(BaseSettings):
 
     @property
     def APP_DIR(self) -> Path:  # pylint: disable=invalid-name
-        """Returns the path to Ralph's configuration directory."""
-
+        """Return the path to Ralph's configuration directory."""
         return self._CORE.APP_DIR
 
     @property
     def LOCALE_ENCODING(self) -> str:  # pylint: disable=invalid-name
-        """Returns Ralph's default locale encoding."""
-
+        """Return Ralph's default locale encoding."""
         return self._CORE.LOCALE_ENCODING
 
 

--- a/src/ralph/exceptions.py
+++ b/src/ralph/exceptions.py
@@ -1,6 +1,4 @@
-"""
-Ralph exceptions.
-"""
+"""Ralph exceptions."""
 
 
 class BackendException(Exception):

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -6,7 +6,7 @@ from .exceptions import EventKeyError
 def anonymous(event):
     """Remove anonymous events.
 
-    Args:
+    Parameters:
         event (dict): Event to filter.
 
     Returns:
@@ -16,7 +16,6 @@ def anonymous(event):
     Raises:
         EventKeyError: When the event does not contain the `username` key.
     """
-
     if "username" not in event:
         raise EventKeyError("Cannot filter anonymous event without 'username' key.")
     if not event.get("username", ""):

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -1,6 +1,5 @@
-"""
-Ralph tracking logs filters.
-"""
+"""Ralph tracking logs filters."""
+
 from .exceptions import EventKeyError
 
 
@@ -16,7 +15,6 @@ def anonymous(event):
 
     Raises:
         EventKeyError: When the event does not contain the `username` key.
-
     """
 
     if "username" not in event:

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -8,7 +8,6 @@ from ralph.exceptions import ConfigurationException
 
 def configure_logging():
     """Set up Ralph logging configuration."""
-
     try:
         dictConfig(settings.LOGGING)
     except Exception as error:

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -1,4 +1,4 @@
-""""Ralph logging manager"""
+"""Ralph logging manager."""
 
 from logging.config import dictConfig
 

--- a/src/ralph/models/converter.py
+++ b/src/ralph/models/converter.py
@@ -1,4 +1,4 @@
-"""Converter methods definition"""
+"""Converter methods definition."""
 
 import json
 import logging
@@ -35,9 +35,9 @@ class ConversionItem:
     raw_input: bool
 
     def __init__(self, dest: str, src=None, transformers=lambda _: _, raw_input=False):
-        """Initializes ConversionItem.
+        """Initialize ConversionItem.
 
-        Args:
+        Parameters:
             dest (str): The destination path where to place the converted value.
             src (str or None): The source from where the value to convert is fetched.
                 - When `src` is a path (ex. `context__user_id`) - the value is the item
@@ -48,7 +48,6 @@ class ConversionItem:
             raw_input (bool): Flag indicating whether `get_value` will receive a raw
                 event string or a parsed event dictionary.
         """
-
         object.__setattr__(self, "dest", tuple(dest.split(MODEL_PATH_SEPARATOR)))
         src = tuple(src.split(MODEL_PATH_SEPARATOR)) if src else None
         object.__setattr__(self, "src", src)
@@ -57,15 +56,14 @@ class ConversionItem:
         object.__setattr__(self, "raw_input", raw_input)
 
     def get_value(self, data: Union[dict, str]):
-        """Returns fetched source value after having applied all transformers to it.
+        """Return fetched source value after having applied all transformers to it.
 
-        Args:
+        Parameters:
             data (dict or string): The event to convert.
 
         Raises:
             ConversionException: When a field transformation fails.
         """
-
         if self.src:
             data = get_dict_value_from_path(data, self.src)
         try:
@@ -87,13 +85,12 @@ class BaseConversionSet(ABC):
     __dest__: BaseModel
 
     def __init__(self):
-        """Initializes BaseConversionSet."""
-
+        """Initialize BaseConversionSet."""
         self._conversion_items = self._get_conversion_items()
 
     @abstractmethod
     def _get_conversion_items(self) -> set[ConversionItem]:
-        """Returns a set of ConversionItems used for conversion."""
+        """Return a set of ConversionItems used for conversion."""
 
     def __iter__(self):
         return iter(self._conversion_items)
@@ -102,10 +99,10 @@ class BaseConversionSet(ABC):
 def convert_dict_event(
     event: dict, event_str: str, conversion_set: BaseConversionSet
 ) -> BaseModel:
-    """Converts the event dictionary using the provided original event string and
+    """Convert the event dictionary using the provided original event string and
     conversion_set.
 
-    Args:
+    Parameters:
         event (dict): The event to convert.
         event_str (dict): The original event string.
         conversion_set (BaseConversionSet): A conversion set used for conversion.
@@ -117,7 +114,6 @@ def convert_dict_event(
         ConversionException: When a field transformation fails.
         ValidationError: When the final converted event is invalid.
     """
-
     converted_event = {}
     for conversion_item in conversion_set:
         data = event_str if conversion_item.raw_input else event
@@ -129,9 +125,9 @@ def convert_dict_event(
 
 
 def convert_str_event(event_str: str, conversion_set: BaseConversionSet) -> BaseModel:
-    """Converts the event string using the provided conversion_set.
+    """Convert the event string using the provided conversion_set.
 
-    Args:
+    Parameters:
         event_str (str): The event to convert.
         conversion_set (BaseConversionSet): A conversion set used for conversion.
 
@@ -143,7 +139,6 @@ def convert_str_event(event_str: str, conversion_set: BaseConversionSet) -> Base
         ConversionException: When a field transformation fails.
         ValidationError: When the converted event is invalid.
     """
-
     try:
         event = json.loads(event_str)
     except (TypeError, json.JSONDecodeError) as err:
@@ -153,7 +148,7 @@ def convert_str_event(event_str: str, conversion_set: BaseConversionSet) -> Base
 
 
 class Converter:
-    """Converts events using pydantic models."""
+    """Convert events using pydantic models."""
 
     def __init__(
         self,
@@ -161,8 +156,7 @@ class Converter:
         module="ralph.models.edx.converters.xapi",
         **conversion_set_kwargs,
     ):
-        """Initializes the Converter."""
-
+        """Initialize the Converter."""
         self.model_selector = model_selector
         self.src_conversion_set = self.get_src_conversion_set(
             import_module(module), **conversion_set_kwargs
@@ -170,8 +164,7 @@ class Converter:
 
     @staticmethod
     def get_src_conversion_set(module: ModuleType, **conversion_set_kwargs):
-        """Returns a dictionary of initialized conversion_sets defined in the module."""
-
+        """Return a dictionary of initialized conversion_sets defined in the module."""
         src_conversion_set = {}
         for _, class_ in getmembers(module, isclass):
             if issubclass(class_, BaseConversionSet):
@@ -179,8 +172,7 @@ class Converter:
         return src_conversion_set
 
     def convert(self, input_file: TextIO, ignore_errors: bool, fail_on_unknown: bool):
-        """Converts JSON event strings line by line."""
-
+        """Convert JSON event strings line by line."""
         total = 0
         success = 0
         for event_str in input_file:
@@ -211,9 +203,9 @@ class Converter:
         logger.info("Total events: %d, Invalid events: %d", total, total - success)
 
     def _convert_event(self, event_str: str):
-        """Converts a single JSON string event.
+        """Convert a single JSON string event.
 
-        Args:
+        Parameters:
             event_str (str): The event to convert.
 
         Returns:
@@ -228,7 +220,6 @@ class Converter:
             ConversionException: When a field transformation fails.
             ValidationError: When the final converted event is invalid.
         """
-
         event = json.loads(event_str)
         model = self.model_selector.get_model(event)
         conversion_set = self.src_conversion_set.get(model, None)

--- a/src/ralph/models/edx/__init__.py
+++ b/src/ralph/models/edx/__init__.py
@@ -1,4 +1,4 @@
-"""edX pydantic models"""
+"""edX pydantic models."""
 
 # flake8: noqa
 

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -1,4 +1,4 @@
-"""Base event model definitions"""
+"""Base event model definitions."""
 
 from datetime import datetime
 from ipaddress import IPv4Address

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,4 +1,4 @@
-"""Browser event model definitions"""
+"""Browser event model definitions."""
 
 from typing import Literal, Union
 

--- a/src/ralph/models/edx/converters/xapi/__init__.py
+++ b/src/ralph/models/edx/converters/xapi/__init__.py
@@ -1,4 +1,4 @@
-"""edX to xAPI conversion sets"""
+"""edX to xAPI conversion sets."""
 
 # flake8: noqa
 

--- a/src/ralph/models/edx/converters/xapi/base.py
+++ b/src/ralph/models/edx/converters/xapi/base.py
@@ -1,4 +1,4 @@
-"""Base xAPI Converter"""
+"""Base xAPI Converter."""
 
 import re
 from uuid import UUID, uuid5
@@ -25,8 +25,7 @@ class BaseXapiConverter(BaseConversionSet):
     """
 
     def __init__(self, uuid_namespace: str, platform_url: str):
-        """Initializes BaseXapiConverter."""
-
+        """Initialize BaseXapiConverter."""
         self.platform_url = platform_url
         try:
             self.uuid_namespace = UUID(uuid_namespace)
@@ -35,8 +34,7 @@ class BaseXapiConverter(BaseConversionSet):
         super().__init__()
 
     def _get_conversion_items(self):
-        """Returns a set of ConversionItems used for conversion."""
-
+        """Return a set of ConversionItems used for conversion."""
         return {
             ConversionItem(
                 "id",
@@ -71,10 +69,9 @@ class BaseXapiConverter(BaseConversionSet):
 
     @staticmethod
     def parse_course_id(course_id: str):
-        """Returns a dictionary with `course` and `module` of edX event's
+        """Return a dictionary with `course` and `module` of edX event's
         `context.course_id`.
         """
-
         match = re.match(r"^course-v1:.+\+(.+)\+(.+)$", course_id)
         if not match:
             return {"course": None, "module": None}

--- a/src/ralph/models/edx/converters/xapi/navigational.py
+++ b/src/ralph/models/edx/converters/xapi/navigational.py
@@ -1,4 +1,4 @@
-"""Navigational event xAPI Converter"""
+"""Navigational event xAPI Converter."""
 
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.navigational.statements import UIPageClose
@@ -8,7 +8,7 @@ from .base import BaseXapiConverter
 
 
 class UIPageCloseToPageTerminated(BaseXapiConverter):
-    """Converts a common edX `page_close` event to xAPI.
+    """Convert a common edX `page_close` event to xAPI.
 
     Example Statement: John terminated https://www.fun-mooc.fr/ page.
 
@@ -20,7 +20,6 @@ class UIPageCloseToPageTerminated(BaseXapiConverter):
     __dest__ = PageTerminated
 
     def _get_conversion_items(self):
-        """Returns a set of ConversionItems used for conversion."""
-
+        """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union({ConversionItem("object__id", "page")})

--- a/src/ralph/models/edx/converters/xapi/server.py
+++ b/src/ralph/models/edx/converters/xapi/server.py
@@ -1,4 +1,4 @@
-"""Server event xAPI Converter"""
+"""Server event xAPI Converter."""
 
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.server import Server
@@ -8,7 +8,7 @@ from .base import BaseXapiConverter
 
 
 class ServerEventToPageViewed(BaseXapiConverter):
-    """Converts a common edX server event to xAPI.
+    """Convert a common edX server event to xAPI.
 
     Example Statement: John viewed https://www.fun-mooc.fr/ page.
     """
@@ -17,7 +17,7 @@ class ServerEventToPageViewed(BaseXapiConverter):
     __dest__ = PageViewed
 
     def _get_conversion_items(self):
-        """Returns a set of ConversionItems used for conversion."""
+        """Return a set of ConversionItems used for conversion."""
 
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/enrollment/fields/contexts.py
+++ b/src/ralph/models/edx/enrollment/fields/contexts.py
@@ -1,4 +1,4 @@
-"""Enrollment event models context fields definitions"""
+"""Enrollment event models context fields definitions."""
 
 from typing import Literal, Union
 

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -1,4 +1,4 @@
-"""Enrollment models event field definition"""
+"""Enrollment models event field definition."""
 
 from typing import Literal, Union
 

--- a/src/ralph/models/edx/enrollment/statements.py
+++ b/src/ralph/models/edx/enrollment/statements.py
@@ -1,4 +1,4 @@
-"""Enrollment event model definitions"""
+"""Enrollment event model definitions."""
 
 from typing import Literal, Union
 

--- a/src/ralph/models/edx/navigational/fields/events.py
+++ b/src/ralph/models/edx/navigational/fields/events.py
@@ -1,4 +1,4 @@
-"""Navigational event field definition"""
+"""Navigational event field definition."""
 
 from pydantic import constr
 

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -1,4 +1,4 @@
-"""Navigational event model definitions"""
+"""Navigational event model definitions."""
 
 from typing import Literal, Union
 
@@ -73,7 +73,7 @@ class UISeqNext(BaseBrowserModel):
     @validator("event")
     @classmethod
     def validate_next_jump_event_field(cls, value):
-        """Checks that event.new is equal to event.old + 1."""
+        """Check that event.new is equal to event.old + 1."""
 
         if value.new != value.old + 1:
             raise ValueError("event.new - event.old should be equal to 1")
@@ -104,7 +104,7 @@ class UISeqPrev(BaseBrowserModel):
     @validator("event")
     @classmethod
     def validate_prev_jump_event_field(cls, value):
-        """Checks that event.new is equal to event.old - 1."""
+        """Check that event.new is equal to event.old - 1."""
 
         if value.new != value.old - 1:
             raise ValueError("event.old - event.new should be equal to 1")

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -1,4 +1,4 @@
-"""Problem interaction events model event fields definitions"""
+"""Problem interaction events model event fields definitions."""
 
 from datetime import datetime
 from typing import Literal, Optional, Union

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -1,4 +1,4 @@
-"""Problem interaction events model definitions"""
+"""Problem interaction events model definitions."""
 
 from typing import Literal, Union
 

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -1,4 +1,4 @@
-"""Server event model definitions"""
+"""Server event model definitions."""
 
 from pathlib import Path
 from typing import Literal, Union

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -1,4 +1,4 @@
-"""Textbook interaction event fields definitions"""
+"""Textbook interaction event fields definitions."""
 
 from typing import Literal, Optional, Union
 

--- a/src/ralph/models/edx/textbook_interaction/statements.py
+++ b/src/ralph/models/edx/textbook_interaction/statements.py
@@ -1,4 +1,4 @@
-"""Textbook interaction event model definitions"""
+"""Textbook interaction event model definitions."""
 
 from typing import Literal, Union
 

--- a/src/ralph/models/edx/video/fields/events.py
+++ b/src/ralph/models/edx/video/fields/events.py
@@ -1,4 +1,4 @@
-"""Video event fields definitions"""
+"""Video event fields definitions."""
 
 from typing import Literal
 

--- a/src/ralph/models/edx/video/statements.py
+++ b/src/ralph/models/edx/video/statements.py
@@ -1,4 +1,4 @@
-"""Video event model definitions"""
+"""Video event model definitions."""
 
 from typing import Literal, Optional, Union
 

--- a/src/ralph/models/selector.py
+++ b/src/ralph/models/selector.py
@@ -1,4 +1,4 @@
-"""Model selector definition"""
+"""Model selector definition."""
 
 from collections import Counter
 from dataclasses import dataclass
@@ -33,9 +33,9 @@ class Rule:
     value: Union[LazyModelField, Any]  # pylint: disable=unsubscriptable-object
 
     def check(self, event):
-        """Checks if event matches the rule.
+        """Check if event matches the rule.
 
-        Args:
+        Parameters:
             event (dict): The event to check.
         """
 
@@ -47,10 +47,10 @@ class Rule:
 
 
 class ModelRules(dict):
-    """Stores the list of rules for each model."""
+    """Store the list of rules for each model."""
 
     def __setitem__(self, new_model: Type[BaseModel], new_rules: list[Rule]):
-        """Inserts a new model with it's associated list of rules.
+        """Insert a new model with it's associated list of rules.
 
         Raises:
             ModelRulesException: When new_rules list is a subset or superset of
@@ -68,9 +68,9 @@ class ModelRules(dict):
 
 
 def selector(**filters):
-    """Returns a list of rules that should match in order to select an event.
+    """Return a list of rules that should match in order to select an event.
 
-    Args:
+    Parameters:
         **filters: Each keyword represents the path to a field, the corresponding
             value represents the value which the field should match.
             Example: `event_type="server"` will generate a Rule verifying that
@@ -89,14 +89,14 @@ class ModelSelector:
     """
 
     def __init__(self, module="ralph.models.edx"):
-        """Instantiates ModelSelector."""
+        """Instantiate ModelSelector."""
 
         self.model_rules = ModelSelector.build_model_rules(import_module(module))
         self.decision_tree = self.get_decision_tree(self.model_rules)
 
     @staticmethod
     def build_model_rules(module: ModuleType):
-        """Builds the model_rules dictionary from BaseModel classes defined
+        """Build the model_rules dictionary from BaseModel classes defined
         in the module.
         """
 
@@ -110,7 +110,7 @@ class ModelSelector:
         """Recursively walks through the decision tree to return the matching model
         for the event.
 
-        Args:
+        Parameters:
             event (dict): Event to retrieve the corresponding model.
             tree (dict): The (sub) decision tree, `None` stands for the whole decision
                          tree.

--- a/src/ralph/models/validator.py
+++ b/src/ralph/models/validator.py
@@ -14,16 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 class Validator:
-    """Validates events using pydantic models."""
+    """Validate events using pydantic models."""
 
     def __init__(self, model_selector: ModelSelector):
-        """Initializes Validator."""
-
+        """Initialize Validator."""
         self.model_selector = model_selector
 
     def validate(self, input_file: TextIO, ignore_errors: bool, fail_on_unknown: bool):
-        """Validates JSON event strings line by line."""
-
+        """Validate JSON event strings line by line."""
         total = 0
         success = 0
         for event_str in input_file:
@@ -48,7 +46,7 @@ class Validator:
         logger.info("Total events: %d, Invalid events: %d", total, total - success)
 
     def _validate_event(self, event_str: str):
-        """Validates a single JSON string event.
+        """Validate a single JSON string event.
 
         Raises:
             TypeError: When the event_str is not of type string.
@@ -59,7 +57,6 @@ class Validator:
         Returns:
             event_str (str): The cleaned JSON-formatted input event_str.
         """
-
         event = json.loads(event_str)
         return self.model_selector.get_model(event)(**event).json()
 

--- a/src/ralph/models/validator.py
+++ b/src/ralph/models/validator.py
@@ -1,4 +1,4 @@
-"""Event validator definition"""
+"""Event validator definition."""
 
 
 import json
@@ -55,6 +55,7 @@ class Validator:
             JSONDecodeError: When the event_str is not a valid JSON string.
             UnknownEventException: When no matching model is found for the event.
             ValidationError: When the event is failing the pydantic model validation.
+
         Returns:
             event_str (str): The cleaned JSON-formatted input event_str.
         """

--- a/src/ralph/models/xapi/__init__.py
+++ b/src/ralph/models/xapi/__init__.py
@@ -1,4 +1,4 @@
-"""xAPI pydantic models"""
+"""xAPI pydantic models."""
 
 # flake8: noqa
 

--- a/src/ralph/models/xapi/base.py
+++ b/src/ralph/models/xapi/base.py
@@ -1,4 +1,4 @@
-"""Base xAPI model definition"""
+"""Base xAPI model definition."""
 
 from datetime import datetime
 from typing import Optional
@@ -47,12 +47,11 @@ class BaseXapiModel(BaseModelWithConfig):
     @root_validator(pre=True)
     @classmethod
     def check_abscence_of_empty_and_invalid_values(cls, values):
-        """Checks the model for empty and invalid values.
+        """Check the model for empty and invalid values.
 
         Checks that the `context` field contains `platform` and `revision` fields
         only if the `object.objectType` property is equal to `Activity`.
         """
-
         for field, value in list(values.items()):
             if value in [None, "", {}]:
                 raise ValueError(f"{field}: invalid empty value")

--- a/src/ralph/models/xapi/config.py
+++ b/src/ralph/models/xapi/config.py
@@ -1,4 +1,4 @@
-"""Base xAPI model configuration"""
+"""Base xAPI model configuration."""
 
 from pydantic import BaseModel, Extra
 

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -1,4 +1,4 @@
-"""Constants for xAPI specifications"""
+"""Constants for xAPI specifications."""
 
 from typing import Literal
 

--- a/src/ralph/models/xapi/fields/actors.py
+++ b/src/ralph/models/xapi/fields/actors.py
@@ -1,4 +1,4 @@
-"""Common xAPI actor field definitions"""
+"""Common xAPI actor field definitions."""
 
 from typing import Literal, Optional, Union
 

--- a/src/ralph/models/xapi/fields/attachments.py
+++ b/src/ralph/models/xapi/fields/attachments.py
@@ -1,4 +1,4 @@
-"""Common xAPI attachments field definitions"""
+"""Common xAPI attachments field definitions."""
 
 from typing import Optional
 

--- a/src/ralph/models/xapi/fields/common.py
+++ b/src/ralph/models/xapi/fields/common.py
@@ -1,4 +1,4 @@
-"""Common xAPI field definitions"""
+"""Common xAPI field definitions."""
 
 from langcodes import tag_is_valid
 from pydantic import StrictStr, validate_email
@@ -11,8 +11,7 @@ class IRI(str):
     @classmethod
     def __get_validators__(cls):
         def validate(iri: str):
-            """Checks whether the provided IRI is a valid RFC 3987 IRI."""
-
+            """Check whether the provided IRI is a valid RFC 3987 IRI."""
             parse(iri, rule="IRI")
             return cls(iri)
 
@@ -25,8 +24,7 @@ class LanguageTag(str):
     @classmethod
     def __get_validators__(cls):
         def validate(tag: str):
-            """Checks whether the provided tag is a valid RFC 5646 Language tag."""
-
+            """Check whether the provided tag is a valid RFC 5646 Language tag."""
             if not tag_is_valid(tag):
                 raise TypeError("Invalid RFC 5646 Language tag")
             return cls(tag)
@@ -45,8 +43,7 @@ class MailtoEmail(str):
     @classmethod
     def __get_validators__(cls):
         def validate(mailto: str):
-            """Checks whether the provided value follows the `mailto:email` format."""
-
+            """Check whether the provided value follows the `mailto:email` format."""
             if not mailto.startswith("mailto:"):
                 raise TypeError("Invalid `mailto:email` value")
             valid = validate_email(mailto[7:])

--- a/src/ralph/models/xapi/fields/contexts.py
+++ b/src/ralph/models/xapi/fields/contexts.py
@@ -1,4 +1,4 @@
-"""Common xAPI context field definitions"""
+"""Common xAPI context field definitions."""
 
 from typing import Optional, Union
 from uuid import UUID

--- a/src/ralph/models/xapi/fields/objects.py
+++ b/src/ralph/models/xapi/fields/objects.py
@@ -1,4 +1,4 @@
-"""Common xAPI object field definitions"""
+"""Common xAPI object field definitions."""
 
 # Nota bene: we split object definitions into `objects.py` and `unnested_objects.py`
 # because of the circular dependency : objects -> context -> objects.

--- a/src/ralph/models/xapi/fields/results.py
+++ b/src/ralph/models/xapi/fields/results.py
@@ -1,4 +1,4 @@
-"""Common xAPI result field definitions"""
+"""Common xAPI result field definitions."""
 
 from datetime import timedelta
 from decimal import Decimal
@@ -28,8 +28,7 @@ class ScoreResultField(BaseModelWithConfig):
     @root_validator
     @classmethod
     def check_raw_min_max_relation(cls, values):
-        """Checks the relationship `min < raw < max`."""
-
+        """Check the relationship `min < raw < max`."""
         raw_value = values.get("raw", None)
         min_value = values.get("min", None)
         max_value = values.get("max", None)

--- a/src/ralph/models/xapi/fields/unnested_objects.py
+++ b/src/ralph/models/xapi/fields/unnested_objects.py
@@ -1,4 +1,4 @@
-"""Common xAPI object field definitions"""
+"""Common xAPI object field definitions."""
 
 from typing import Literal, Optional, Union
 from uuid import UUID
@@ -74,7 +74,7 @@ class InteractionObjectDefinitionField(ObjectDefinitionField):
     @validator("choices", "scale", "source", "target", "steps")
     @classmethod
     def check_unique_ids(cls, value):
-        """Checks the uniqueness of interaction components IDs."""
+        """Check the uniqueness of interaction components IDs."""
 
         if len(value) != len({x.id for x in value}):
             raise ValueError("Duplicate InteractionComponents are not valid")

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -1,4 +1,4 @@
-"""Common xAPI verb field definitions"""
+"""Common xAPI verb field definitions."""
 
 from typing import Optional
 

--- a/src/ralph/models/xapi/navigation/fields/objects.py
+++ b/src/ralph/models/xapi/navigation/fields/objects.py
@@ -1,4 +1,4 @@
-"""Navigation xAPI events object fields definitions"""
+"""Navigation xAPI events object fields definitions."""
 
 from typing import Optional
 

--- a/src/ralph/models/xapi/navigation/statements.py
+++ b/src/ralph/models/xapi/navigation/statements.py
@@ -1,4 +1,4 @@
-"""Navigation xAPI event definitions"""
+"""Navigation xAPI event definitions."""
 
 from ...selector import selector
 from ..base import BaseXapiModel

--- a/src/ralph/models/xapi/video/constants.py
+++ b/src/ralph/models/xapi/video/constants.py
@@ -1,4 +1,4 @@
-"""Constants for xAPI video specifications"""
+"""Constants for xAPI video specifications."""
 
 from typing import Literal
 

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -1,4 +1,4 @@
-"""Video xAPI events context fields definitions"""
+"""Video xAPI events context fields definitions."""
 
 from typing import Literal, Optional
 

--- a/src/ralph/models/xapi/video/fields/objects.py
+++ b/src/ralph/models/xapi/video/fields/objects.py
@@ -1,4 +1,4 @@
-"""Video xAPI events object fields definitions"""
+"""Video xAPI events object fields definitions."""
 
 from typing import Optional
 

--- a/src/ralph/models/xapi/video/fields/results.py
+++ b/src/ralph/models/xapi/video/fields/results.py
@@ -1,4 +1,4 @@
-"""Video xAPI events result fields definitions"""
+"""Video xAPI events result fields definitions."""
 
 from datetime import timedelta
 from typing import Literal, Optional

--- a/src/ralph/models/xapi/video/fields/verbs.py
+++ b/src/ralph/models/xapi/video/fields/verbs.py
@@ -1,4 +1,4 @@
-"""Video xAPI events verb fields definitions"""
+"""Video xAPI events verb fields definitions."""
 
 from ...constants import (
     LANG_EN_US_DISPLAY,

--- a/src/ralph/models/xapi/video/statements.py
+++ b/src/ralph/models/xapi/video/statements.py
@@ -1,4 +1,4 @@
-"""Video xAPI event definitions"""
+"""Video xAPI event definitions."""
 
 from ...selector import selector
 from ..base import BaseXapiModel

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -1,6 +1,4 @@
-"""
-Ralph tracking logs parsers.
-"""
+"""Ralph tracking logs parsers."""
 
 import json
 import logging

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -14,9 +14,9 @@ class BaseParser(ABC):
 
     @abstractmethod
     def parse(self, input_file):
-        """Parses GELF formatted logs (one JSON string event per row).
+        """Parse GELF formatted logs (one JSON string event per row).
 
-        Args:
+        Parameters:
             input_file (file-like): The log file to parse.
 
         Yields:
@@ -34,9 +34,9 @@ class GELFParser(BaseParser):
     name = "gelf"
 
     def parse(self, input_file):
-        """Parses GELF formatted logs (one JSON string event per row).
+        """Parse GELF formatted logs (one JSON string event per row).
 
-        Args:
+        Parameters:
             input_file (file-like): The log file to parse.
 
         Yields:
@@ -67,9 +67,9 @@ class ElasticSearchParser(BaseParser):
     name = "es"
 
     def parse(self, input_file):
-        """Parses Elasticsearch JSON documents.
+        """Parse Elasticsearch JSON documents.
 
-        Args:
+        Parameters:
             input_file (file-like): The file containing Elasticsearch JSON documents.
 
         Yields:

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -1,4 +1,4 @@
-"""Utilities for Ralph"""
+"""Utilities for Ralph."""
 
 import datetime
 import logging
@@ -32,8 +32,7 @@ def import_string(dotted_path):
 
 
 def get_backend_type(backends: BaseModel, backend_name: str):
-    """Returns the backend type from a backend name."""
-
+    """Return the backend type from a backend name."""
     backend_name = backend_name.upper()
     for _, backend_type in backends:
         if hasattr(backend_type, backend_name):
@@ -42,7 +41,7 @@ def get_backend_type(backends: BaseModel, backend_name: str):
 
 
 def get_backend_instance(backend_type: BaseModel, backend_name: str, options: dict):
-    """Returns the instantiated backend instance given backend-name-prefixed options."""
+    """Return the instantiated backend instance given backend-name-prefixed options."""
 
     prefix = f"{backend_name}_"
     # Filter backend-related parameters. Parameter name is supposed to start
@@ -53,8 +52,7 @@ def get_backend_instance(backend_type: BaseModel, backend_name: str, options: di
 
 
 def get_root_logger():
-    """Get main Ralph logger"""
-
+    """Get main Ralph logger."""
     ralph_logger = logging.getLogger("ralph")
     ralph_logger.propagate = True
 
@@ -62,13 +60,12 @@ def get_root_logger():
 
 
 def now():
-    """Return the current UTC time in ISO format"""
-
+    """Return the current UTC time in ISO format."""
     return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
 
 def get_dict_value_from_path(dict_: dict, path: list[str]):
-    """Gets a nested dictionary value using an array of keys representing the path
+    """Get a nested dictionary value using an array of keys representing the path
     to the value.
     """
 
@@ -81,7 +78,7 @@ def get_dict_value_from_path(dict_: dict, path: list[str]):
 
 
 def set_dict_value_from_path(dict_: dict, path: list[str], value: any):
-    """Sets a nested dictionary value using an array of keys representing the path
+    """Set a nested dictionary value using an array of keys representing the path
     to the value.
     """
 

--- a/tests/api/test_forwarding.py
+++ b/tests/api/test_forwarding.py
@@ -1,4 +1,4 @@
-"""Tests for the xAPI statements forwarding background task"""
+"""Tests for the xAPI statements forwarding background task."""
 
 import asyncio
 import json
@@ -152,10 +152,10 @@ def test_api_forwarding_forward_xapi_statements_with_successful_request(
 
         @staticmethod
         def raise_for_status():
-            """Does not raise any exceptions."""
+            """Do not raise any exceptions."""
 
     async def post_success(*args, **kwargs):  # pylint: disable=unused-argument
-        """Returns a MockSuccessfulResponse instance."""
+        """Return a MockSuccessfulResponse instance."""
 
         return MockSuccessfulResponse()
 
@@ -193,12 +193,11 @@ def test_api_forwarding_forward_xapi_statements_with_unsuccessful_request(
 
         @staticmethod
         def raise_for_status():
-            """Dummy raise_for_status method that is always raising an exception."""
-
+            """Fake raise_for_status method that is always raising an exception."""
             raise RequestError("Failure during request.")
 
     async def post_fail(*args, **kwargs):  # pylint: disable=unused-argument
-        """Returns a MockUnsuccessfulResponse instance."""
+        """Return a MockUnsuccessfulResponse instance."""
 
         return MockUnsuccessfulResponse()
 

--- a/tests/api/test_statements.py
+++ b/tests/api/test_statements.py
@@ -1,4 +1,4 @@
-"""Tests for the statements endpoint of the Ralph API"""
+"""Tests for the statements endpoint of the Ralph API."""
 
 from importlib import reload
 

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -1,4 +1,4 @@
-"""Tests for the GET statements endpoint of the Ralph API"""
+"""Tests for the GET statements endpoint of the Ralph API."""
 
 import re
 from datetime import datetime, timedelta
@@ -24,7 +24,7 @@ client = TestClient(app)
 
 
 def insert_es_statements(es_client, statements):
-    """Inserts a bunch of example statements into Elasticsearch for testing."""
+    """Insert a bunch of example statements into Elasticsearch for testing."""
 
     bulk(
         es_client,
@@ -42,7 +42,7 @@ def insert_es_statements(es_client, statements):
 
 
 def insert_mongo_statements(mongo_client, statements):
-    """Inserts a bunch of example statements into MongoDB for testing."""
+    """Insert a bunch of example statements into MongoDB for testing."""
 
     database = getattr(mongo_client, MONGO_TEST_DATABASE)
     collection = getattr(database, MONGO_TEST_COLLECTION)
@@ -55,7 +55,7 @@ def insert_statements_and_monkeypatch_backend(request, es, mongo, monkeypatch):
     # pylint: disable=invalid-name
 
     def _insert_statements_and_monkeypatch_backend(statements):
-        """Inserts statements once into Elasticsearch and once into MongoDB."""
+        """Insert statements once into Elasticsearch and once into MongoDB."""
 
         database_client_class_path = "ralph.api.routers.statements.DATABASE_CLIENT"
         if request.param == "mongo":
@@ -397,7 +397,7 @@ def test_api_statements_get_statements_with_database_query_failure(
     # pylint: disable=redefined-outer-name
 
     def mock_query_statements(*_):
-        """Mocks the DATABASE_CLIENT.query_statements method."""
+        """Mock the DATABASE_CLIENT.query_statements method."""
 
         raise BackendException()
 

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -1,4 +1,4 @@
-"""Tests for the POST statements endpoint of the Ralph API"""
+"""Tests for the POST statements endpoint of the Ralph API."""
 
 import re
 from uuid import uuid4
@@ -266,7 +266,7 @@ def test_api_statements_post_statements_with_a_failure_during_storage(
     # pylint: disable=invalid-name,unused-argument, too-many-arguments
 
     def put_mock(*args, **kwargs):
-        """Raises an exception. Mocks the database.put method."""
+        """Raise an exception. Mocks the database.put method."""
 
         raise BackendException()
 
@@ -307,7 +307,7 @@ def test_api_statements_post_statements_with_a_failure_during_id_query(
     # pylint: disable=invalid-name,unused-argument,too-many-arguments
 
     def query_statements_by_ids_mock(*args, **kwargs):
-        """Raises an exception. Mocks the database.query_statements_by_ids method."""
+        """Raise an exception. Mocks the database.query_statements_by_ids method."""
 
         raise BackendException()
 
@@ -354,7 +354,7 @@ def test_post_statements_list_without_statement_forwarding(
     spy = {}
 
     def spy_mock_forward_xapi_statements(_):
-        """Mocks the forward_xapi_statements; spies over whether it has been called."""
+        """Mock the forward_xapi_statements; spies over whether it has been called."""
 
         spy["error"] = "forward_xapi_statements should not have been called!"
 

--- a/tests/backends/database/test_es.py
+++ b/tests/backends/database/test_es.py
@@ -398,7 +398,7 @@ def test_backends_database_es_query_statements_with_pit_query_failure(
     # pylint: disable=invalid-name,unused-argument
 
     def mock_open_point_in_time(**_):
-        """Mocks the Elasticsearch.open_point_in_time method."""
+        """Mock the Elasticsearch.open_point_in_time method."""
 
         raise ValueError("ES failure")
 
@@ -425,7 +425,7 @@ def test_backends_database_es_query_statements_with_search_query_failure(
     # pylint: disable=invalid-name,unused-argument
 
     def mock_search(**_):
-        """Mocks the Elasticsearch.search method."""
+        """Mock the Elasticsearch.search method."""
 
         raise ApiError("Something is wrong", ApiResponseMeta(*([None] * 5)), None)
 
@@ -452,7 +452,7 @@ def test_backends_database_es_query_statements_by_ids_with_search_query_failure(
     # pylint: disable=invalid-name,unused-argument
 
     def mock_search(**_):
-        """Mocks the Elasticsearch.search method."""
+        """Mock the Elasticsearch.search method."""
 
         raise ApiError("Something is wrong", ApiResponseMeta(*([None] * 5)), None)
 

--- a/tests/backends/database/test_es.py
+++ b/tests/backends/database/test_es.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph es database backend"""
+"""Tests for Ralph es database backend."""
 
 import json
 import logging
@@ -65,7 +65,8 @@ def test_backends_database_es_database_instantiation_with_forbidden_op_type(es):
 
 def test_backends_database_es_client_kwargs(es):
     """Tests the ES backend client instantiation using client_options that must be
-    passed to the http(s) connection pool."""
+    passed to the http(s) connection pool.
+    """
     # pylint: disable=invalid-name,unused-argument,protected-access
 
     database = ESDatabase(

--- a/tests/backends/database/test_mongo.py
+++ b/tests/backends/database/test_mongo.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph mongo database backend"""
+"""Tests for Ralph mongo database backend."""
 
 import logging
 from datetime import datetime
@@ -406,7 +406,7 @@ def test_backends_database_mongo_query_statements_with_search_query_failure(
     # pylint: disable=unused-argument
 
     def mock_find(**_):
-        """Mocks the MongoClient.collection.find method."""
+        """Mock the MongoClient.collection.find method."""
 
         raise PyMongoError("Something is wrong")
 
@@ -437,7 +437,7 @@ def test_backends_database_mongo_query_statements_by_ids_with_search_query_failu
     # pylint: disable=unused-argument
 
     def mock_find(**_):
-        """Mocks the MongoClient.collection.find method."""
+        """Mock the MongoClient.collection.find method."""
 
         raise ValueError("Something is wrong")
 

--- a/tests/backends/storage/test_base.py
+++ b/tests/backends/storage/test_base.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph base storage backend"""
+"""Tests for Ralph base storage backend."""
 
 from ralph.backends.storage.base import BaseStorage
 

--- a/tests/backends/storage/test_fs.py
+++ b/tests/backends/storage/test_fs.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph fs storage backend"""
+"""Tests for Ralph fs storage backend."""
 
 from collections.abc import Iterable
 from pathlib import Path

--- a/tests/backends/storage/test_ldp.py
+++ b/tests/backends/storage/test_ldp.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph ldp storage backend"""
+"""Tests for Ralph ldp storage backend."""
 
 import datetime
 import gzip
@@ -94,7 +94,7 @@ def test_backends_storage_ldp_details_method(monkeypatch):
     # pylint: disable=protected-access
 
     def mock_get(url):
-        """Mocks the OVH client get request."""
+        """Mock the OVH client get request."""
 
         name = PurePath(urlparse(url).path).name
         return {
@@ -128,7 +128,7 @@ def test_backends_storage_ldp_url_method(monkeypatch):
     """Tests the LDPStorage url method."""
 
     def mock_post(url):
-        """Mocks the OVH Client post request."""
+        """Mock the OVH Client post request."""
         # pylint: disable=unused-argument
         return {
             "expirationDate": "2020-10-13T12:59:37.326131+00:00",
@@ -168,7 +168,7 @@ def test_backends_storage_ldp_list_method(monkeypatch):
     """Tests the LDPStorage list method with a blank history."""
 
     def mock_list(url):
-        """Mocks OVH client list stream archives get request."""
+        """Mock OVH client list stream archives get request."""
         # pylint: disable=unused-argument
         return [
             "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
@@ -206,7 +206,7 @@ def test_backends_storage_ldp_list_method_history_management(monkeypatch, fs):
     # pylint: disable=invalid-name
 
     def mock_list(url):
-        """Mocks the OVH client list stream archives get request."""
+        """Mock the OVH client list stream archives get request."""
         # pylint: disable=unused-argument
         return [
             "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
@@ -299,7 +299,7 @@ def test_backends_storage_ldp_list_method_with_details(monkeypatch):
     get_details_response = (response for response in details_responses)
 
     def mock_get(url):
-        """Mocks OVH client get requests."""
+        """Mock OVH client get requests."""
 
         # list request
         if url.endswith("archive"):
@@ -328,7 +328,7 @@ def test_backends_storage_ldp_list_method_with_details(monkeypatch):
 
 
 def test_backends_storage_ldp_read_method(monkeypatch, fs):
-    """Tests the LDPStorage read method with detailed output."""
+    """Test the LDPStorage read method with detailed output."""
     # pylint: disable=invalid-name
 
     # Create fake archive to stream
@@ -338,7 +338,7 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs):
         archive_file.write(bytes(json.dumps(archive_content), encoding="utf-8"))
 
     def mock_ovh_post(url):
-        """Mocks the OVH Client post request."""
+        """Mock the OVH Client post request."""
         # pylint: disable=unused-argument
 
         return {
@@ -354,7 +354,7 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs):
         }
 
     def mock_ovh_get(url):
-        """Mocks the OVH client get requests."""
+        """Mock the OVH client get requests."""
         # pylint: disable=unused-argument
 
         return {
@@ -386,10 +386,10 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs):
                     yield chunk
 
         def raise_for_status(self):
-            """Does nothing for now."""
+            """Empty function for now."""
 
     def mock_requests_get(url, stream=True):
-        """Mocks the requests get method."""
+        """Mock the requests get method."""
         # pylint: disable=unused-argument
 
         return MockRequestsResponse()
@@ -402,7 +402,7 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs):
 
         @classmethod
         def now(cls, **kwargs):
-            """Always returns the same testable now value."""
+            """Return the same testable now value everytime."""
             # pylint: disable=unused-argument
 
             return freezed_now

--- a/tests/backends/storage/test_swift.py
+++ b/tests/backends/storage/test_swift.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph swift storage backend"""
+"""Tests for Ralph swift storage backend."""
 
 import datetime
 import json
@@ -15,7 +15,7 @@ from ralph.exceptions import BackendException, BackendParameterException
 def test_backends_storage_swift_storage_instantiation_failure_should_raise_exception(
     monkeypatch, swift, caplog
 ):
-    """Checks that SwiftStorage raises BackendParameterException on failure."""
+    """Check that SwiftStorage raises BackendParameterException on failure."""
 
     error = "Unauthorized. Check username/id"
 
@@ -35,7 +35,7 @@ def test_backends_storage_swift_storage_instantiation_failure_should_raise_excep
 def test_backends_storage_swift_storage_instantiation_should_not_raise_exception(
     monkeypatch, swift
 ):
-    """Checks that SwiftStorage doesn't raise exceptions when the connection is
+    """Check that SwiftStorage doesn't raise exceptions when the connection is
     successful.
     """
 
@@ -289,7 +289,7 @@ def test_backends_storage_swift_write_should_log_the_error(
 def test_backends_storage_url_should_concatenate_the_storage_url_and_name(
     swift, monkeypatch
 ):
-    """Checks the url method returns `os_storage_url/name`."""
+    """Check the url method returns `os_storage_url/name`."""
 
     def mock_successful_stat(*args, **kwargs):  # pylint:disable=unused-argument
         return {"success": True}

--- a/tests/backends/stream/test_base.py
+++ b/tests/backends/stream/test_base.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph base stream backend"""
+"""Tests for Ralph base stream backend."""
 
 from ralph.backends.stream.base import BaseStream
 

--- a/tests/backends/stream/test_ws.py
+++ b/tests/backends/stream/test_ws.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph ws stream backend"""
+"""Tests for Ralph ws stream backend."""
 
 import json
 from io import BytesIO

--- a/tests/backends/test_mixins.py
+++ b/tests/backends/test_mixins.py
@@ -1,4 +1,4 @@
-"""Tests for ralph backends mixins"""
+"""Tests for ralph backends mixins."""
 
 import json
 import os.path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Module py.test fixtures"""
+"""Module py.test fixtures."""
 
 # pylint: disable=unused-import
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
-"""
-Module py.test fixtures
-"""
+"""Module py.test fixtures"""
+
 # pylint: disable=unused-import
 
 from .fixtures import hypothesis_configuration  # noqa: F401

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -1,4 +1,4 @@
-"""Test fixtures for backends"""
+"""Test fixtures for backends."""
 
 import asyncio
 import json
@@ -62,15 +62,13 @@ WS_TEST_PORT = 8765
 
 @lru_cache
 def get_es_test_backend():
-    """Returns a ESDatabase backend instance using test defaults."""
-
+    """Return a ESDatabase backend instance using test defaults."""
     return ESDatabase(hosts=ES_TEST_HOSTS, index=ES_TEST_INDEX)
 
 
 @lru_cache
 def get_mongo_test_backend():
-    """Returns a MongoDatabase backend instance using test defaults."""
-
+    """Return a MongoDatabase backend instance using test defaults."""
     return MongoDatabase(
         connection_uri=MONGO_TEST_CONNECTION_URI,
         database=MONGO_TEST_DATABASE,
@@ -98,10 +96,9 @@ class NamedClassEnum(Enum):
 
 
 def get_es_fixture(host=ES_TEST_HOSTS, index=ES_TEST_INDEX):
-    """Creates / deletes an ElasticSearch test index and yields an instantiated
+    """Create / deletes an ElasticSearch test index and yields an instantiated
     client.
     """
-
     client = Elasticsearch(host)
     try:
         client.indices.create(index=index)
@@ -115,17 +112,15 @@ def get_es_fixture(host=ES_TEST_HOSTS, index=ES_TEST_INDEX):
 
 @pytest.fixture
 def es():
-    """Yields an ElasticSearch test client. See get_es_fixture above."""
+    """Yield an ElasticSearch test client. See get_es_fixture above."""
     # pylint: disable=invalid-name
-
     for es_client in get_es_fixture():
         yield es_client
 
 
 @pytest.fixture
 def es_forwarding():
-    """Yields a second ElasticSearch test client. See get_es_fixture above."""
-
+    """Yield a second ElasticSearch test client. See get_es_fixture above."""
     for es_client in get_es_fixture(index=ES_TEST_FORWARDING_INDEX):
         yield es_client
 
@@ -135,10 +130,9 @@ def get_mongo_fixture(
     database=MONGO_TEST_DATABASE,
     collection=MONGO_TEST_COLLECTION,
 ):
-    """Creates / deletes a Mongo test database + collection and yields an
+    """Create / deletes a Mongo test database + collection and yields an
     instantiated client.
     """
-
     client = MongoClient(connection_uri)
     database = getattr(client, database)
     try:
@@ -154,26 +148,23 @@ def get_mongo_fixture(
 
 @pytest.fixture
 def mongo():
-    """Yields a Mongo test client. See get_mongo_fixture above."""
-
+    """Yield a Mongo test client. See get_mongo_fixture above."""
     for mongo_client in get_mongo_fixture():
         yield mongo_client
 
 
 @pytest.fixture
 def mongo_forwarding():
-    """Yields a second Mongo test client. See get_mongo_fixture above."""
-
+    """Yield a second Mongo test client. See get_mongo_fixture above."""
     for mongo_client in get_mongo_fixture(collection=MONGO_TEST_FORWARDING_COLLECTION):
         yield mongo_client
 
 
 @pytest.fixture
 def es_data_stream():
-    """Creates / deletes an ElasticSearch test datastream and yields an instantiated
+    """Create / deletes an ElasticSearch test datastream and yields an instantiated
     client.
     """
-
     client = Elasticsearch(ES_TEST_HOSTS)
 
     # Create statements index template with enabled data stream
@@ -224,11 +215,10 @@ def es_data_stream():
 
 @pytest.fixture
 def swift():
-    """Returns get_swift_storage function."""
+    """Return get_swift_storage function."""
 
     def get_swift_storage():
-        """Returns an instance of SwiftStorage."""
-
+        """Return an instance of SwiftStorage."""
         return SwiftStorage(
             os_tenant_id="os_tenant_id",
             os_tenant_name="os_tenant_name",
@@ -243,15 +233,14 @@ def swift():
 
 @pytest.fixture
 def events():
-    """Returns test events fixture."""
+    """Return test events fixture."""
     return [{"id": idx} for idx in range(10)]
 
 
 @pytest.fixture
 def ws(events):
-    """Returns a websocket server instance."""
+    """Return a websocket server instance."""
     # pylint: disable=invalid-name,redefined-outer-name
-
     async def forward(websocket, path):
         """Stupid test server that sends events."""
         # pylint: disable=unused-argument
@@ -270,9 +259,8 @@ def ws(events):
 
 @pytest.fixture
 def lrs():
-    """Returns a context manager that runs ralph's lrs server."""
+    """Return a context manager that runs ralph's lrs server."""
     # pylint: disable=invalid-name,redefined-outer-name
-
     @asynccontextmanager
     async def runserver(app, host=RUNSERVER_TEST_HOST, port=RUNSERVER_TEST_PORT):
         process = Process(

--- a/tests/fixtures/hypothesis_configuration.py
+++ b/tests/fixtures/hypothesis_configuration.py
@@ -1,4 +1,4 @@
-"""Hypothesis fixture configuration"""
+"""Hypothesis fixture configuration."""
 
 import operator
 
@@ -11,8 +11,7 @@ from ralph.models.xapi.fields.common import IRI, LanguageTag, MailtoEmail
 
 
 def is_base_model(klass):
-    """Returns True if the given class is a subclass of the pydantic BaseModel."""
-
+    """Return True if the given class is a subclass of the pydantic BaseModel."""
     try:
         return issubclass(klass, BaseModel)
     except TypeError:
@@ -20,8 +19,7 @@ def is_base_model(klass):
 
 
 def custom_resolve_json(cls):
-    """Returns a hypothesis build strategy for Json types."""
-
+    """Return a hypothesis build strategy for Json types."""
     if not is_base_model(getattr(cls, "inner_type", None)):
         return resolve_json(cls)
     return st.builds(cls.inner_type.json, st.from_type(cls.inner_type))

--- a/tests/fixtures/hypothesis_strategies.py
+++ b/tests/fixtures/hypothesis_strategies.py
@@ -1,4 +1,4 @@
-"""Hypothesis build strategies with special constraints"""
+"""Hypothesis build strategies with special constraints."""
 
 import random
 from typing import Union
@@ -19,7 +19,6 @@ OVERWRITTEN_STATEGIES = {}
 
 def get_strategy_from(annotation):
     """Infers a Hypothesis strategy from the given annotation."""
-
     origin = getattr(annotation, "__origin__", None)
     args = getattr(annotation, "__args__", None)
     if is_base_model(annotation):
@@ -42,9 +41,9 @@ def get_strategy_from(annotation):
 def custom_builds(
     klass: BaseModel, _overwrite_default=True, **kwargs: Union[st.SearchStrategy, bool]
 ):
-    """Returns a fixed_dictionaries Hypothesis strategy for pydantic models.
+    """Return a fixed_dictionaries Hypothesis strategy for pydantic models.
 
-    Args:
+    Parameters:
         klass (BaseModel): The pydantic model for which to generate a strategy.
         _overwrite_default (bool): By default, fields overwritten by kwargs become
             required. If _overwrite_default is set to False, we keep the original field
@@ -54,7 +53,6 @@ def custom_builds(
             If kwargs contains booleans, they set whether the given key should be
             present (True) or omitted (False) in the generated model.
     """
-
     for special_class, special_kwargs in OVERWRITTEN_STATEGIES.items():
         if issubclass(klass, special_class):
             kwargs = special_kwargs | kwargs
@@ -78,8 +76,7 @@ def custom_builds(
 
 
 def custom_given(*args: Union[st.SearchStrategy, BaseModel], **kwargs):
-    """Wraps the Hypothesis `given` function. Replaces st.builds with custom_builds."""
-
+    """Wrap the Hypothesis `given` function. Replaces st.builds with custom_builds."""
     strategies = []
     for arg in args:
         strategies.append(custom_builds(arg) if is_base_model(arg) else arg)

--- a/tests/fixtures/logs.py
+++ b/tests/fixtures/logs.py
@@ -1,4 +1,4 @@
-"""Logs format pytest fixtures"""
+"""Logs format pytest fixtures."""
 
 import logging
 from secrets import token_hex
@@ -11,7 +11,6 @@ from logging_gelf.formatters import GELFFormatter
 @pytest.fixture
 def gelf_logger():
     """Generate a GELF logger to generate wrapped tracking log fixtures."""
-
     with NamedTemporaryFile(mode="w+", delete=False) as temp_file:
         handler = logging.StreamHandler(temp_file)
         handler.setLevel(logging.INFO)

--- a/tests/models/edx/converters/xapi/test_base.py
+++ b/tests/models/edx/converters/xapi/test_base.py
@@ -1,4 +1,4 @@
-"""Tests for the base xAPI Converter"""
+"""Tests for the base xAPI Converter."""
 
 from uuid import UUID
 
@@ -18,7 +18,7 @@ def test_base_xapi_converter_successful_initialization(
         """Dummy implementation of abstract BaseXapiConverter."""
 
         def _get_conversion_items(self):  # pylint: disable=no-self-use
-            """Returns a set of ConversionItems used for conversion."""
+            """Return a set of ConversionItems used for conversion."""
 
             return set()
 
@@ -34,7 +34,7 @@ def test_base_xapi_converter_unsuccessful_initialization():
         """Dummy implementation of abstract BaseXapiConverter."""
 
         def _get_conversion_items(self):  # pylint: disable=no-self-use
-            """Returns a set of ConversionItems used for conversion."""
+            """Return a set of ConversionItems used for conversion."""
 
             return set()
 

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -1,4 +1,4 @@
-"""Tests for the server event xAPI converter"""
+"""Tests for the server event xAPI converter."""
 
 import json
 from uuid import UUID, uuid5

--- a/tests/models/edx/converters/xapi/test_server.py
+++ b/tests/models/edx/converters/xapi/test_server.py
@@ -1,4 +1,4 @@
-"""Tests for the server event xAPI converter"""
+"""Tests for the server event xAPI converter."""
 
 import json
 from uuid import UUID, uuid5

--- a/tests/models/edx/problem_interaction/test_events.py
+++ b/tests/models/edx/problem_interaction/test_events.py
@@ -1,4 +1,4 @@
-"""Tests for problem interaction models event fields"""
+"""Tests for problem interaction models event fields."""
 
 import json
 import re

--- a/tests/models/edx/problem_interaction/test_statements.py
+++ b/tests/models/edx/problem_interaction/test_statements.py
@@ -145,7 +145,8 @@ def test_models_edx_problem_check_fail_selector_with_valid_statement(statement):
 @custom_given(UIProblemGraded)
 def test_models_edx_ui_problem_graded_with_valid_statement(statement):
     """Tests that a `problem_graded` browser statement has the expected `event_type` and
-    `name`."""
+    `name`.
+    """
 
     assert statement.event_type == "problem_graded"
     assert statement.name == "problem_graded"
@@ -153,7 +154,8 @@ def test_models_edx_ui_problem_graded_with_valid_statement(statement):
 
 @custom_given(UIProblemGraded)
 def test_models_edx_ui_problem_graded_selector_with_valid_statement(statement):
-    """Tests given a `problem_graded` statement the selector `get_model`
+    """
+    Tests given a `problem_graded` statement the selector `get_model`
     method should return `ProblemGraded` model.
     """
 
@@ -166,7 +168,8 @@ def test_models_edx_ui_problem_graded_selector_with_valid_statement(statement):
 @custom_given(ProblemRescore)
 def test_models_edx_problem_rescore_with_valid_statement(statement):
     """Tests that a `problem_rescore` server statement has the expected `event_type` and
-    `page`."""
+    `page`.
+    """
 
     assert statement.event_type == "problem_rescore"
     assert statement.page == "x_module"
@@ -187,7 +190,8 @@ def test_models_edx_problem_rescore_selector_with_valid_statement(statement):
 @custom_given(ProblemRescoreFail)
 def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
     """Tests that a `problem_rescore` server statement has the expected `event_type` and
-    `page`."""
+    `page`.
+    """
 
     assert statement.event_type == "problem_rescore_fail"
     assert statement.page == "x_module"
@@ -195,7 +199,8 @@ def test_models_edx_problem_rescore_fail_with_valid_statement(statement):
 
 @custom_given(ProblemRescoreFail)
 def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement):
-    """Tests given a `problem_rescore_fail` statement the selector `get_model` method
+    """
+    Tests given a `problem_rescore_fail` statement the selector `get_model` method
     should return `ProblemRescoreFail` model.
     """
 
@@ -209,7 +214,8 @@ def test_models_edx_problem_rescore_fail_selector_with_valid_statement(statement
 @custom_given(UIProblemReset)
 def test_models_edx_ui_problem_reset_with_valid_statement(statement):
     """Tests that a `problem_reset` browser statement has the expected `event_type` and
-    `name`."""
+    `name`.
+    """
 
     assert statement.event_type == "problem_reset"
     assert statement.name == "problem_reset"

--- a/tests/models/edx/problem_interaction/test_statements.py
+++ b/tests/models/edx/problem_interaction/test_statements.py
@@ -1,4 +1,4 @@
-"""Tests for the problem interaction event models"""
+"""Tests for the problem interaction event models."""
 
 import json
 

--- a/tests/models/edx/test_base.py
+++ b/tests/models/edx/test_base.py
@@ -1,4 +1,4 @@
-"""Tests for the base event model"""
+"""Tests for the base event model."""
 
 import json
 import re

--- a/tests/models/edx/test_browser.py
+++ b/tests/models/edx/test_browser.py
@@ -1,4 +1,4 @@
-"""Tests for the browser event models"""
+"""Tests for the browser event models."""
 
 import json
 import re

--- a/tests/models/edx/test_enrollment.py
+++ b/tests/models/edx/test_enrollment.py
@@ -1,4 +1,4 @@
-"""Tests for the enrollment event models"""
+"""Tests for the enrollment event models."""
 
 import json
 

--- a/tests/models/edx/test_navigational.py
+++ b/tests/models/edx/test_navigational.py
@@ -1,4 +1,4 @@
-"""Tests for the navigational event models"""
+"""Tests for the navigational event models."""
 
 import json
 import re

--- a/tests/models/edx/test_server.py
+++ b/tests/models/edx/test_server.py
@@ -1,4 +1,4 @@
-"""Tests for the server event models"""
+"""Tests for the server event models."""
 
 import json
 

--- a/tests/models/edx/test_textbook_interaction.py
+++ b/tests/models/edx/test_textbook_interaction.py
@@ -1,4 +1,4 @@
-"""Tests for the textbook interaction event models"""
+"""Tests for the textbook interaction event models."""
 
 import json
 import re

--- a/tests/models/edx/video/test_events.py
+++ b/tests/models/edx/video/test_events.py
@@ -1,4 +1,4 @@
-"""Tests for video models event fields"""
+"""Tests for video models event fields."""
 
 import json
 

--- a/tests/models/edx/video/test_statements.py
+++ b/tests/models/edx/video/test_statements.py
@@ -1,4 +1,4 @@
-"""Tests for the video event models"""
+"""Tests for the video event models."""
 
 import json
 

--- a/tests/models/test_converter.py
+++ b/tests/models/test_converter.py
@@ -1,4 +1,4 @@
-"""Tests for converter method"""
+"""Tests for converter method."""
 
 import json
 import logging
@@ -116,7 +116,7 @@ def test_converter_convert_dict_event_with_empty_conversion_set(event):
         __dest__ = BaseModel
 
         def _get_conversion_items(self):  # pylint: disable=no-self-use
-            """Returns a set of ConversionItems used for conversion."""
+            """Return a set of ConversionItems used for conversion."""
 
             return set()
 
@@ -157,7 +157,7 @@ def test_converter_convert_dict_event_with_one_conversion_item(
         __dest__ = DummyBaseModel
 
         def _get_conversion_items(self):  # pylint: disable=no-self-use
-            """Returns a set of ConversionItems used for conversion."""
+            """Return a set of ConversionItems used for conversion."""
 
             return {ConversionItem("converted", source, transformer)}
 
@@ -177,7 +177,7 @@ def test_converter_convert_dict_event_with_one_conversion_item_raising_an_except
         __dest__ = BaseModel
 
         def _get_conversion_items(self):  # pylint: disable=no-self-use
-            """Returns a set of ConversionItems used for conversion."""
+            """Return a set of ConversionItems used for conversion."""
 
             return {item}
 
@@ -196,7 +196,7 @@ def test_converter_convert_str_event_with_invalid_json_string(invalid_json):
         __dest__ = BaseModel
 
         def _get_conversion_items(self):  # pylint: disable=no-self-use
-            """Returns a set of ConversionItems used for conversion."""
+            """Return a set of ConversionItems used for conversion."""
 
             return set()
 

--- a/tests/models/test_selector.py
+++ b/tests/models/test_selector.py
@@ -1,4 +1,4 @@
-"""Tests for the models selector"""
+"""Tests for the models selector."""
 
 
 import pytest

--- a/tests/models/test_validator.py
+++ b/tests/models/test_validator.py
@@ -166,7 +166,8 @@ def test_models_validator_validate_with_valid_events(
 @custom_given(UIPageClose)
 def test_models_validator_validate_counter(caplog, event):
     """Tests given multiple events the validate method
-    should log the total and invalid events."""
+    should log the total and invalid events.
+    """
 
     valid_event = event.json()
     invalid_event_1 = 1

--- a/tests/models/test_validator.py
+++ b/tests/models/test_validator.py
@@ -1,4 +1,4 @@
-"""Tests for the event validator"""
+"""Tests for the event validator."""
 
 import copy
 import json

--- a/tests/models/xapi/fields/test_actors.py
+++ b/tests/models/xapi/fields/test_actors.py
@@ -1,4 +1,4 @@
-"""Tests for the xAPI actor fields"""
+"""Tests for the xAPI actor fields."""
 
 from ralph.models.xapi.fields.actors import AccountActorField
 

--- a/tests/models/xapi/fields/test_common.py
+++ b/tests/models/xapi/fields/test_common.py
@@ -1,4 +1,4 @@
-"""Tests for common xAPI fields"""
+"""Tests for common xAPI fields."""
 
 import pytest
 from pydantic import BaseModel, ValidationError

--- a/tests/models/xapi/fields/test_objects.py
+++ b/tests/models/xapi/fields/test_objects.py
@@ -1,4 +1,4 @@
-"""Tests for the xAPI object fields"""
+"""Tests for the xAPI object fields."""
 
 from ralph.models.xapi.navigation.fields.objects import PageObjectField
 

--- a/tests/models/xapi/fields/test_verbs.py
+++ b/tests/models/xapi/fields/test_verbs.py
@@ -1,4 +1,4 @@
-"""Tests for the xAPI verb fields"""
+"""Tests for the xAPI verb fields."""
 
 import json
 

--- a/tests/models/xapi/test_base.py
+++ b/tests/models/xapi/test_base.py
@@ -1,4 +1,4 @@
-"""Tests for the BaseXapiModel"""
+"""Tests for the BaseXapiModel."""
 
 import pytest
 from hypothesis import settings

--- a/tests/models/xapi/test_navigation.py
+++ b/tests/models/xapi/test_navigation.py
@@ -1,4 +1,4 @@
-"""Tests for the xAPI navigation statements"""
+"""Tests for the xAPI navigation statements."""
 
 import json
 

--- a/tests/models/xapi/test_video.py
+++ b/tests/models/xapi/test_video.py
@@ -1,4 +1,4 @@
-"""Tests for the xAPI played statement"""
+"""Tests for the xAPI played statement."""
 
 import json
 

--- a/tests/models/xapi/test_video.py
+++ b/tests/models/xapi/test_video.py
@@ -26,7 +26,8 @@ def test_models_xapi_video_initialized_with_valid_statement(statement):
 @custom_given(VideoInitialized)
 def test_models_xapi_video_initialized_selector_with_valid_statement(statement):
     """Tests given a video initialized event, the get_model method should return
-    VideoInitialized model."""
+    VideoInitialized model.
+    """
 
     statement = json.loads(statement.json())
     assert (
@@ -113,7 +114,8 @@ def test_models_xapi_video_terminated_with_valid_statement(statement):
 @custom_given(VideoTerminated)
 def test_models_xapi_video_terminated_selector_with_valid_statement(statement):
     """Tests given a video terminated event, the get_model method should return
-    VideoTerminated model."""
+    VideoTerminated model.
+    """
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoTerminated
@@ -129,7 +131,8 @@ def test_models_xapi_video_interacted_with_valid_statement(statement):
 @custom_given(VideoInteracted)
 def test_models_xapi_video_interacted_selector_with_valid_statement(statement):
     """Tests given a video interacted event, the get_model method should return
-    VideoInteracted model."""
+    VideoInteracted model.
+    """
 
     event = json.loads(statement.json())
     assert ModelSelector(module="ralph.models.xapi").get_model(event) is VideoInteracted

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,4 @@
-"""
-Tests for authentication for the Ralph API.
-"""
+"""Tests for authentication for the Ralph API."""
 import base64
 import json
 
@@ -25,9 +23,7 @@ STORED_CREDENTIALS = json.dumps(
 
 
 def test_get_whoami_no_credentials():
-    """
-    whoami route returns a 401 error when no credentials are sent.
-    """
+    """Whoami route returns a 401 error when no credentials are sent."""
     response = client.get("/whoami")
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Basic"
@@ -35,9 +31,7 @@ def test_get_whoami_no_credentials():
 
 
 def test_get_whoami_credentials_wrong_scheme():
-    """
-    whoami route returns a 401 error when the wrong scheme is used for authorization.
-    """
+    """Whoami route returns a 401 error when the wrong scheme is used for authorization."""
     response = client.get("/whoami", headers={"Authorization": "Bearer sometoken"})
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Basic"
@@ -45,9 +39,7 @@ def test_get_whoami_credentials_wrong_scheme():
 
 
 def test_get_whoami_credentials_encoding_error():
-    """
-    whoami route returns a 401 error when the credentials' encoding is broken.
-    """
+    """Whoami route returns a 401 error when the credentials' encoding is broken."""
     response = client.get("/whoami", headers={"Authorization": "Basic not-base64"})
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Basic"
@@ -56,9 +48,7 @@ def test_get_whoami_credentials_encoding_error():
 
 # pylint: disable=invalid-name
 def test_get_whoami_credentials_username_not_found(fs):
-    """
-    whoami route returns a 401 error when the credentials' username cannot be found.
-    """
+    """Whoami route returns a 401 error when the credentials' username cannot be found."""
     credential_bytes = base64.b64encode("john:admin".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
 
@@ -74,9 +64,7 @@ def test_get_whoami_credentials_username_not_found(fs):
 
 # pylint: disable=invalid-name
 def test_get_whoami_wrong_password(fs):
-    """
-    whoami route returns a 401 error when the credentials' password is wrong.
-    """
+    """Whoami route returns a 401 error when the credentials' password is wrong."""
     credential_bytes = base64.b64encode("john:not-admin".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
 
@@ -92,8 +80,7 @@ def test_get_whoami_wrong_password(fs):
 
 # pylint: disable=invalid-name
 def test_get_whoami_correct_credentials(fs):
-    """
-    whoami returns a 200 response with the username and associated scopes when
+    """Whoami returns a 200 response with the username and associated scopes when
     the credentials are correct.
     """
     credential_bytes = base64.b64encode("ralph:admin".encode("utf-8"))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -31,7 +31,9 @@ def test_get_whoami_no_credentials():
 
 
 def test_get_whoami_credentials_wrong_scheme():
-    """Whoami route returns a 401 error when the wrong scheme is used for authorization."""
+    """Whoami route returns a 401 error when the wrong scheme is used for
+    authorization.
+    """
     response = client.get("/whoami", headers={"Authorization": "Bearer sometoken"})
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Basic"
@@ -48,7 +50,9 @@ def test_get_whoami_credentials_encoding_error():
 
 # pylint: disable=invalid-name
 def test_get_whoami_credentials_username_not_found(fs):
-    """Whoami route returns a 401 error when the credentials' username cannot be found."""
+    """Whoami route returns a 401 error when the credentials' username cannot be
+    found.
+    """
     credential_bytes = base64.b64encode("john:admin".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph cli"""
+"""Tests for Ralph cli."""
 
 import json
 import logging
@@ -36,7 +36,6 @@ test_logger = logging.getLogger("ralph")
 
 def test_cli_comma_separated_key_value_param_type():
     """Tests the CommaSeparatedKeyValueParamType custom parameter type."""
-
     param_type = CommaSeparatedKeyValueParamType()
 
     # Bad options
@@ -399,9 +398,8 @@ def test_cli_fetch_command_with_ldp_backend(monkeypatch):
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size=500):
-        """Always return the same archive."""
+        """Return the same archive everytime."""
         # pylint: disable=unused-argument
-
         yield bytes(json.dumps(archive_content), encoding="utf-8")
 
     monkeypatch.setattr(LDPStorage, "read", mock_read)
@@ -422,9 +420,8 @@ def test_cli_fetch_command_with_fs_backend(fs, monkeypatch):
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size):
-        """Always return the same archive."""
+        """Return the same archive everytime."""
         # pylint: disable=unused-argument
-
         yield bytes(json.dumps(archive_content), encoding="utf-8")
 
     monkeypatch.setattr(FSStorage, "read", mock_read)
@@ -813,7 +810,7 @@ def test_cli_runserver_command_with_host_and_port_arguments(host_, port_, monkey
     """Tests the ralph runserver command should consider the host and port arguments."""
 
     def mock_uvicorn_run(_, host=None, port=None, **kwargs):
-        """Mocks uvicorn.run asserting host and port values."""
+        """Mock uvicorn.run asserting host and port values."""
 
         assert host == host_
         assert port == int(port_)
@@ -830,7 +827,7 @@ def test_cli_runserver_command_environment_file_generation(monkeypatch):
     """Tests the ralph runserver command should create the expected environment file."""
 
     def mock_uvicorn_run(_, env_file=None, **kwargs):
-        """Mocks uvicorn.run asserting environment file content."""
+        """Mock uvicorn.run asserting environment file content."""
 
         with open(env_file, mode="r", encoding=settings.LOCALE_ENCODING) as file:
             assert file.readlines() == [

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph's configuration loading"""
+"""Tests for Ralph's configuration loading."""
 
 from importlib import reload
 from inspect import signature

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-"""Tests for the ralph.filters module"""
+"""Tests for the ralph.filters module."""
 
 import pytest
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,4 +1,4 @@
-"""Tests for the ralph.logger module"""
+"""Tests for the ralph.logger module."""
 
 import pytest
 from click.testing import CliRunner

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph utils"""
+"""Tests for Ralph utils."""
 
 import pytest
 from pydantic import BaseModel
@@ -60,7 +60,7 @@ def test_utils_get_backend_instance(options, expected):
         foo: str = "foo"  # pylint: disable=disallowed-name
 
         def get_instance(self, **init_parameters):  # pylint: disable=no-self-use
-            """Returns the init_parameters."""
+            """Return the init_parameters."""
 
             return init_parameters
 


### PR DESCRIPTION
## Purpose

This PR aims to implement the issue #154, which proposes to implement pydocstyle as a docstring linter.

I added numerous docstring error codes in ignore so we can fix them one at a time until the whole documentation is valid.

Some errors should be ignored:
- D105 can be ignored as it concern magic methods, and they oftendo not require documentation.
- D106 can also be ignored as it concerns nested classes, which are rarely documented. But it can be corrected, as there are not many D106 errors.
- D205 is problematic as some docstring titles are two lines long. I would consider ignoring it.
- D400 is linked to D205: if the title is two lines long, the first line does not end with a period. I would also ignore this error.

## Contributions

- [x] Add pydocstyle in the Makefile, in the setup.cfg and in the .circleci config.
- [x] Fix of errors D100, D401
- [ ] Fix of errors D406 and D407 (underlined sections for numpy convention)
- [ ] Fix of error D202 (Removal of unnecessary line after docstrings)
- [ ] Fix of error D104 (Public packages docstring, mostly in __init__.py files)


