### PR TITLE
🩹(xapi) allow extra fields for xAPI extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+- Allow xAPI extra fields in `extensions` fields
+
 ## [3.2.1] - 2023-02-01
 
 ### Changed

--- a/src/ralph/models/xapi/config.py
+++ b/src/ralph/models/xapi/config.py
@@ -9,3 +9,11 @@ class BaseModelWithConfig(BaseModel):
     class Config:  # pylint: disable=missing-class-docstring # noqa: D106
         extra = Extra.forbid
         min_anystr_length = 1
+
+
+class BaseExtensionModelWithConfig(BaseModel):
+    """Pydantic model for extension configuration shared among all models."""
+
+    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
+        extra = Extra.allow
+        min_anystr_length = 0

--- a/src/ralph/models/xapi/fields/objects.py
+++ b/src/ralph/models/xapi/fields/objects.py
@@ -8,7 +8,7 @@ from typing import Literal, Optional, Union
 
 from pydantic import Field
 
-from ..config import BaseModelWithConfig
+from ..config import BaseExtensionModelWithConfig, BaseModelWithConfig
 from ..constants import EXTENSION_COURSE_ID, EXTENSION_MODULE_ID, EXTENSION_SCHOOL_ID
 from .actors import ActorField
 from .attachments import AttachmentField
@@ -42,7 +42,7 @@ class SubStatementObjectField(BaseModelWithConfig):
 ObjectField = Union[UnnestedObjectField, SubStatementObjectField]
 
 
-class ObjectDefinitionExtensionsField(BaseModelWithConfig):
+class ObjectDefinitionExtensionsField(BaseExtensionModelWithConfig):
     """Pydantic model for `object.definition.extensions` field.
 
     Attributes:

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat
 
-from ...base import BaseModelWithConfig
+from ...config import BaseExtensionModelWithConfig
 from ...fields.contexts import ContextActivitiesContextField, ContextField
 from ..constants import (
     VIDEO_CONTEXT_CATEGORY,
@@ -46,7 +46,7 @@ class BaseVideoContextField(ContextField):
     contextActivities: Optional[VideoContextActivitiesField]
 
 
-class VideoContextExtensionsField(BaseModelWithConfig):
+class VideoContextExtensionsField(BaseExtensionModelWithConfig):
     """Pydantic model for video core `context`.`extensions` field.
 
     Attributes:

--- a/src/ralph/models/xapi/video/fields/results.py
+++ b/src/ralph/models/xapi/video/fields/results.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional
 
 from pydantic import Field, NonNegativeFloat
 
-from ...base import BaseModelWithConfig
+from ...config import BaseExtensionModelWithConfig
 from ...fields.results import ResultField
 from ..constants import (
     VIDEO_EXTENSION_CC_ENABLED,
@@ -17,7 +17,7 @@ from ..constants import (
 )
 
 
-class VideoResultExtensionsField(BaseModelWithConfig):
+class VideoResultExtensionsField(BaseExtensionModelWithConfig):
     """Pydantic model for video `result`.`extensions` field.
 
     Attributes:
@@ -40,11 +40,8 @@ class VideoPausedResultExtensionsField(VideoResultExtensionsField):
 
     progress: Optional[NonNegativeFloat] = Field(alias=VIDEO_EXTENSION_PROGRESS)
 
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        min_anystr_length = 0
 
-
-class VideoSeekedResultExtensionsField(BaseModelWithConfig):
+class VideoSeekedResultExtensionsField(BaseExtensionModelWithConfig):
     """Pydantic model for video seeked `result`.`extensions` field.
 
     Attributes:
@@ -57,9 +54,6 @@ class VideoSeekedResultExtensionsField(BaseModelWithConfig):
     timeFrom: NonNegativeFloat = Field(alias=VIDEO_EXTENSION_TIME_FROM)
     timeTo: NonNegativeFloat = Field(alias=VIDEO_EXTENSION_TIME_TO)
 
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        min_anystr_length = 0
-
 
 class VideoCompletedResultExtensionsField(VideoResultExtensionsField):
     """Pydantic model for video completed `result`.`extensions` field.
@@ -69,9 +63,6 @@ class VideoCompletedResultExtensionsField(VideoResultExtensionsField):
     """
 
     progress: NonNegativeFloat = Field(alias=VIDEO_EXTENSION_PROGRESS)
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        min_anystr_length = 0
 
 
 class VideoTerminatedResultExtensionsField(VideoResultExtensionsField):
@@ -83,9 +74,6 @@ class VideoTerminatedResultExtensionsField(VideoResultExtensionsField):
 
     progress: NonNegativeFloat = Field(alias=VIDEO_EXTENSION_PROGRESS)
 
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        min_anystr_length = 0
-
 
 class VideoEnableClosedCaptioningResultExtensionsField(VideoResultExtensionsField):
     """Pydantic model for video enable closed captioning `result`.`extensions` field.
@@ -95,9 +83,6 @@ class VideoEnableClosedCaptioningResultExtensionsField(VideoResultExtensionsFiel
     """
 
     ccEnabled: bool = Field(alias=VIDEO_EXTENSION_CC_ENABLED)
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        min_anystr_length = 0
 
 
 class VideoPlayedResultField(ResultField):


### PR DESCRIPTION
## Purpose

Fix issue #254

## Proposal

After reading xAPI profile spec, Ralph should not forbid additional extensions.
Base models of Extension fields now allow extra fields.
