### PR TITLE
🐛(api) fix sentry integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Upgrade `fastapi` to `0.92.0`
 - Upgrade `sentry_sdk` to `1.15.0`
 
+### Fixed
+
+- Restore sentry integration in the LRS server
+
 ## [3.3.0] - 2023-02-03
 
 ### Added

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,5 +1,5 @@
 """Main module for Ralph's LRS API."""
-
+import sentry_sdk
 from fastapi import Depends, FastAPI
 
 from ralph.conf import settings
@@ -9,7 +9,7 @@ from .auth import AuthenticatedUser, authenticated_user
 from .routers import health, statements
 
 if settings.SENTRY_DSN is not None:
-    sentry_sdk.init(  # noqa: F821 # pylint: disable=undefined-variable
+    sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         traces_sample_rate=settings.SENTRY_LRS_TRACES_SAMPLE_RATE,
         release=__version__,


### PR DESCRIPTION
## Purpose

When the SENTRY_DSN setting is active, the LRS server cannot start as the sentry_sdk module is not imported.

## Proposal

- [x] import the `sentry_sdk` in the LRS server module
