### PR TITLE
🏷️(library) restore python 3.7+ compatibility for models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ docker-login: &docker-login
         echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin ||
         echo "Docker Hub anonymous mode"
 
-version: 2
+version: 2.1
 jobs:
   # Git jobs
   # Check that the git history is clean and complies with our expectations
@@ -209,8 +209,11 @@ jobs:
               ~/.local/bin/pytest
 
   test-library:
+    parameters:
+      python-image:
+        type: string
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/<< parameters.python-image >>
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
@@ -519,6 +522,9 @@ workflows:
             tags:
               only: /.*/
       - test-library:
+          matrix:
+            parameters:
+              python-image: [python:3.7, python:3.8, python:3.9, python:3.10, python:3.11]
           filters:
             tags:
               only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Restored python 3.7+ support for library usage (models)
+
 ### Changed
+
 - Allow xAPI extra fields in `extensions` fields
 
 ## [3.2.1] - 2023-02-01

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -2,7 +2,12 @@
 
 import io
 from pathlib import Path
-from typing import Literal, Union
+from typing import List, Tuple, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 try:
     from click import get_app_dir
@@ -46,7 +51,7 @@ class CommaSeparatedTuple(str):
 
     @classmethod
     def __get_validators__(cls):  # noqa: D105
-        def validate(value: Union[str, tuple[str]]) -> tuple[str]:
+        def validate(value: Union[str, Tuple[str]]) -> Tuple[str]:
             """Checks whether the value is a comma separated string or a tuple."""
             if isinstance(value, tuple):
                 return value
@@ -307,7 +312,7 @@ class Settings(BaseSettings):
     SENTRY_DSN: str = None
     SENTRY_CLI_TRACES_SAMPLE_RATE = 1.0
     SENTRY_LRS_TRACES_SAMPLE_RATE = 0.1
-    XAPI_FORWARDINGS: list[XapiForwardingConfigurationSettings] = []
+    XAPI_FORWARDINGS: List[XapiForwardingConfigurationSettings] = []
 
     @property
     def APP_DIR(self) -> Path:  # pylint: disable=invalid-name

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -3,7 +3,12 @@
 from datetime import datetime
 from ipaddress import IPv4Address
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Dict, Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import AnyHttpUrl, BaseModel, constr
 
@@ -37,7 +42,7 @@ class BaseContextField(BaseModelWithConfig):
     """Pydantic model for core `context` field.
 
     Attributes:
-        course_user_tags (dict of str): Content from `user_api_usercoursetag` table.
+        course_user_tags (Dict of str): Content from `user_api_usercoursetag` table.
             Retrieved with:
                 `dict(
                     UserCourseTag.objects.filter(
@@ -76,7 +81,7 @@ class BaseContextField(BaseModelWithConfig):
     """
 
     course_id: constr(regex=r"^$|^course-v1:.+\+.+\+.+$")  # noqa:F722
-    course_user_tags: Optional[dict[str, str]]
+    course_user_tags: Optional[Dict[str, str]]
     module: Optional[ContextModuleField]
     org_id: str
     path: Path

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,6 +1,11 @@
 """Browser event model definitions."""
 
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import AnyUrl, constr
 

--- a/src/ralph/models/edx/enrollment/fields/contexts.py
+++ b/src/ralph/models/edx/enrollment/fields/contexts.py
@@ -1,6 +1,11 @@
 """Enrollment event models context fields definitions."""
 
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from ...base import BaseContextField
 

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -1,6 +1,11 @@
 """Enrollment models event field definition."""
 
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from ...base import AbstractBaseEventField
 

--- a/src/ralph/models/edx/enrollment/statements.py
+++ b/src/ralph/models/edx/enrollment/statements.py
@@ -1,6 +1,11 @@
 """Enrollment event model definitions."""
 
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Json
 

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -1,6 +1,11 @@
 """Navigational event model definitions."""
 
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Json, validator
 

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -1,7 +1,12 @@
 """Problem interaction events model event fields definitions."""
 
 from datetime import datetime
-from typing import Literal, Optional, Union
+from typing import Dict, List, Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import constr
 
@@ -55,7 +60,7 @@ class State(BaseModelWithConfig):
         student_answers (dict): Consists of the answer(s) given by the user.
     """
 
-    correct_map: dict[
+    correct_map: Dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
         CorrectMap,
     ]
@@ -80,7 +85,7 @@ class SubmissionAnswerField(BaseModelWithConfig):
             this user.
     """
 
-    answer: Union[str, list[str]]
+    answer: Union[str, List[str]]
     correct: bool
     input_type: str
     question: str
@@ -129,10 +134,10 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
             `student_answer` response. Consists either of `single` or `compound` value.
     """
 
-    choice_all: Optional[list[str]]
+    choice_all: Optional[List[str]]
     correctness: bool
     hint_label: str
-    hints: list[dict]
+    hints: List[dict]
     module_id: str
     problem_part_id: str
     question_type: Union[
@@ -142,7 +147,7 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
         Literal["numericalresponse"],
         Literal["optionresponse"],
     ]
-    student_answer: list[str]
+    student_answer: List[str]
     trigger_type: Union[Literal["single"], Literal["compound"]]
 
 
@@ -163,12 +168,12 @@ class ProblemCheckEventField(AbstractBaseEventField):
         success (str): Consists of either the `correct` or `incorrect` value.
     """
 
-    answers: dict[
+    answers: Dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
-        Union[list[str], str],
+        Union[List[str], str],
     ]
     attempts: int
-    correct_map: dict[
+    correct_map: Dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
         CorrectMap,
     ]
@@ -179,7 +184,7 @@ class ProblemCheckEventField(AbstractBaseEventField):
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
     )
     state: State
-    submission: dict[
+    submission: Dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
         SubmissionAnswerField,
     ]
@@ -197,9 +202,9 @@ class ProblemCheckFailEventField(AbstractBaseEventField):
         state (dict): Consists of the current problem state.
     """
 
-    answers: dict[
+    answers: Dict[
         constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
-        Union[list[str], str],
+        Union[List[str], str],
     ]
     failure: Union[Literal["closed"], Literal["unreset"]]
     problem_id: constr(
@@ -262,7 +267,7 @@ class UIProblemResetEventField(AbstractBaseEventField):
             strings if multiple choices are allowed.
     """
 
-    answers: Union[str, list[str]]
+    answers: Union[str, List[str]]
 
 
 class UIProblemShowEventField(AbstractBaseEventField):
@@ -321,7 +326,7 @@ class SaveProblemFailEventField(AbstractBaseEventField):
         state (json): see StateField.
     """
 
-    answers: dict[str, Union[int, str, list, dict]]
+    answers: Dict[str, Union[int, str, list, dict]]
     failure: Union[Literal["closed"], Literal["done"]]
     problem_id: constr(
         regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
@@ -340,7 +345,7 @@ class SaveProblemSuccessEventField(AbstractBaseEventField):
         state (json): see StateField.
     """
 
-    answers: dict[str, Union[int, str, list, dict]]
+    answers: Dict[str, Union[int, str, list, dict]]
     problem_id: constr(
         regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -1,6 +1,11 @@
 """Problem interaction events model definitions."""
 
-from typing import Literal, Union
+from typing import List, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Json
 
@@ -135,7 +140,7 @@ class UIProblemGraded(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="problem_graded")
 
-    event: list[Union[str, Literal[None], None]]
+    event: List[Union[str, Literal[None], None]]
     event_type: Literal["problem_graded"]
     name: Literal["problem_graded"]
 

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -1,7 +1,12 @@
 """Server event model definitions."""
 
 from pathlib import Path
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Json
 

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -1,6 +1,11 @@
 """Textbook interaction event fields definitions."""
 
-from typing import Literal, Optional, Union
+from typing import Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Field, constr
 

--- a/src/ralph/models/edx/textbook_interaction/statements.py
+++ b/src/ralph/models/edx/textbook_interaction/statements.py
@@ -1,6 +1,11 @@
 """Textbook interaction event model definitions."""
 
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Json
 

--- a/src/ralph/models/edx/video/fields/events.py
+++ b/src/ralph/models/edx/video/fields/events.py
@@ -1,6 +1,9 @@
 """Video event fields definitions."""
 
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from ...base import AbstractBaseEventField
 

--- a/src/ralph/models/edx/video/statements.py
+++ b/src/ralph/models/edx/video/statements.py
@@ -1,6 +1,11 @@
 """Video event model definitions."""
 
-from typing import Literal, Optional, Union
+from typing import Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Json
 

--- a/src/ralph/models/selector.py
+++ b/src/ralph/models/selector.py
@@ -6,7 +6,7 @@ from importlib import import_module
 from inspect import getmembers, isclass
 from itertools import chain
 from types import ModuleType
-from typing import Any, Union
+from typing import Any, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -19,7 +19,7 @@ from ralph.utils import get_dict_value_from_path
 class LazyModelField:
     """Model field."""
 
-    path: tuple[str]
+    path: Tuple[str]
 
     def __init__(self, path: str):
         """Initalizes Lazy Model Field."""

--- a/src/ralph/models/xapi/base.py
+++ b/src/ralph/models/xapi/base.py
@@ -1,7 +1,7 @@
 """Base xAPI model definition."""
 
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import constr, root_validator
@@ -29,7 +29,7 @@ class BaseXapiModel(BaseModelWithConfig):
         stored (datetime): Consists of the timestamp of when the event was recorded.
         authority (ActorField): Consists of the Actor asserting this Statement is true.
         version (str): Consists of the associated xAPI version of the Statement.
-        attachments (list): Consists of a list of Attachments.
+        attachments (List): Consists of a list of Attachments.
     """
 
     id: Optional[UUID]
@@ -42,7 +42,7 @@ class BaseXapiModel(BaseModelWithConfig):
     stored: Optional[datetime]
     authority: Optional[ActorField]
     version: constr(regex=r"^1\.0\.[0-9]+$") = "1.0.0"  # noqa:F722
-    attachments: Optional[list[AttachmentField]]
+    attachments: Optional[List[AttachmentField]]
 
     @root_validator(pre=True)
     @classmethod

--- a/src/ralph/models/xapi/constants.py
+++ b/src/ralph/models/xapi/constants.py
@@ -1,6 +1,9 @@
 """Constants for xAPI specifications."""
 
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 # Languages
 LANG_EN_US_DISPLAY = Literal["en-US"]  # pylint:disable=invalid-name

--- a/src/ralph/models/xapi/fields/actors.py
+++ b/src/ralph/models/xapi/fields/actors.py
@@ -1,6 +1,11 @@
 """Common xAPI actor field definitions."""
 
-from typing import Literal, Optional, Union
+from typing import List, Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import AnyUrl, StrictStr, constr
 
@@ -98,7 +103,7 @@ class AnonymousGroupActorField(BaseActorField):
     """
 
     objectType: Literal["Group"]
-    member: list[AgentActorField]
+    member: List[AgentActorField]
 
 
 class BaseIdentifiedGroupActorField(AnonymousGroupActorField):
@@ -110,7 +115,7 @@ class BaseIdentifiedGroupActorField(AnonymousGroupActorField):
         member (list): Consist of a list of the members of this Group.
     """
 
-    member: Optional[list[AgentActorField]]
+    member: Optional[List[AgentActorField]]
 
 
 class MboxGroupActorField(BaseIdentifiedGroupActorField, MboxActorField):

--- a/src/ralph/models/xapi/fields/common.py
+++ b/src/ralph/models/xapi/fields/common.py
@@ -1,5 +1,7 @@
 """Common xAPI field definitions."""
 
+from typing import Dict
+
 from langcodes import tag_is_valid
 from pydantic import StrictStr, validate_email
 from rfc3987 import parse
@@ -32,7 +34,7 @@ class LanguageTag(str):
         yield validate
 
 
-LanguageMap = dict[LanguageTag, StrictStr]
+LanguageMap = Dict[LanguageTag, StrictStr]
 
 
 class MailtoEmail(str):

--- a/src/ralph/models/xapi/fields/contexts.py
+++ b/src/ralph/models/xapi/fields/contexts.py
@@ -1,6 +1,6 @@
 """Common xAPI context field definitions."""
 
-from typing import Optional, Union
+from typing import Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import StrictStr
@@ -15,17 +15,17 @@ class ContextActivitiesContextField(BaseModelWithConfig):
     """Pydantic model for `context.contextActivities` field.
 
     Attributes:
-        parent (list): An Activity with a direct relation to the statement's Activity.
-        grouping (list): An Activity with an indirect relation to the statement's
+        parent (List): An Activity with a direct relation to the statement's Activity.
+        grouping (List): An Activity with an indirect relation to the statement's
             Activity.
-        category (list): An Activity used to categorize the Statement.
-        other (list): A contextActivity that doesn't fit one of the other properties.
+        category (List): An Activity used to categorize the Statement.
+        other (List): A contextActivity that doesn't fit one of the other properties.
     """
 
-    parent: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
-    grouping: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
-    category: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
-    other: Optional[Union[ActivityObjectField, list[ActivityObjectField]]]
+    parent: Optional[Union[ActivityObjectField, List[ActivityObjectField]]]
+    grouping: Optional[Union[ActivityObjectField, List[ActivityObjectField]]]
+    category: Optional[Union[ActivityObjectField, List[ActivityObjectField]]]
+    other: Optional[Union[ActivityObjectField, List[ActivityObjectField]]]
 
 
 class ContextField(BaseModelWithConfig):
@@ -51,4 +51,4 @@ class ContextField(BaseModelWithConfig):
     platform: Optional[StrictStr]
     language: Optional[LanguageTag]
     statement: Optional[StatementRefObjectField]
-    extensions: Optional[dict[IRI, Union[str, int, bool, list, dict, None]]]
+    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]]

--- a/src/ralph/models/xapi/fields/objects.py
+++ b/src/ralph/models/xapi/fields/objects.py
@@ -4,7 +4,12 @@
 # because of the circular dependency : objects -> context -> objects.
 
 from datetime import datetime
-from typing import Literal, Optional, Union
+from typing import List, Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Field
 
@@ -36,7 +41,7 @@ class SubStatementObjectField(BaseModelWithConfig):
     result: Optional[ResultField]
     context: Optional[ContextField]
     timestamp: Optional[datetime]
-    attachments: Optional[list[AttachmentField]]
+    attachments: Optional[List[AttachmentField]]
 
 
 ObjectField = Union[UnnestedObjectField, SubStatementObjectField]

--- a/src/ralph/models/xapi/fields/results.py
+++ b/src/ralph/models/xapi/fields/results.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 from decimal import Decimal
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from pydantic import StrictBool, StrictStr, conint, root_validator
 
@@ -62,4 +62,4 @@ class ResultField(BaseModelWithConfig):
     completion: Optional[StrictBool]
     response: Optional[StrictStr]
     duration: Optional[timedelta]
-    extensions: Optional[dict[IRI, Union[str, int, bool, list, dict, None]]]
+    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]]

--- a/src/ralph/models/xapi/fields/unnested_objects.py
+++ b/src/ralph/models/xapi/fields/unnested_objects.py
@@ -1,6 +1,12 @@
 """Common xAPI object field definitions."""
 
-from typing import Literal, Optional, Union
+from typing import Dict, List, Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from uuid import UUID
 
 from pydantic import AnyUrl, StrictStr, constr, validator
@@ -17,14 +23,14 @@ class ObjectDefinitionField(BaseModelWithConfig):
         description (LanguageMap): Consists of a description of the Activity.
         type (IRI): Consists of the type of the Activity.
         moreInfo (URL): Consists of an URL to a document about the Activity.
-        extensions (dict): Consists of a dictionary of other properties as needed.
+        extensions (Dict): Consists of a dictionary of other properties as needed.
     """
 
     name: Optional[LanguageMap]
     description: Optional[LanguageMap]
     type: Optional[IRI]
     moreInfo: Optional[AnyUrl]
-    extensions: Optional[dict[IRI, Union[str, int, bool, list, dict, None]]]
+    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]]
 
 
 class InteractionComponent(BaseModelWithConfig):
@@ -66,12 +72,12 @@ class InteractionObjectDefinitionField(ObjectDefinitionField):
         "numeric",
         "other",
     ]
-    correctResponsesPattern: Optional[list[StrictStr]]
-    choices: Optional[list[InteractionComponent]]
-    scale: Optional[list[InteractionComponent]]
-    source: Optional[list[InteractionComponent]]
-    target: Optional[list[InteractionComponent]]
-    steps: Optional[list[InteractionComponent]]
+    correctResponsesPattern: Optional[List[StrictStr]]
+    choices: Optional[List[InteractionComponent]]
+    scale: Optional[List[InteractionComponent]]
+    source: Optional[List[InteractionComponent]]
+    target: Optional[List[InteractionComponent]]
+    steps: Optional[List[InteractionComponent]]
 
     @validator("choices", "scale", "source", "target", "steps")
     @classmethod

--- a/src/ralph/models/xapi/fields/verbs.py
+++ b/src/ralph/models/xapi/fields/verbs.py
@@ -1,6 +1,6 @@
 """Common xAPI verb field definitions."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from ..config import BaseModelWithConfig
 from ..constants import (
@@ -34,7 +34,7 @@ class ViewedVerbField(VerbField):
     """
 
     id: VERB_VIEWED_ID = VERB_VIEWED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_VIEWED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_VIEWED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_VIEWED_DISPLAY.__args__[0]
     }
 
@@ -48,6 +48,6 @@ class TerminatedVerbField(VerbField):
     """
 
     id: VERB_TERMINATED_ID = VERB_TERMINATED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_TERMINATED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_TERMINATED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_TERMINATED_DISPLAY.__args__[0]
     }

--- a/src/ralph/models/xapi/navigation/fields/objects.py
+++ b/src/ralph/models/xapi/navigation/fields/objects.py
@@ -1,6 +1,6 @@
 """Navigation xAPI events object fields definitions."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from ...constants import ACTIVITY_PAGE_DISPLAY, ACTIVITY_PAGE_ID, LANG_EN_US_DISPLAY
 from ...fields.objects import ObjectDefinitionExtensionsField
@@ -16,7 +16,7 @@ class PageObjectDefinitionField(ObjectDefinitionField):
        extensions (dict): See ObjectDefinitionExtensionsField.
     """
 
-    name: dict[LANG_EN_US_DISPLAY, ACTIVITY_PAGE_DISPLAY] = {
+    name: Dict[LANG_EN_US_DISPLAY, ACTIVITY_PAGE_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: ACTIVITY_PAGE_DISPLAY.__args__[0]
     }
     type: ACTIVITY_PAGE_ID = ACTIVITY_PAGE_ID.__args__[0]

--- a/src/ralph/models/xapi/video/constants.py
+++ b/src/ralph/models/xapi/video/constants.py
@@ -1,6 +1,9 @@
 """Constants for xAPI video specifications."""
 
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 # xAPI video extensions
 VIDEO_EXTENSION_CC_SUBTITLE_LANG = (

--- a/src/ralph/models/xapi/video/fields/contexts.py
+++ b/src/ralph/models/xapi/video/fields/contexts.py
@@ -1,6 +1,12 @@
 """Video xAPI events context fields definitions."""
 
-from typing import Literal, Optional
+from typing import Dict, List, Optional
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat
@@ -27,11 +33,11 @@ class VideoContextActivitiesField(ContextActivitiesContextField):
     """Pydantic model for video `contextActivities` field.
 
     Attributes:
-        category (list): Consists of a list containing the dictionary
+        category (List): Consists of a list containing the dictionary
             {"id": "https://w3id.org/xapi/video"}.
     """
 
-    category: list[dict[Literal["id"], VIDEO_CONTEXT_CATEGORY]] = [
+    category: List[Dict[Literal["id"], VIDEO_CONTEXT_CATEGORY]] = [
         {"id": VIDEO_CONTEXT_CATEGORY.__args__[0]}
     ]
 

--- a/src/ralph/models/xapi/video/fields/objects.py
+++ b/src/ralph/models/xapi/video/fields/objects.py
@@ -1,6 +1,6 @@
 """Video xAPI events object fields definitions."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from ...constants import LANG_EN_US_DISPLAY
 from ...fields.objects import ObjectDefinitionExtensionsField
@@ -32,5 +32,5 @@ class VideoObjectField(ActivityObjectField):
         definition (dict): See VideoObjectDefinitionField.
     """
 
-    name: Optional[dict[LANG_EN_US_DISPLAY, str]]
+    name: Optional[Dict[LANG_EN_US_DISPLAY, str]]
     definition: VideoObjectDefinitionField = VideoObjectDefinitionField()

--- a/src/ralph/models/xapi/video/fields/results.py
+++ b/src/ralph/models/xapi/video/fields/results.py
@@ -1,7 +1,12 @@
 """Video xAPI events result fields definitions."""
 
 from datetime import timedelta
-from typing import Literal, Optional
+from typing import Optional
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import Field, NonNegativeFloat
 

--- a/src/ralph/models/xapi/video/fields/verbs.py
+++ b/src/ralph/models/xapi/video/fields/verbs.py
@@ -1,5 +1,7 @@
 """Video xAPI events verb fields definitions."""
 
+from typing import Dict
+
 from ...constants import (
     LANG_EN_US_DISPLAY,
     VERB_COMPLETED_DISPLAY,
@@ -23,11 +25,11 @@ class VideoInitializedVerbField(VerbField):
 
     Attributes:
         id (str): Consists of the value `http://adlnet.gov/expapi/verbs/initialized`.
-        display (dict): Consists of the dictionary `{"en-US": "initialized"}`.
+        display (Dict): Consists of the dictionary `{"en-US": "initialized"}`.
     """
 
     id: VERB_INITIALIZED_ID = VERB_INITIALIZED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_INITIALIZED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_INITIALIZED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_INITIALIZED_DISPLAY.__args__[0]
     }
 
@@ -41,7 +43,7 @@ class VideoPlayedVerbField(VerbField):
     """
 
     id: VERB_VIDEO_PLAYED_ID = VERB_VIDEO_PLAYED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_PLAYED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_PLAYED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_PLAYED_DISPLAY.__args__[0]
     }
 
@@ -55,7 +57,7 @@ class VideoPausedVerbField(VerbField):
     """
 
     id: VERB_VIDEO_PAUSED_ID = VERB_VIDEO_PAUSED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_PAUSED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_PAUSED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_PAUSED_DISPLAY.__args__[0]
     }
 
@@ -69,7 +71,7 @@ class VideoSeekedVerbField(VerbField):
     """
 
     id: VERB_VIDEO_SEEKED_ID = VERB_VIDEO_SEEKED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_SEEKED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_SEEKED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_SEEKED_DISPLAY.__args__[0]
     }
 
@@ -83,7 +85,7 @@ class VideoCompletedVerbField(VerbField):
     """
 
     id: VERB_COMPLETED_ID = VERB_COMPLETED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_COMPLETED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_COMPLETED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_COMPLETED_DISPLAY.__args__[0]
     }
 
@@ -97,7 +99,7 @@ class VideoTerminatedVerbField(VerbField):
     """
 
     id: VERB_TERMINATED_ID = VERB_TERMINATED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_TERMINATED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_TERMINATED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_TERMINATED_DISPLAY.__args__[0]
     }
 
@@ -111,6 +113,6 @@ class VideoInteractedVerbField(VerbField):
     """
 
     id: VERB_INTERACTED_ID = VERB_INTERACTED_ID.__args__[0]
-    display: dict[LANG_EN_US_DISPLAY, VERB_INTERACTED_DISPLAY] = {
+    display: Dict[LANG_EN_US_DISPLAY, VERB_INTERACTED_DISPLAY] = {
         LANG_EN_US_DISPLAY.__args__[0]: VERB_INTERACTED_DISPLAY.__args__[0]
     }

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -5,6 +5,7 @@ import logging
 import operator
 from functools import reduce
 from importlib import import_module
+from typing import List
 
 from pydantic import BaseModel
 
@@ -64,12 +65,12 @@ def now():
     return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
 
-def get_dict_value_from_path(dict_: dict, path: list[str]):
+def get_dict_value_from_path(dict_: dict, path: List[str]):
     """Gets a nested dictionary value.
 
     Args:
         dict_ (dict): #FIXME I miss the info for this argument.
-        path (list): array of keys representing the path to the value
+        path (List): array of keys representing the path to the value
     """
     if path is None:
         return None
@@ -79,12 +80,12 @@ def get_dict_value_from_path(dict_: dict, path: list[str]):
         return None
 
 
-def set_dict_value_from_path(dict_: dict, path: list[str], value: any):
+def set_dict_value_from_path(dict_: dict, path: List[str], value: any):
     """Sets a nested dictionary value.
 
     Args:
         dict_ (dict): #FIXME I miss the info for this argument.
-        path (list): array of keys representing the path to the value
+        path (List): array of keys representing the path to the value
         value: #FIXME I miss the info for this argument.
     """
     for key in path[:-1]:


### PR DESCRIPTION
## Purpose

Projects still running python 3.7 should be able to integrate Ralph models in their code base.

## Proposal

- [x] fix typing issues
- [x] automate library testing for various python versions from 3.7 to 3.11
