### PR TITLE
✅(tests) fix hypothesis warnings

### DIFF
--- a/tests/fixtures/hypothesis_configuration.py
+++ b/tests/fixtures/hypothesis_configuration.py
@@ -4,28 +4,9 @@ import operator
 
 from hypothesis import provisional, settings
 from hypothesis import strategies as st
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Json, JsonWrapper, StrictStr
-from pydantic._hypothesis_plugin import RESOLVERS, resolve_json
+from pydantic import AnyHttpUrl, AnyUrl, StrictStr
 
 from ralph.models.xapi.fields.common import IRI, LanguageTag, MailtoEmail
-
-
-def is_base_model(klass):
-    """Returns True if the given class is a subclass of the pydantic BaseModel."""
-
-    try:
-        return issubclass(klass, BaseModel)
-    except TypeError:
-        return False
-
-
-def custom_resolve_json(cls):
-    """Returns a hypothesis build strategy for Json types."""
-
-    if not is_base_model(getattr(cls, "inner_type", None)):
-        return resolve_json(cls)
-    return st.builds(cls.inner_type.json, st.from_type(cls.inner_type))
-
 
 settings.register_profile("development", max_examples=1)
 settings.load_profile("development")
@@ -39,5 +20,3 @@ st.register_type_strategy(
     MailtoEmail, st.builds(operator.add, st.just("mailto:"), st.emails())
 )
 st.register_type_strategy(LanguageTag, st.just("en-US"))
-st.register_type_strategy(Json, custom_resolve_json)
-RESOLVERS[JsonWrapper] = custom_resolve_json

--- a/tests/fixtures/hypothesis_strategies.py
+++ b/tests/fixtures/hypothesis_strategies.py
@@ -12,9 +12,16 @@ from ralph.models.edx.navigational.statements import UISeqNext, UISeqPrev
 from ralph.models.xapi.fields.contexts import ContextField
 from ralph.models.xapi.fields.results import ScoreResultField
 
-from tests.fixtures.hypothesis_configuration import is_base_model
-
 OVERWRITTEN_STATEGIES = {}
+
+
+def is_base_model(klass):
+    """Returns True if the given class is a subclass of the pydantic BaseModel."""
+
+    try:
+        return issubclass(klass, BaseModel)
+    except TypeError:
+        return False
 
 
 def get_strategy_from(annotation):

--- a/tests/fixtures/hypothesis_strategies.py
+++ b/tests/fixtures/hypothesis_strategies.py
@@ -65,9 +65,9 @@ def custom_builds(
         arg = kwargs.get(name, None)
         if arg is False:
             continue
-        is_required = field.required or (arg and _overwrite_default)
-        required_optional = required if is_required or arg else optional
-        field_strategy = arg if arg else get_strategy_from(field.outer_type_)
+        is_required = field.required or (arg is not None and _overwrite_default)
+        required_optional = required if is_required or arg is not None else optional
+        field_strategy = get_strategy_from(field.outer_type_) if arg is None else arg
         required_optional[field.alias] = field_strategy
     if not required:
         # To avoid generating empty values


### PR DESCRIPTION
## Purpose

The new version of `hypothesis` emits a warning during boolean comparison of a hypothesis strategy which pollutes test logs.
Also, the new version of `pydantic` includes our fix for resolving nested JSON fields. thus we don't need our custom JSON resolver anymore.

## Proposal

- [x] fix `hypothesis` boolean comparison warning by comparing with `None` instead.
- [x] remove our custom JSON resolver.