### PR TITLE
🔖(minor) bump release to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.5.0] - 2023-03-08
+
 ### Added
 
 - Implement PUT verb on statements endpoint
@@ -16,13 +18,14 @@ and this project adheres to
 ### Changed
 
 - Make trailing slashes optional on statements endpoint
+- Upgrade `sentry_sdk` to `1.16.0`
 
 ## [3.4.0] - 2023-03-01
 
 ### Changed
 
 - Upgrade `fastapi` to `0.92.0`
-- Upgrade `sentry_sdk` to `1.16.0`
+- Upgrade `sentry_sdk` to `1.15.0`
 
 ### Fixed
 
@@ -257,7 +260,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.4.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.5.0...master
+[3.5.0]: https://github.com/openfun/ralph/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/openfun/ralph/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/openfun/ralph/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/openfun/ralph/compare/v3.2.0...v3.2.1

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,5 +1,5 @@
 metadata:
   name: ralph
-  version: 3.4.0
+  version: 3.5.0
 source:
   path: src/tray

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.4.0
+version = 3.5.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.4.0"
+appVersion: "3.5.0"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.4.0
+  version: 3.5.0


### PR DESCRIPTION
## Added

- Implement PUT verb on statements endpoint
- Add ClickHouse database backend support

## Changed

- Make trailing slashes optional on statements endpoint
- Upgrade `sentry_sdk` to `1.16.0`
