### PR TITLE
📝(project) add xAPI models documentation

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -12,5 +12,5 @@ Data validation and serialisation/de-serialisation are achieved using
 [pydantics](https://pydantic-docs.helpmanual.io) models that are documented in
 the following subsections:
 
-- [Open edX](./models/edx/)
-- xAPI (work in progress)
+- [Open edX events](./edx/)
+- [xAPI events](./xapi/)

--- a/docs/models/xapi.md
+++ b/docs/models/xapi.md
@@ -1,0 +1,1 @@
+::: ralph.models.xapi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
         - 'Learning event models':
             - 'Rationale': models/index.md
             - 'Open edX events': models/edx.md
+            - 'xAPI events': models/xapi.md
         - 'API': api.md
     - 'Developer guide':
         - 'Contribute': contribute.md


### PR DESCRIPTION
Generate documentation about xAPI pydantic models implemented in Ralph.
Also correct the 404 on link to Open edX models subsection. 
