### PR TITLE
🔧(project) improve Sentry integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - Upgrade `sentry_sdk` to `1.11.1`
 - Upgrade `uvicorn` to `0.20.0`
 - Tray: add the `ca_certs` path for the ES backend client option (LRS)
+- Improve Sentry integration for the LRS
 
 ## [3.1.0] - 2022-11-17
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ backend-ws =
 cli =
     click>=8.1.0
     click-option-group>=0.5.0
-    sentry-sdk>=1.9.0
+    sentry-sdk[fastapi]>=1.9.0
 dev =
     bandit==1.7.4
     black==22.10.0

--- a/src/ralph/__main__.py
+++ b/src/ralph/__main__.py
@@ -14,7 +14,7 @@ from . import __version__, cli
 if settings.SENTRY_DSN is not None:
     sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
         dsn=settings.SENTRY_DSN,
-        traces_sample_rate=1.0,
+        traces_sample_rate=settings.SENTRY_CLI_TRACES_SAMPLE_RATE,
         release=__version__,
         environment=settings.EXECUTION_ENVIRONMENT,
         max_breadcrumbs=50,

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -11,7 +11,7 @@ from .routers import health, statements
 if settings.SENTRY_DSN is not None:
     sentry_sdk.init(  # noqa: F821 # pylint: disable=undefined-variable
         dsn=settings.SENTRY_DSN,
-        traces_sample_rate=1.0,
+        traces_sample_rate=settings.SENTRY_LRS_TRACES_SAMPLE_RATE,
         release=__version__,
         environment=settings.EXECUTION_ENVIRONMENT,
         max_breadcrumbs=50,

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -271,6 +271,8 @@ class Settings(BaseSettings):
     RUNSERVER_POINT_IN_TIME_KEEP_ALIVE: str = "1m"
     RUNSERVER_PORT: int = 8100
     SENTRY_DSN: str = None
+    SENTRY_CLI_TRACES_SAMPLE_RATE = 1.0
+    SENTRY_LRS_TRACES_SAMPLE_RATE = 0.1
     XAPI_FORWARDINGS: list[XapiForwardingConfigurationSettings] = []
 
     @property


### PR DESCRIPTION
## Purpose

Sentry integration is too basic and requires to be a bit more configurable and adapted to used web framework (FastAPI).

## Proposal

We now install the FastAPI sentry integration to better track server performance and post mortem report.

Traces sample rate is now configurable for the CLI and the LRS.
