### PR TITLE
🚧 (project) add rich library for a user friendly CLI

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,7 @@
 # Configuration
 RALPH_APP_DIR=/app/.ralph
+FORCE_COLOR=1
+TERM=xterm-256
 
 # Uncomment lines (by removing # characters at the beginning of target lines)
 # to define environment variables associated to the backend(s) you need.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 ### Added
 
+- `rich` library for the CLI
 - Add a new `auth` subcommand to generate required credentials file for the LRS
 - Add an official Helm Chart (experimental)
 - Implement support for AWS S3 storage backend

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ cli =
     bcrypt>=4.0.0
     click>=8.1.0
     click-option-group>=0.5.0
+    rich>=13.1.0
     sentry-sdk[fastapi]>=1.9.0
 dev =
     bandit==1.7.4

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -276,12 +276,16 @@ class Settings(BaseSettings):
             },
         },
         "handlers": {
+            # "console": {
+            #     "class": "logging.StreamHandler",
+            #     "level": "INFO",
+            #     "stream": "ext://sys.stderr",
+            #     "formatter": "ralph",
+            # },
             "console": {
-                "class": "logging.StreamHandler",
+                "class": "rich.logging.RichHandler",
                 "level": "INFO",
-                "stream": "ext://sys.stderr",
-                "formatter": "ralph",
-            },
+            }
         },
         "loggers": {
             "ralph": {

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -276,12 +276,6 @@ class Settings(BaseSettings):
             },
         },
         "handlers": {
-            # "console": {
-            #     "class": "logging.StreamHandler",
-            #     "level": "INFO",
-            #     "stream": "ext://sys.stderr",
-            #     "formatter": "ralph",
-            # },
             "console": {
                 "class": "rich.logging.RichHandler",
                 "level": "INFO",

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -270,11 +270,6 @@ class Settings(BaseSettings):
     LOGGING: dict = {
         "version": 1,
         "propagate": True,
-        "formatters": {
-            "ralph": {
-                "format": "%(asctime)-23s %(levelname)-8s %(name)-8s %(message)s"
-            },
-        },
         "handlers": {
             "console": {
                 "class": "rich.logging.RichHandler",

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -1,11 +1,7 @@
 """Ralph logging manager."""
 
-import logging
-from rich import traceback, pretty
-from rich.logging import RichHandler
-from rich.console import Console
+from logging.config import dictConfig
 
-import click
 from ralph.conf import settings
 from ralph.exceptions import ConfigurationException
 
@@ -13,13 +9,14 @@ from ralph.exceptions import ConfigurationException
 def configure_logging():
     """Set up Ralph logging configuration."""
     try:
-        console = Console(color_system="standard")
-        logging.basicConfig(
-            format="%(message)s",
-            datefmt="[%X]",
-            handlers=[RichHandler(console=console)]
-        )
-        traceback.install(show_locals=True, suppress=[click])
-        pretty.install()
+        # console = Console(color_system="standard")
+        # logging.basicConfig(
+        #     format="%(message)s",
+        #     datefmt="[%X]",
+        #     handlers=[RichHandler(console=console)]
+        # )
+        # traceback.install(show_locals=True, suppress=[click])
+        # pretty.install()
+        dictConfig(settings.LOGGING)
     except Exception as error:
         raise ConfigurationException("Improperly configured logging") from error

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -1,7 +1,11 @@
 """Ralph logging manager."""
 
-from logging.config import dictConfig
+import logging
+from rich import traceback, pretty
+from rich.logging import RichHandler
+from rich.console import Console
 
+import click
 from ralph.conf import settings
 from ralph.exceptions import ConfigurationException
 
@@ -9,6 +13,13 @@ from ralph.exceptions import ConfigurationException
 def configure_logging():
     """Set up Ralph logging configuration."""
     try:
-        dictConfig(settings.LOGGING)
+        console = Console(color_system="standard")
+        logging.basicConfig(
+            format="%(message)s",
+            datefmt="[%X]",
+            handlers=[RichHandler(console=console)]
+        )
+        traceback.install(show_locals=True, suppress=[click])
+        pretty.install()
     except Exception as error:
         raise ConfigurationException("Improperly configured logging") from error

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -9,14 +9,6 @@ from ralph.exceptions import ConfigurationException
 def configure_logging():
     """Set up Ralph logging configuration."""
     try:
-        # console = Console(color_system="standard")
-        # logging.basicConfig(
-        #     format="%(message)s",
-        #     datefmt="[%X]",
-        #     handlers=[RichHandler(console=console)]
-        # )
-        # traceback.install(show_locals=True, suppress=[click])
-        # pretty.install()
         dictConfig(settings.LOGGING)
     except Exception as error:
         raise ConfigurationException("Improperly configured logging") from error


### PR DESCRIPTION
## Purpose

`ralph` can be used as a CLI and integrating the rich library makes the tool more user friendly and easy to read.

## Proposal

The [provided handler from rich](https://rich.readthedocs.io/en/stable/reference/logging.html?rich.logging.RichHandler) replaces the custom made stream handler.

:test_tube: logger tests are failing, as for now, I have not updated them with the new handler. The rich integration enforces message wrapping. It is not yet possible to run correctly the test

