### PR TITLE
Update fixme checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
           command: |
             ! git diff origin/master..HEAD -- . ':(exclude).circleci' | grep "print("
       - run:
+          name: enforce absence of FIXME in code
+          command: |
+            ! git diff origin/master..HEAD -- . ':(exclude).circleci' | grep "FIXME"
+      - run:
           name: Check absence of fixup commits
           command: |
             ! git log --pretty=format:%s | grep 'fixup!'

--- a/Makefile
+++ b/Makefile
@@ -224,18 +224,15 @@ logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app
 .PHONY: logs
 
-run: ## alias for run-es run-mongo run-clickhouse
+run: ## run LRS server with the runserver backends (development mode)
 run: \
-	run-es \
-	run-mongo \
-	run-clickhouse
+	run-databases
+	@$(COMPOSE) up -d app
 .PHONY: run
 
 run-all: ## start all supported local backends
 run-all: \
-	run-clickhouse \
-	run-es \
-	run-mongo \
+	run-databases \
 	run-swift
 .PHONY: run-all
 
@@ -245,19 +242,18 @@ run-clickhouse: ## start clickhouse backend
 	@$(COMPOSE_RUN) dockerize -wait tcp://clickhouse:9000 -timeout 60s
 .PHONY: run-clickhouse
 
+run-databases: ## alias for running database services
+run-databases: \
+	run-es \
+	run-mongo \
+	run-clickhouse
+.PHONY: run-databases
+
 run-es: ## start elasticsearch backend
 	@$(COMPOSE) up -d elasticsearch
 	@echo "Waiting for elasticsearch to be up and running..."
 	@$(COMPOSE_RUN) dockerize -wait tcp://elasticsearch:9200 -timeout 60s
 .PHONY: run-es
-
-run-lrs: ## run LRS server with the runserver backends (development mode)
-run-lrs: \
-	run-es \
-	run-mongo \
-	run-clickhouse
-	@$(COMPOSE) up -d app
-.PHONY: run-lrs
 
 run-mongo: ## start mongodb backend
 	@$(COMPOSE) up -d mongo
@@ -280,7 +276,7 @@ stop: ## stops backend servers
 .PHONY: stop
 
 test: ## run back-end tests
-test: run-lrs
+test: run
 	bin/pytest
 .PHONY: test
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ docker compose ps
 You may now start the LRS server using:
 
 ```
-$ make run-lrs
+$ make run
 ```
 
 The server should be up and running at

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ where = src
 
 [options.entry_points]
 console_scripts =
-  ralph = ralph.__main__:cli
+  ralph = ralph.__main__:cli.cli
 
 [wheel]
 universal = 1

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -69,7 +69,8 @@ def get_dict_value_from_path(dict_: dict, path: List[str]):
     """Gets a nested dictionary value.
 
     Args:
-        dict_ (dict): #FIXME I miss the info for this argument.
+        dict_ (dict): dictionnary of values to which the reduction is
+            applied
         path (List): array of keys representing the path to the value
     """
     if path is None:
@@ -84,9 +85,9 @@ def set_dict_value_from_path(dict_: dict, path: List[str], value: any):
     """Sets a nested dictionary value.
 
     Args:
-        dict_ (dict): #FIXME I miss the info for this argument.
+        dict_ (dict): dictionnary where the given value is set
         path (List): array of keys representing the path to the value
-        value: #FIXME I miss the info for this argument.
+        value: value to be set
     """
     for key in path[:-1]:
         dict_ = dict_.setdefault(key, {})


### PR DESCRIPTION
## Purpose

FIXME statements is not properly checked in pylint when they are written in
docstrings.

## Proposal

- Add a step in the circle ci config for gint-lit job to detect presence of FIXME
statements.
- Remove remaining FIXME statements
- ➕ (bonus) Update name of `run` alias in Makefile

