### PR TITLE
✨(api) add PUT route, make trailing slashes optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Implement PUT verb on statements endpoint
+- Add ClickHouse database backend support
+
+### Changed
+
+- Make trailing slashes optional on statements endpoint
+
 ## [3.4.0] - 2023-03-01
 
 ### Changed
@@ -24,7 +33,6 @@ and this project adheres to
 ### Added
 
 - Restore python 3.7+ support for library usage (models)
-- Add ClickHouse database backend support
 
 ### Changed
 

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -61,7 +61,6 @@ def insert_clickhouse_statements(statements):
         database=CLICKHOUSE_TEST_DATABASE,
         event_table_name=CLICKHOUSE_TEST_TABLE_NAME,
     )
-    # documents = list(ClickHouseDatabase.to_documents(statements))
     success = backend.put(statements)
     assert success == len(statements)
 
@@ -111,12 +110,14 @@ def test_api_statements_get_statements(
     ]
     insert_statements_and_monkeypatch_backend(statements)
 
-    response = client.get(
-        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
-    )
+    # Confirm that calling this with and without the trailing slash both work
+    for path in ("/xAPI/statements", "/xAPI/statements/"):
+        response = client.get(
+            path, headers={"Authorization": f"Basic {auth_credentials}"}
+        )
 
-    assert response.status_code == 200
-    assert response.json() == {"statements": [statements[1], statements[0]]}
+        assert response.status_code == 200
+        assert response.json() == {"statements": [statements[1], statements[0]]}
 
 
 def test_api_statements_get_statements_ascending(


### PR DESCRIPTION
## Purpose

Make the statements endpoint more compliant with xAPI docs and samples.

## Proposal

- Add a PUT route for receiving a single statement to store
- Make trailing slashes on the `statements` endpoint optional