### PR TITLE
🔖(minor) bump release to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.1.0] - 2022-11-17
+
 ### Added
 
 - EdX to xAPI converters for video events
@@ -194,7 +196,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.0.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.1.0...master
+[3.1.0]: https://github.com/openfun/ralph/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/openfun/ralph/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/openfun/ralph/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/openfun/ralph/compare/v2.0.0...v2.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.0.0
-description = A learning logs processor to feed your LRS
+version = 3.1.0
+description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown
 author = Open FUN (France Universite Numerique)

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module"""
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.0.0
+  version: 3.1.0


### PR DESCRIPTION
## Added

- EdX to xAPI converters for video events

## Changed

- Improve Ralph's library integration by unpinning dependencies (and prefer ranges)
- Upgrade `fastapi` to `0.87.0`