### PR TITLE
🔖(major) bump release to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.0.0] - 2022-10-19
+
 ### Added
 
 - Implement edx video browser events pydantic models
@@ -178,7 +180,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v2.1.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.0.0...master
+[3.0.0]: https://github.com/openfun/ralph/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/openfun/ralph/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/openfun/ralph/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/openfun/ralph/compare/v1.2.0...v2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 2.1.0
+version = 3.0.0
 description = A learning logs processor to feed your LRS
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module"""
 
-__version__ = "2.1.0"
+__version__ = "3.0.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 2.1.0
+  version: 3.0.0


### PR DESCRIPTION
### Added

- Implement edx video browser events pydantic models
- Create a `post` endpoint for statements implementing the LRS spec
- Implement support for the MongoDB database backend
- Implement support for custom queries when using database backends `get` method (used in the `fetch` command)
- Add dotenv configuration file support and `python-dotenv` dependency
- Add `host` and `port` options for the `runserver` cli command
- Add support for database selection when running the Ralph LRS server
- Implement support for xAPI statement forwarding
- Add database backends `status` checking
- Add `health` LRS router
- Tray: add LRS server support

### Changed

- Migrate to `python-legacy` handler for `mkdocstrings` package
- Upgrade `click` to `8.1.3`
- Upgrade `elasticsearch` to `8.3.3`
- Upgrade `fastapi` to `0.79.1`
- Upgrade `ovh` to `1.0.0`
- Upgrade `pydantic` to `1.9.2`
- Upgrade `pymongo` to `4.2.0`
- Upgrade `python-keystoneclient` to `5.0.0`
- Upgrade `python-swiftclient` to `4.0.1`
- Upgrade `requests` to `2.28.1`
- Upgrade `sentry_sdk` to `1.9.5`
- Upgrade `uvicorn` to `0.18.2`
- Upgrade `websockets` to `10.3`
- Make backends yield results instead of writing to standard streams (BC)
- Use pydantic settings management instead of global variables in defaults.py
- Rename backend and parser parameter environment variables (BC)
- Make project dependencies management more modular for library usage

### Removed

- Remove YAML configuration file support and `pyyaml` dependency (BC)

### Fixed

- Tray: do not create a cronjobs list when no cronjob has been defined
- Restore history mixin logger
