### PR TITLE
🔧(tray) add CA cert file path for the LRS ES backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - Upgrade `httpx` to `0.23.1`
 - Upgrade `sentry_sdk` to `1.11.1`
 - Upgrade `uvicorn` to `0.20.0`
+- Tray: add the `ca_certs` path for the ES backend client option (LRS)
 
 ## [3.1.0] - 2022-11-17
 

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -74,6 +74,10 @@ spec:
               value: "/app/.ralph"
             - name: RALPH_AUTH_FILE
               value: "/var/run/ralph/auth.json"
+{% if ralph_mount_es_ca_secret %}
+            - name: RALPH_BACKENDS__DATABASE__ES__CLIENT_OPTIONS__ca_certs
+              value: "/usr/local/share/ca-certificates/es-cluster.pem"
+{% endif %}
           envFrom:
             - secretRef:
                 name: "{{ ralph_secret_name }}"


### PR DESCRIPTION
## Purpose

When using the Elasticsearch (ES) backend in an LRS context, for SSL connections to the cluster, python's ES client requires access to the ES cluster self-generated CA root certificate.

## Proposal

- [x] configure ES backend option using an injected environment variable when required
