### PR TITLE
🔖(minor) bump release to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.3.0] - 2023-02-03
+
 ### Added
 
 - Restored python 3.7+ support for library usage (models)
@@ -235,7 +237,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.2.1...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.3.0...master
+[3.3.0]: https://github.com/openfun/ralph/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/openfun/ralph/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/openfun/ralph/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/openfun/ralph/compare/v3.0.0...v3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.2.1
+version = 3.3.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.2.1"
+__version__ = "3.3.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.2.1
+  version: 3.3.0


### PR DESCRIPTION
### Added

- Restored python 3.7+ support for library usage (models)

### Changed

- Allow xAPI extra fields in `extensions` fields
