### PR TITLE
CLI: add --version option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Add a new `auth` subcommand to generate required credentials file for the LRS
 - Add an official Helm Chart (experimental)
 - Implement support for AWS S3 storage backend
+- Add CLI `--version` option
 
 ### Changed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ backend-ldp =
     requests>=2.0.0
 backend-mongo =
     pymongo[srv]>=4.0.0
-backend-s3 = 
+backend-s3 =
     boto3>=1.24.70
     botocore>=1.27.71
 backend-swift =
@@ -119,7 +119,7 @@ exclude =
 
 [pydocstyle]
 convention = google
-match_dir = ^(?!tests).*
+match_dir = ^(?!tests|venv|build|scripts).*
 match = ^(?!(setup)\.(py)$).*\.(py)$
 
 [isort]

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -276,7 +276,7 @@ def auth(username, password, scope, write):
     help="Container format parser used to extract events",
 )
 def extract(parser):
-    """Extracts input events from a container format using a dedicated parser."""
+    """Extract input events from a container format using a dedicated parser."""
     logger.info("Extracting events using the %s parser", parser)
 
     parser = getattr(settings.PARSERS, parser.upper()).get_instance()
@@ -309,7 +309,7 @@ def extract(parser):
     help="Stop validating at first unknown event",
 )
 def validate(format_, ignore_errors, fail_on_unknown):
-    """Validates input events of given format."""
+    """Validate input events of given format."""
     logger.info(
         "Validating %s events (ignore_errors=%s | fail-on-unknown=%s)",
         format_,
@@ -371,7 +371,7 @@ def validate(format_, ignore_errors, fail_on_unknown):
     help="Stop converting at first unknown event",
 )
 def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs):
-    """Converts input events to a given format."""
+    """Convert input events to a given format."""
     logger.info(
         "Converting %s events to %s format (ignore_errors=%s | fail-on-unknown=%s)",
         from_,
@@ -537,7 +537,7 @@ def list_(details, new, backend, **options):
     help="LRS server port",
 )
 def runserver(backend: str, host: str, port: int, **options):
-    """Runs the API server for the development environment.
+    """Run the API server for the development environment.
 
     Starts uvicorn programmatically for convenience and documentation.
     """

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
 from click_option_group import optgroup
 from pydantic import BaseModel
 
+from ralph import __version__ as ralph_version
 from ralph.conf import CommaSeparatedTuple, settings
 from ralph.exceptions import UnsupportedBackendException
 from ralph.logger import configure_logging
@@ -132,6 +133,7 @@ class JSONStringParamType(click.ParamType):
     required=False,
     help="Either CRITICAL, ERROR, WARNING, INFO (default) or DEBUG",
 )
+@click.version_option(version=ralph_version)
 def cli(verbosity=None):
     """Ralph is a stream-based tool to play with your logs."""
     configure_logging()


### PR DESCRIPTION
## Purpose

It's often useful to be able to quickly check version number of installed Ralph instance.

## Proposal

- [x] add `--version` CLI option

During this work, I also improved the following:

- [x] pydoctyle: ignore development folders
- [x] cli: homogenize commands help
