### PR TITLE
📝(project) update handbook link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - Upgrade `uvicorn` to `0.20.0`
 - Tray: add the `ca_certs` path for the ES backend client option (LRS)
 - Improve Sentry integration for the LRS
+- Update handbook link to `https://handbook.openfun.fr`
 
 ## [3.1.0] - 2022-11-17
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ decisions.
 
 We try to raise our code quality standards and expect contributors to follow
 the recommandations from our
-[handbook](https://openfun.gitbooks.io/handbook/content).
+[handbook](https://handbook.openfun.fr).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ decisions.
 
 We try to raise our code quality standards and expect contributors to follow
 the recommendations from our
-[handbook](https://openfun.gitbooks.io/handbook/content).
+[handbook](https://handbook.openfun.fr).
 
 ## License
 


### PR DESCRIPTION
## Purpose

Handbook with best practices and recommendations for contributors is now under https://handbook.openfun.fr instead of https://openfun.gitbooks.io/handbook/content

## Proposal

- [x] update handbook link

