### PR TITLE
🔖(minor) bump release to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.2.0] - 2023-01-25
+
 ### Added
 
 - Add a new `auth` subcommand to generate required credentials file for the LRS
@@ -219,7 +221,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.1.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.2.0...master
+[3.2.0]: https://github.com/openfun/ralph/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/openfun/ralph/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/openfun/ralph/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/openfun/ralph/compare/v2.0.1...v2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.1.0
+version = 3.2.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.1.0
+  version: 3.2.0


### PR DESCRIPTION
# Added

- Add a new `auth` subcommand to generate required credentials file for the LRS
- Add an official Helm Chart (experimental)
- Implement support for AWS S3 storage backend
- Add CLI `--version` option

# Changed

- Upgrade `fastapi` to `0.89.1`
- Upgrade `httpx` to `0.23.3`
- Upgrade `sentry_sdk` to `1.13.0`
- Upgrade `uvicorn` to `0.20.0`
- Tray: add the `ca_certs` path for the ES backend client option (LRS)
- Improve Sentry integration for the LRS
- Update handbook link to `https://handbook.openfun.fr`
- Upgrade base python version to 3.11 for the development stack and Docker
  image

# Fixed

- Restore ES and Mongo backends ability to use client options

