### PR TITLE
🧑‍💻(project) relax python version to 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Relax required Python version to `3.7`+
+
 ## [3.2.0] - 2023-01-25
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ classifiers =
     License :: OSI Approved :: MIT License
     Natural Language :: English
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
 
 [options]
@@ -32,7 +36,7 @@ package_dir =
     =src
 packages = find:
 zip_safe = True
-python_requires = >= 3.9
+python_requires = >= 3.7
 
 [options.extras_require]
 backend-es =


### PR DESCRIPTION
Relax required Python version for Ralph to be used as a library in older Python environment (3.7+).