### PR TITLE
📝(project) add helm chart tutorial

### DIFF
--- a/docs/tutorials/helm.md
+++ b/docs/tutorials/helm.md
@@ -1,26 +1,25 @@
-# Deploy a learning analytics stack to Kubernetes in minutes using Helm
+# Deploy Ralph LRS to Kubernetes using Helm
 
-This tutorial aims at deploying a complete Learning Analytics stack running over
-Kubernetes using Helm. In this tutorial, you will learn to:
+This tutorial aims at deploying Ralph LRS running over Kubernetes using Helm. In this tutorial, you will learn to:
 
 - run a small Kubernetes cluster on your machine,
-- deploy application to this cluster using Helm,
+- deploy applications to this cluster using Helm,
 - submit learning traces to a LRS (Learning Record Store),
-- analyze learning traces _via_ Grafana dashboards.
 
 ## Requirements
 
 - [`curl`](https://curl.se/), the CLI to make HTTP requests.
 - [`jq`](https://stedolan.github.io/jq/), the JSON data Swiss-Knife.
-- [`k3d`](https://k3d.io), a lighweight kubernetes distribution to work locally on the project.
+- [`k3d`](https://k3d.io), a lightweight kubernetes distribution to work locally on the project.
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl), the Kubernetes CLI.
 - [`helm`](https://helm.sh/), the package manager for Kubernetes.
 
 ## Create a local kubernetes cluster
 
-> 🤚 If you already have a fully fonctional Kubernetes cluster to work with,
-> you can use it and proceed to the next section after have created the
-> `development-ralph` namespace.
+!!! info
+    If you already have a fully fonctional Kubernetes cluster to work with,
+    you can use it and proceed to the next section after having created the
+    `development-ralph` namespace.
 
 Thanks to K3D, creating a local, docker-based Kubernetes cluster can be
 achieved using the following command:
@@ -43,6 +42,29 @@ NAME     SERVERS   AGENTS   LOADBALANCER
 ralph    1/1       0/0      true
 ```
 
+Check that we can see the `k3d` context with `kubectl`:
+```
+kubectl config get-contexts
+```
+
+This command should print the following output:
+```
+CURRENT   NAME        CLUSTER     AUTHINFO          NAMESPACE
+*         k3d-ralph   k3d-ralph   admin@k3d-ralph
+```
+
+!!! tip
+
+    If you don't see it in the list of contexts, you probably already use `kubectl` to manage other clusters.
+    You need to create and use a specific config for `k3d` as so:
+
+    ```
+    export KUBECONFIG=$(k3d kubeconfig write ralph)
+    ```
+    
+    Don't forget to unset the variable when you want to manage other clusters back! (or just, you know, kill the terminal 👀)
+
+
 We will now create a new namespace to work on:
 
 ```sh
@@ -60,17 +82,16 @@ Our cluster is now ready to host our learning analytics stack!
 
 ## Deploy a learning analytics stack
 
-The proposed learning analytics stack is composed of three different
+The proposed lightweight learning analytics stack is composed of two different
 applications:
 
-1. [Ralph](https://github.com/openfun/ralph), a lightweight LRS,
-2. [Elasticsearch](https://www.elastic.co/elasticsearch/), our data lake that will store learning traces (xAPI),
-3. [Grafana](https://grafana.com/grafana/), a dashboarding solution.
+1. [Elasticsearch](https://www.elastic.co/elasticsearch/), the data lake that will store learning traces (xAPI),
+2. [Ralph](https://github.com/openfun/ralph), our lightweight LRS,
 
 ### Elasticsearch
 
-As Elasticsearch is required by Ralph and Grafana, we will deploy an
-Elasticsearch cluster using the official elasticsearch Helm Chart:
+In its recent releases, Elastic recommends to deploy its services using Custom Resource Definitions (CRDs) installed via its official Helm chart.
+Let's install it:
 
 ```sh
 # Add the offical Elasticsearch Helm repository
@@ -79,151 +100,163 @@ helm repo add elastic https://helm.elastic.co
 # Update the list of available charts
 helm repo update
 
-# Deploy a "simple" Elasticsearch cluster with 3 nodes
+# Install the eck operator
+helm install elastic-operator elastic/eck-operator
+```
+
+Now we need to specify what we want the operator to deploy. Let's create a `manifest/data-lake.yaml` file with the following content:
+
+```yaml title="manifest/data-lake.yaml"
+
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: data-lake
+spec:
+  version: 8.8.1
+  nodeSets:
+    - name: default
+      count: 2
+      config:
+        node.store.allow_mmap: false
+      podTemplate:
+        spec:
+          containers:
+          - name: elasticsearch
+            env:
+              - name: ES_JAVA_OPTS
+                value: -Xms512m -Xmx512m
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 0.5
+              limits:
+                memory: 2Gi
+                cpu: 2
+
+```
+
+Let's deploy a two-nodes elasticsearch "cluster":
+
+```sh
+kubectl apply -f manifest/data-lake.yaml
+```
+
+Once applied, your elasticsearch pods should be running. You can check pods status by using the following command:
+
+```sh
+kubectl get pods -w
+```
+
+We expect to see two pods called `data-lake-es-default-0` and `data-lake-es-default-1`.
+
+When our Elasticsearch cluster is up (this can take few minutes), you may create the Elasticsearch index that will be used to store learning traces (xAPI statements):
+
+```sh
+# Store elastic user password
+export ELASTIC_PASSWORD="$(kubectl get secret data-lake-es-elastic-user -o jsonpath="{.data.elastic}" | base64 -d)"
+
+# Execute an index creation request in the elasticsearch container
+kubectl exec data-lake-es-default-0 --container elasticsearch -- \
+    curl -ks -X PUT "https://elastic:${ELASTIC_PASSWORD}@localhost:9200/statements?pretty"
+```
+
+!!! warning
+    In a production environment, we recommend to create a user with appropriate
+    roles and permissions depending on your application needs and use its
+    credentials.
+
+Our data lake is now ready! Let's deploy Ralph LRS.
+
+### Ralph LRS
+
+Ralph LRS is distributed as a Helm chart in the DockerHub OCI [openfuncharts](https://hub.docker.com/r/openfuncharts).
+
+First, create a `dev-values.yaml` file and add with the following:
+
+```yaml title="dev-values.yaml"
+envSecrets:
+  RALPH_BACKENDS__DATA__ES__INDEX: statements
+  RALPH_BACKENDS__DATA__ES__CLIENT_OPTIONS__ca_certs: "/usr/local/share/ca-certificates/ca.crt"
+  RALPH_BACKENDS__DATA__ES__CLIENT_OPTIONS__verify_certs: "true"
+
+lrs:
+  auth:
+    - username: "admin"
+      hash: "$2b$12$JFK.YCdbUWD2rS94fT4.m.KC/fIMzUMPMtjaD4t3t1iAfqki3ZPOq"
+      scopes: ["example_scope"]
+
+elastic:
+  enabled: true
+  mountCACert: true
+  caSecretName: "data-lake-es-http-certs-public"
+```
+
+!!! tip
+
+    All the default values of Ralph Helm chart can be fetched with:
+
+    ```sh
+    helm show values oci://registry-1.docker.io/openfuncharts/ralph --version 0.3.0
+    ```
+
+Now we can install Ralph LRS with this single line:
+```
 helm install \
-  es-quickstart \
-  elastic/elasticsearch \
-  -n development-ralph \
-  --set antiAffinity=soft
+  --values dev-values.yaml \
+  --set envSecrets.RALPH_BACKENDS__DATA__ES__HOSTS=https://elastic:"${ELASTIC_PASSWORD}"@data-lake-es-http:9200 \
+  lrs oci://registry-1.docker.io/openfuncharts/ralph \
+  --version 0.3.0
 ```
+!!! tip
+    You are now familiar with the procedure: you can check Ralph deployment using the `kubectl get pods -w` and `kubectl get svc -w lrs-ralph` commands.
 
-> By default, this Helm chart will deploy three (3) Elasticsearch nodes in
-> three (3) differents Kubernetes nodes. Since we only have a single-node
-> Kubernetes cluster, we set the `antiAffinity` value to `soft` to allow our
-> deployment scenario. Feel free to adapt this option value depending on your
-> cluster constraints.
-
-Once installed, you can check pods status using the following command (and wait
-for them to get ready):
-
-```sh
-kubectl get pods -l app=elasticsearch-master -w
-```
-
-Once the Elasticsearch cluster is up and running, we will need to get
-automatically generated credentials to connect other applications to the
-service.
-
-For this tutorial, we will fetch `elastic` user's password using the following
-command:
-
-```sh
-kubectl get secrets \
-  elasticsearch-master-credentials \
-  -ojsonpath='{.data.password}' | \
-    base64 -d
-```
-
-> In a production environment, we recommend to create a user with appropriate
-> roles and permissions depending on your application needs and use its
-> credentials.
-
-To secure Elasticsearch cluster nodes communication, during its deployment, the
-Helm chart created a self-generated root certificate used to sign Elasticsearch
-cluster node SSL certificates. We will need to provide this certificate to our
-applications that connect to the cluster. It can be fetched using:
-
-```sh
-kubectl get secrets elasticsearch-master-certs -ojson | \
-  jq -r ".data.\"ca.crt\"" | \
-  base64 -d
-```
-
-The final step of the Elasticsearch cluster preparation is to create an index
-to store our xAPI statements. As the Elasticsearch service is not exposed, we
-will create a bridge from our machine to the Elasticsearch cluster using the
-`kubectl port-forward` command:
-
-```sh
-kubectl port-forward svc/elasticsearch-master 9200
-```
-
-The command waits until it is stop using <kbd>CTRL+C</kbd> kill signal, so we
-will need to create the `statements` index from another terminal using Curl:
+As the Ralph LRS is not exposed, we will create a bridge from our machine to the Ralph LRS cluster using the `kubectl port-forward` command:
 
 ```
-curl -k -X PUT https://elastic:<PASTE PASSWORD HERE>@localhost:9200/statements
+kubectl port-forward svc/lrs-ralph 8080
 ```
 
-> You need to substitute the `<PASTE PASSWORD HERE>` placeholder with the
-> `elastic` user password we've fetched previously.
-
-> Note that our request target the `localhost` server name, since all traffic
-> on port 9200 is forwarded to the Elasticsearch service running in our
-> Kubernetes cluster.
-
-### Ralph
-
-As long as Ralph Helm chart is not published in a public repository,
-one will need to clone Ralph's project first.
-
-Next step is to add a new user to be able to log in the LRS server. 
-Create credentials for a new user with the following command:
-
-```sh
-docker run --rm fundocker/ralph:3.5.0 ralph auth \
-    --username janedoe \
-    --password supersecret \
-    --scope janedoe_scope
-```
-
-Edit Ralph's vault (src/helm/ralph/vault.yml) to define the following values:
-
-```yaml
-# Elasticsearch cluster connection URL
-RALPH_BACKENDS__DATABASE__ES__HOSTS: https://elastic:<PASTE PASSWORD HERE>@elasticsearch-master:9200
-
-# Elasticsearch cluster nodes CA certificate
-ES_CA_CERTIFICATE: |
-  -----BEGIN CERTIFICATE-----
-  <PASTE CERTIFICATE HERE>
-  -----END CERTIFICATE-----
-
-# LRS client credentials
-LRS_AUTH:
-  - username: "janedoe"
-    hash: "<PASTE HASH HERE>"
-    scopes:
-      - "janedoe_scope"
-```
-
-Edit your `dev-values.yml` (default Helm chart values override).
-
-```
-cd src/helm
-helm install ralph-lrs ralph/ \
-  -n development-ralph \
-  -f dev-values.yaml \
-  --set ralph_lrs.host="ralph.$(hostname -I | awk '{print $1}').nip.io"
-```
-
-**FIXME** review ingress usage in a local k8s cluster and prefer using the following:
-
-```
-kubectl port-forward svc/ralph-app-traefik 8080
-```
-
-Send one hundred (100) example statements to the LRS:
+The command waits until it is stopped using <kbd>CTRL+C</kbd> kill signal.
+To test our deployment, in another terminal, let's send 100 example statements to the LRS:
 
 ```sh
 curl -sL https://github.com/openfun/potsie/raw/main/fixtures/elasticsearch/lrs.json.gz | \
   gunzip | \
   head -n 100 | \
   jq -s . | \
-  curl -Lk \
-    --user johndoe:password \
+  sed "s/@timestamp/timestamp/g" | \
+  curl -L \
+    --user admin:password \
     -X POST \
     -H "Content-Type: application/json" \
     http://localhost:8080/xAPI/statements/ -d @-
 ```
 
-And fetch them back:
+If everything went well, the LRS should respond with 100 UUIDs filling our terminal.
+Let's check what our statements look like by querying them to the LRS:
 
 ```sh
-curl -Lk --user johndoe:password http://localhost:8080/xAPI/statements/ | \
+# Fetch stored statements
+curl -L --user admin:password http://localhost:8080/xAPI/statements/ | \
   jq
 ```
 
-### Apache Superset
+!!! tip
+    You may choose to click on the LRS URL link from your terminal to open it with your default web browser. HTTP Basic Auth credentials are `admin` for the login and `password` for the password.
 
-TODO.
+Congrats, you did it! 🎉
+
+You can stop and delete the k3d cluster with:
+```sh
+k3d cluster stop ralph
+k3d cluster delete ralph
+```
+
+## Go further 
+
+If you want to deploy a complete learning analytics stack, check this great tutorial at [https://github.com/openfun/k8s-la-stack-tutorial/]() that deploys on a real Kubernetes cluster:
+
+- Ralph LRS;
+- Elasticsearch datalake;
+- Superset dashboard system.

--- a/docs/tutorials/helm.md
+++ b/docs/tutorials/helm.md
@@ -1,0 +1,226 @@
+# Deploy a learning analytics stack to Kubernetes in minutes using Helm
+
+This tutorial aims at deploying a complete Learning Analytics stack running over
+Kubernetes using Helm. In this tutorial, you will learn to:
+
+- run a small Kubernetes cluster on your machine,
+- deploy application to this cluster using Helm,
+- submit learning traces to a LRS (Learning Record Store),
+- analyze learning traces _via_ Grafana dashboards.
+
+## Requirements
+
+- [`curl`](https://curl.se/), the CLI to make HTTP requests.
+- [`jq`](https://stedolan.github.io/jq/), the JSON data Swiss-Knife.
+- [`k3d`](https://k3d.io), a lighweight kubernetes distribution to work locally on the project.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl), the Kubernetes CLI.
+- [`helm`](https://helm.sh/), the package manager for Kubernetes.
+
+## Create a local kubernetes cluster
+
+> 🤚 If you already have a fully fonctional Kubernetes cluster to work with,
+> you can use it and proceed to the next section after have created the
+> `development-ralph` namespace.
+
+Thanks to K3D, creating a local, docker-based Kubernetes cluster can be
+achieved using the following command:
+
+```sh
+k3d cluster create ralph
+```
+
+This cluster is called `ralph`, you can check that it has been created using:
+
+```
+k3d cluster list
+```
+
+This command should print the following output (note that the cluster is up and
+running):
+
+```
+NAME     SERVERS   AGENTS   LOADBALANCER
+ralph    1/1       0/0      true
+```
+
+We will now create a new namespace to work on:
+
+```
+kubectl create namespace development-ralph
+```
+
+And we will set this namespace as the default namespace for future `kubectl`
+commands:
+
+```
+kubectl config set-context --current --namespace=development-ralph
+```
+
+Our cluster is now ready to host our learning analytics stack!
+
+## Deploy a learning analytics stack
+
+The proposed learning analytics stack is composed of three different
+applications:
+
+1. [Ralph](https://github.com/openfun/ralph), a lightweight LRS,
+2. [Elasticsearch](https://www.elastic.co/elasticsearch/), our data lake that will store learning traces (xAPI),
+3. [Grafana](https://grafana.com/grafana/), a dashboarding solution.
+
+### Elasticsearch
+
+As Elasticsearch is required by Ralph and Grafana, we will deploy an
+Elasticsearch cluster using the official elasticsearch Helm Chart:
+
+```sh
+# Add the offical Elasticsearch Helm repository
+helm repo add elastic https://helm.elastic.co
+
+# Update the list of available charts
+helm repo update
+
+# Deploy a "simple" Elasticsearch cluster with 3 nodes
+helm install \
+  es-quickstart \
+  elastic/elasticsearch \
+  -n development-ralph \
+  --set antiAffinity=soft
+```
+
+> By default, this Helm chart will deploy three (3) Elasticsearch nodes in
+> three (3) differents Kubernetes nodes. Since we only have a single-node
+> Kubernetes cluster, we set the `antiAffinity` value to `soft` to allow our
+> deployment scenario. Feel free to adapt this option value depending on your
+> cluster constraints.
+
+Once installed, you can check pods status using the following command (and wait
+for them to get ready):
+
+```
+kubectl get pods -l app=elasticsearch-master -w
+```
+
+Once the Elasticsearch cluster is up and running, we will need to get
+automatically generated credentials to connect other applications to the
+service.
+
+For this tutorial, we will fetch `elastic` user's password using the following
+command:
+
+```
+kubectl get secrets \
+  elasticsearch-master-credentials \
+  -ojsonpath='{.data.password}' | \
+    base64 -d
+```
+
+> In a production environment, we recommend to create a user with appropriate
+> roles and permissions depending on your application needs and use its
+> credentials.
+
+To secure Elasticsearch cluster nodes communication, during its deployment, the
+Helm chart created a self-generated root certificate used to sign Elasticsearch
+cluster node SSL certificates. We will need to provide this certificate to our
+applications that connect to the cluster. It can be fetched using:
+
+```
+kubectl get secrets elasticsearch-master-certs -ojson | \
+  jq -r ".data.\"ca.crt\"" | \
+  base64 -d
+```
+
+The final step of the Elasticsearch cluster preparation is to create an index
+to store our xAPI statements. As the Elasticsearch service is not exposed, we
+will create a bridge from our machine to the Elasticsearch cluster using the
+`kubectl port-forward` command:
+
+```sh
+kubectl port-forward svc/elasticsearch-master 9200
+```
+
+The command waits until it is stop using <kbd>CTRL+C</kbd> kill signal, so we
+will need to create the `statements` index from another terminal using Curl:
+
+```
+curl -k -X PUT https://elastic:<PASTE PASSWORD HERE>@localhost:9200/statements
+```
+
+> You need to substitute the `<PASTE PASSWORD HERE>` placeholder with the
+> `elastic` user password we've fetched previously.
+
+> Note that our request target the `localhost` server name, since all traffic
+> on port 9200 is forwarded to the Elasticsearch service running in our
+> Kubernetes cluster.
+
+### Ralph
+
+**FIXME**: as long as Ralph Helm chart is not published in a public repository,
+one will need to clone Ralph's project first (and possibly checkout the
+`add-helm-chart` branch).
+
+Edit Ralph's vault to define the following values:
+
+```yaml
+# Elasticsearch cluster connection URL
+RALPH_BACKENDS__DATABASE__ES__HOSTS: https://elastic:<PASTE PASSWORD HERE>@elasticsearch-master:9200
+
+# Elasticsearch cluster nodes CA certificate
+ES_CA_CERTIFICATE: |
+  -----BEGIN CERTIFICATE-----
+  <PASTE CERTIFICATE HERE>
+  -----END CERTIFICATE-----
+
+# LRS client credentials
+LRS_AUTH:
+  - username: "johndoe"
+    hash: "$2b$12$iKUYWtRYSxAUf19DUvvh9O1NOzKMyjV2GrMBBqktdRUAJOYimWrRi"
+    scopes:
+      - "johndoe_scope"
+```
+
+**FIXME** add an utility to encrypt LRS users password instead and describe its
+usage below.
+
+> To generate LRS client credentials, see:
+> https://openfun.github.io/ralph/api/#creating_a_credentials_file
+
+Edit your `dev-values.yml` (default Helm chart values override).
+
+```
+cd src/helm
+helm install ralph-lrs ralph/ \
+  -n development-ralph \
+  -f dev-values.yaml \
+  --set ralph_lrs.host="ralph.$(hostname -I | awk '{print $1}').nip.io"
+```
+
+**FIXME** review ingress usage in a local k8s cluster and prefer using the following:
+
+```
+kubectl port-forward svc/ralph-app-traefik 8080
+```
+
+Send one hundred (100) example statements to the LRS:
+
+```
+curl -sL https://github.com/openfun/potsie/raw/main/fixtures/elasticsearch/lrs.json.gz | \
+  gunzip | \
+  head -n 100 | \
+  jq -s . | \
+  curl -Lk \
+    --user johndoe:password \
+    -X POST \
+    -H "Content-Type: application/json" \
+    http://localhost:8080/xAPI/statements/ -d @-
+```
+
+And fetch them back:
+
+```
+curl -Lk --user johndoe:password http://localhost:8080/xAPI/statements/ | \
+  jq
+```
+
+### Grafana
+
+TODO.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
         - 'Development - Contributing': tutorials/development_contributing.md
         - 'Use Ralph as a CLI': tutorials/cli.md
         - 'Use Ralph as a library': tutorials/library.md
+        - 'Deploy Ralph': tutorials/helm.md
     - 'Contributing': contribute.md
     - 'Migration': UPGRADE.md
     - 'About the project':


### PR DESCRIPTION
## Purpose

Ralph can be deployed to a Kubernetes cluster using its official Helm Chart. We need a step-by-steph guide to use it.

## Proposal

This tutorial guides you to the deployment of a complete learning analytics stack to Kubernetes using Helm.
