### PR TITLE
Improve dependencies management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Improve Ralph's library integration by unpinning dependencies (and prefer
+  ranges)
+
 ### Removed
 
 - ModelRules constraint
-
-### Changed
-
-- Upgrade `bcrypt` to `4.0.1`
-- Upgrade `click-option-group` to `0.5.5`
-- Upgrade `elasticsearch` to `8.4.3`
-- Upgrade `fastapi` to `0.85.1`
-- Upgrade `pydantic` to `1.10.2`
-- Upgrade `pymongo` to `4.3.2`
-- Upgrade `python-keystoneclient` to `5.0.1`
-- Upgrade `python-swiftclient` to `4.1.0`
-- Upgrade `sentry_sdk` to `1.10.1`
-- Upgrade `uvicorn` to `0.19.2`
 
 ## [3.0.0] - 2022-10-19
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,9 @@ include_package_data = True
 install_requires =
     ; By default, we only consider core dependencies required to use Ralph as a
     ; library (mostly models).
-    langcodes==3.3.0
-    pydantic[dotenv,email]==1.10.2
-    rfc3987==1.3.8
+    langcodes>=3.2.0
+    pydantic[dotenv,email]>=1.10.0
+    rfc3987>=1.3.0
 package_dir =
     =src
 packages = find:
@@ -36,20 +36,21 @@ python_requires = >= 3.9
 
 [options.extras_require]
 backend-es =
-    elasticsearch==8.4.3
+    elasticsearch>=8.0.0
 backend-ldp =
-    ovh==1.0.0
-    requests==2.28.1
+    ovh>=1.0.0
+    requests>=2.0.0
 backend-mongo =
-    pymongo[srv]==4.3.2
+    pymongo[srv]>=4.0.0
 backend-swift =
-    python-keystoneclient==5.0.1
-    python-swiftclient==4.1.0
+    python-keystoneclient>=5.0.0
+    python-swiftclient>=4.0.0
 backend-ws =
-    websockets==10.3
+    websockets>=10.3
 cli =
-    click==8.1.3
-    click-option-group==0.5.5
+    click>=8.1.0
+    click-option-group>=0.5.0
+    sentry-sdk>=1.9.0
 dev =
     bandit==1.7.4
     black==22.10.0

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,10 +1,23 @@
 """
 Main module for Ralph's LRS API.
 """
+import sentry_sdk
 from fastapi import Depends, FastAPI
 
+from ralph.conf import settings
+
+from .. import __version__
 from .auth import AuthenticatedUser, authenticated_user
 from .routers import health, statements
+
+if settings.SENTRY_DSN is not None:
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        traces_sample_rate=1.0,
+        release=__version__,
+        environment=settings.EXECUTION_ENVIRONMENT,
+        max_breadcrumbs=50,
+    )
 
 app = FastAPI()
 app.include_router(statements.router)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,47 @@
+"""Tests for Ralph flavors dependencies"""
+
+import importlib
+import re
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+
+def test_dependencies_ralph_command_requires_click(monkeypatch):
+    """Tests Click module installation while executing the ralph command."""
+
+    monkeypatch.setitem(sys.modules, "click", None)
+
+    # Force ralph.cli reload now that click is considered as missing
+    if "ralph.cli" in sys.modules:
+        del sys.modules["ralph.cli"]
+
+    with pytest.raises(
+        ModuleNotFoundError,
+        match=re.escape(
+            "You need to install 'cli' optional dependencies to use the ralph "
+            "command: pip install ralph-malph[cli]"
+        ),
+    ):
+        importlib.import_module("ralph.cli")
+
+
+def test_dependencies_runserver_subcommand_requires_uvicorn(monkeypatch):
+    """Tests Uvicorn module installation while executing the runserver sub command."""
+
+    monkeypatch.setitem(sys.modules, "uvicorn", None)
+
+    # Force ralph.cli reload now that uvicorn is considered as missing
+    if "ralph.cli" in sys.modules:
+        del sys.modules["ralph.cli"]
+    cli = importlib.import_module("ralph.cli")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, "runserver -b es".split())
+
+    assert isinstance(result.exception, ModuleNotFoundError)
+    assert str(result.exception) == (
+        "You need to install 'lrs' optional dependencies to use the runserver "
+        "command: pip install ralph-malph[lrs]"
+    )


### PR DESCRIPTION
## Purpose

Current project dependencies definition needs more love:

1. if we want the project to be used as a library, we need to increase the primary dependencies version contraints, and,
2. when Ralph is installed as a library, the `ralph` command is installed and available in the PATH even if Click is not installed leading to unobvious error message when executing the aforementioned command. More than that, if installed as a CLI, the `runserver` command will fail if the the LRS flavor is not installed.

## Proposal

- [x] relax dependencies version contraints
- [x] improve installation flavors consistency by raising an explicit error message
- [x] test dependencies import error
