### PR TITLE
:bug: Fix M1 Mac `make bootstrap` failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,17 @@ FROM core as development
 # Copy all sources, not only runtime-required files
 COPY . /app/
 
+# Only the M1 Mac images need these packages installed
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; \
+    then apt-get update && \
+        apt-get install -y \
+            build-essential \
+            gcc \
+            python-dev && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi;
+
 # Uninstall ralph and re-install it in editable mode along with development
 # dependencies
 RUN pip uninstall -y ralph-malph


### PR DESCRIPTION
## Purpose
Fixes https://github.com/openfun/ralph/issues/246 which occurs on M1 Macs during `make bootstrap`.

## Proposal
Add the missing dependencies only for the `linux/arm64` target platform.