### PR TITLE
✨(cli) add the new "auth" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add a new `auth` subcommand to generate required credentials file for the LRS
+
 ### Changed
 
 - Upgrade `fastapi` to `0.88.0`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 # API Server
 
-Ralph comes with an API server that aims to implement the Learning Record Store (LRS)
-specification (still a work in progress).
+Ralph comes with an API server that aims to implement the Learning Record Store
+(LRS) specification (still a work in progress).
 
 ## Getting started
 
@@ -11,18 +11,24 @@ The API server can be started up with the following command:
 $ ralph runserver --backend es
 ```
 
-The `--backend` (or `-b`) option specifies which database backend to use for LRS data
-storage and retrieval. See Ralph's [backends documentation](./backends.md) for more
-details.
+The `--backend` (or `-b`) option specifies which database backend to use for
+LRS data storage and retrieval. See Ralph's [backends
+documentation](./backends.md) for more details.
 
-However, before you can start your API server and make requests against it, you need to
-set up your credentials.
+However, before you can start your API server and make requests against it, you
+need to set up your credentials.
 
 ### Creating a credentials file
 
-The credentials file is expected to be a valid JSON file. Its location is specified by the `RALPH_AUTH_FILE` configuration value. By default, `ralph` will look for the `auth.json` file in the application directory (see [click documentation for details](https://click.palletsprojects.com/en/8.0.x/api/#click.get_app_dir)).
+The credentials file is expected to be a valid JSON file. Its location is
+specified by the `RALPH_AUTH_FILE` configuration value. By default, `ralph`
+will look for the `auth.json` file in the application directory (see [click
+documentation for
+details](https://click.palletsprojects.com/en/8.0.x/api/#click.get_app_dir)).
 
-The expected format is a list of entries (JSON objects) each containing the username, the user's `bcrypt` hashed+salted password and scopes they can access:
+The expected format is a list of entries (JSON objects) each containing the
+username, the user's `bcrypt` hashed+salted password and scopes they can
+access:
 
 ```json
 [
@@ -39,14 +45,21 @@ The expected format is a list of entries (JSON objects) each containing the user
 ]
 ```
 
-The hash can be generated with a python script executed directly in the command line:
+To create a new user credentials, Ralph's CLI provides a dedicated command:
 
 ```bash
-# Install bcrypt
-$ python3 -m pip install bcrypt
-# Generate the hash and print it to console
-$ python3 -c 'import bcrypt; print(bcrypt.hashpw(b"PASSWORD", bcrypt.gensalt()).decode("ascii"))'
+$ ralph auth \
+    --user janedoe \
+    --password supersecret \
+    --scope janedoe_scope \
+    -w
 ```
+
+This command updates your credentials file with the new `janedoe` user.
+
+> Note that running this command requires that you installed Ralph with the CLI
+> optional dependencies, _e.g._ `pip install ralph-malph[cli]` (which we highly
+> recommend).
 
 ### Making a GET request
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ backend-swift =
 backend-ws =
     websockets>=10.3
 cli =
+    bcrypt>=4.0.0
     click>=8.1.0
     click-option-group>=0.5.0
     sentry-sdk[fastapi]>=1.9.0

--- a/src/ralph/api/auth.py
+++ b/src/ralph/api/auth.py
@@ -1,12 +1,12 @@
 """Authentication & authorization related tools for the Ralph API."""
 
-import json
 from functools import lru_cache
+from pathlib import Path
 
 import bcrypt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 from starlette.authentication import AuthenticationError
 
 from ralph.conf import settings
@@ -24,7 +24,7 @@ class AuthenticatedUser(BaseModel):
     """Pydantic model for user authentication.
 
     Attributes:
-        username(str): Consists of the username of the current user.
+        username (str): Consists of the username of the current user.
         scopes (list): Consists of the scopes the user has access to.
     """
 
@@ -32,25 +32,66 @@ class AuthenticatedUser(BaseModel):
     scopes: list[str]
 
 
+class UserCredentials(AuthenticatedUser):
+    """Pydantic model for user credentials as stored in the credentials file.
+
+    Attributes:
+        username (str): Consists of the username for a declared user.
+        hash (str): Consists of the hashed password for a declared user.
+        scopes (list): Consists of the scopes a declared has access to.
+    """
+
+    hash: str
+
+
+class ServerUsersCredentials(BaseModel):
+    """Custom root pydantic model describing expected list of all server users
+    credentials as stored in the credentials file."""
+
+    __root__: list[UserCredentials]
+
+    def __add__(self, other):
+        return ServerUsersCredentials.parse_obj(self.__root__ + other.__root__)
+
+    def __getitem__(self, item: int):
+        return self.__root__[item]
+
+    def __len__(self):
+        return len(self.__root__)
+
+    def __iter__(self):
+        return iter(self.__root__)
+
+    @root_validator
+    @classmethod
+    def ensure_unique_username(cls, values):
+        """Every username should be unique among registered users."""
+        usernames = [entry.username for entry in values.get("__root__")]
+        if len(usernames) != len(set(usernames)):
+            raise ValueError(
+                "You cannot create multiple credentials with the same username"
+            )
+        return values
+
+
 @lru_cache()
-def get_stored_credentials(auth_file):
+def get_stored_credentials(auth_file: Path) -> ServerUsersCredentials:
     """Helper to read the credentials/scopes file.
 
     Reads credentials from JSON file and stored them to avoid reloading them with every
     request.
 
     Args:
-        auth_file (file): Path to the JSON credentiales scope file.
+        auth_file (Path): Path to the JSON credentials scope file.
 
     Returns:
-        stored_credentials (json): Cache-memorized credentials.
+        credentials (ServerUsersCredentials): Cache-memorized credentials.
+
     """
-    try:
-        with open(auth_file, encoding=settings.LOCALE_ENCODING) as auth:
-            stored_credentials = json.load(auth)
-    except FileNotFoundError as exc:
-        raise AuthenticationError(f"Credentials file {auth_file} not found.") from exc
-    return stored_credentials
+    auth_file = Path(auth_file)
+    if not auth_file.exists():
+        raise AuthenticationError(f"Credentials file {auth_file} not found.")
+    return ServerUsersCredentials.parse_file(auth_file)
 
 
 def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
@@ -62,16 +103,15 @@ def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
     Args:
         credentials (iterator): auth parameters from the Authorization header
 
-
     """
     try:
-        user_info = next(
+        user = next(
             filter(
-                lambda u: u.get("username") == credentials.username,
+                lambda u: u.username == credentials.username,
                 get_stored_credentials(settings.AUTH_FILE),
             )
         )
-        hashed_password = user_info.get("hash", None)
+        hashed_password = user.hash
     except StopIteration:
         # next() gets the first item in the enumerable; if there is none, it raises
         # a StopIteration error as it is out of bounds.
@@ -84,7 +124,9 @@ def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
     if not hashed_password:
         # We're doing a bogus password check anyway to avoid
         # timing attacks on usernames
-        bcrypt.checkpw(credentials.password.encode("UTF-8"), UNUSED_PASSWORD)
+        bcrypt.checkpw(
+            credentials.password.encode(settings.LOCALE_ENCODING), UNUSED_PASSWORD
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication credentials",
@@ -92,7 +134,8 @@ def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
         )
 
     if not bcrypt.checkpw(
-        credentials.password.encode("UTF-8"), hashed_password.encode("UTF-8")
+        credentials.password.encode(settings.LOCALE_ENCODING),
+        hashed_password.encode(settings.LOCALE_ENCODING),
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -100,6 +143,4 @@ def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
             headers={"WWW-Authenticate": "Basic"},
         )
 
-    return AuthenticatedUser(
-        username=credentials.username, scopes=user_info.get("scopes")
-    )
+    return AuthenticatedUser(username=credentials.username, scopes=user.scopes)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,54 @@
+"""Tests for the api.auth module."""
+
+import pytest
+
+from ralph.api.auth import ServerUsersCredentials, UserCredentials
+
+
+def test_api_auth_model_serveruserscredentials():
+    """Test api.auth ServerUsersCredentials model."""
+
+    users = ServerUsersCredentials(
+        __root__=[
+            UserCredentials(
+                username="johndoe", hash="notrealhash", scopes=["johndoe_scope"]
+            ),
+            UserCredentials(username="foo", hash="notsorealhash", scopes=["foo_scope"]),
+        ]
+    )
+    other_users = ServerUsersCredentials.parse_obj(
+        [
+            UserCredentials(
+                username="janedoe", hash="notreallyrealhash", scopes=["janedoe_scope"]
+            ),
+        ]
+    )
+
+    # Test addition operator
+    users += other_users
+
+    # Test len
+    assert len(users) == 3
+
+    # Test getitem
+    assert users[0].username == "johndoe"
+    assert users[1].username == "foo"
+    assert users[2].username == "janedoe"
+
+    # Test iterator
+    usernames = [user.username for user in users]
+    assert len(usernames) == 3
+    assert usernames == ["johndoe", "foo", "janedoe"]
+
+    # Test username uniqueness validator
+    with pytest.raises(
+        ValueError,
+        match="You cannot create multiple credentials with the same username",
+    ):
+        users += ServerUsersCredentials.parse_obj(
+            [
+                UserCredentials(
+                    username="foo", hash="notsorealhash", scopes=["foo_scope"]
+                ),
+            ]
+        )


### PR DESCRIPTION
## Purpose

Generating credentials to authenticate to our LRS should be smooth and painless for our users.

## Proposal

- [x] add a new `auth` command to ease new user credentials generation
- [x] add pydantic models for user credentials checking and credentials file validation
- [x] track authentication issues to the LRS server
