### PR TITLE
Implement synchronous LRS backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
             - v1-dependencies-<< parameters.python-image >>-{{ .Revision }}
       - run:
           name: Install development dependencies
-          command: pip install --user .[backend-clickhouse,backend-es,backend-ldp,backend-mongo,backend-swift,backend-ws,cli,dev,lrs]
+          command: pip install --user .[backend-clickhouse,backend-es,backend-ldp,backend-lrs,backend-mongo,backend-swift,backend-ws,cli,dev,lrs]
       - save_cache:
           paths:
             - ~/.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - Clean xAPI pydantic models naming convention
 - Upgrade `fastapi` to `0.97.0`
 - Upgrade `sentry_sdk` to `1.25.1`
+- Set Clickhouse `client_options` to a dedicated Pydantic model
 - Upgrade `httpx` to `0.24.1`
 - Force a valid (JSON-formatted) IFI to be passed for the `/statements` 
 GET query `agent` filtering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Implement synchronous `lrs` backend
 - Implement xAPI virtual classroom pydantic models
 - Allow to insert custom endpoint url for S3 service
 - Cache the HTTP Basic auth credentials to improve API response time   

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
         python-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install .[backend-clickhouse,backend-es,backend-ldp,backend-mongo,backend-swift,backend-ws,cli,lrs]
+RUN pip install .[backend-clickhouse,backend-es,backend-ldp,backend-lrs,backend-mongo,backend-swift,backend-ws,cli,lrs]
 
 
 # -- Core --

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -183,7 +183,6 @@ The MongoDB client options supported in Ralph are:
 - `document_class`: default class to use for documents returned from queries
 - `tz_aware`: if True, datetime instances returned as values in a document will be timezone aware (otherwise they will be naive)
 
-
 ### ClickHouse
 
 The ClickHouse backend can be used as a data lake and to fetch collections of
@@ -192,6 +191,7 @@ documents from it.
 #### Backend parameters
 
 ClickHouse parameters required to connect are:
+
 - `host`: the connection hostname to connect to (_e.g._ `"clickhouse.yourhost.com"`)
 - `port`: the port to the ClickHouse HTTPS interface (_e.g._ `8123`)
 - `database`: the name of the database to connect to
@@ -199,14 +199,34 @@ ClickHouse parameters required to connect are:
 - `client_options`: a comma separated key=value list of ClickHouse client options
 
 Secondary parameters are needed if not using the default ClickHouse user:
+
 - `username`: the username to connect as
 - `password`: the password for the given ClickHouse username
 
 By default, the following client options are set, if you override the default 
 client options you must also set these:
+
 - `"date_time_input_format": "best_effort"` allows RFC date parsing
 - `"allow_experimental_object_type": 1` allows the JSON data type we use to store statements
 
 The ClickHouse client options supported in Ralph can be found in these locations:
 - [Python driver specific](https://clickhouse.com/docs/en/integrations/language-clients/python/driver-api#settings-argument)
 - [General ClickHouse client settings](https://clickhouse.com/docs/en/operations/settings/settings/)
+
+## HTTP backends
+
+### LRS
+
+The LRS backend is used to store and retrieve xAPI statements from various systems mostly used in e-learning infrastructures.
+
+#### Backend parameters
+
+LRS parameters required to connect are: 
+
+- `url`: the URL to connect to the server (_e.g._ [`http://ralph:secret@lrs:8100`])
+- `username`: the username to connect as
+- `password`: the password for the given LRS username
+
+Optional parameters can be configured if necessary: 
+
+- `headers`: a comma-separated key=value list of LRS server headers

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ $ source venv/bin/activate
 
 # Install the full package (in a virtualenv)
 (venv) $ pip install \
-    ralph-malph[backend-es,backend-ldp,backend-mongo,backend-swift,backend-ws,cli,lrs]
+    ralph-malph[backend-es,backend-ldp,backend-lrs,backend-mongo,backend-swift,backend-ws,cli,lrs]
 
 # Install only the core package with the Elasticsearch backend and the LRS (in
 # a virtualenv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,8 @@ dev =
     pylint==2.17.4
     pytest==7.3.2
     pytest-asyncio==0.21.0
-    pytest-cov==4.1.0
+    pytest-cov==4.0.0
+    pytest-httpx==0.22.0
 ci =
     twine==4.0.2
 lrs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,9 @@ backend-es =
 backend-ldp =
     ovh>=1.0.0
     requests>=2.0.0
+backend-lrs =
+    httpx==0.24.1
+    more-itertools==9.1.0
 backend-mongo =
     pymongo[srv]>=4.0.0
     python-dateutil>=2.8.2

--- a/src/ralph/backends/database/clickhouse.py
+++ b/src/ralph/backends/database/clickhouse.py
@@ -10,7 +10,7 @@ import clickhouse_connect
 from clickhouse_connect.driver.exceptions import ClickHouseError
 from pydantic import BaseModel, ValidationError
 
-from ralph.conf import settings
+from ralph.conf import ClickhouseClientOptions, settings
 from ralph.exceptions import BackendException, BadFormatException
 
 from .base import (
@@ -54,7 +54,7 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
         event_table_name: str = clickhouse_settings.EVENT_TABLE_NAME,
         username: str = clickhouse_settings.USERNAME,
         password: str = clickhouse_settings.PASSWORD,
-        client_options: dict = clickhouse_settings.CLIENT_OPTIONS,
+        client_options: ClickhouseClientOptions = clickhouse_settings.CLIENT_OPTIONS,
     ):
         """Instantiates the ClickHouse configuration.
 
@@ -76,6 +76,8 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
                 "date_time_input_format": "best_effort",  # Allows RFC dates
                 "allow_experimental_object_type": 1,  # Allows JSON data type
             }
+        else:
+            client_options = client_options.dict()
 
         self.host = host
         self.port = port

--- a/src/ralph/backends/http/__init__.py
+++ b/src/ralph/backends/http/__init__.py
@@ -1,3 +1,4 @@
 """HTTP backends for Ralph."""
 
 from .base import BaseHTTP  # noqa: F401
+from .lrs import LRSHTTP  # noqa: F401

--- a/src/ralph/backends/http/__init__.py
+++ b/src/ralph/backends/http/__init__.py
@@ -1,0 +1,3 @@
+"""HTTP backends for Ralph."""
+
+from .base import BaseHTTP  # noqa: F401

--- a/src/ralph/backends/http/base.py
+++ b/src/ralph/backends/http/base.py
@@ -1,0 +1,132 @@
+"""Base HTTP backend for Ralph."""
+
+import functools
+import logging
+from abc import ABC, abstractmethod
+from enum import Enum, unique
+from typing import Iterator, List, Optional, Union
+
+from pydantic import BaseModel, ValidationError
+
+from ralph.exceptions import BackendParameterException
+
+logger = logging.getLogger(__name__)
+
+
+@unique
+class HTTPBackendStatus(Enum):
+    """HTTP backend statuses."""
+
+    OK = "ok"
+    AWAY = "away"
+    ERROR = "error"
+
+
+class OperationType(Enum):
+    """Data backend operation types.
+
+    Attributes:
+        INDEX (str): creates a new record with a specific ID.
+        CREATE (str): creates a new record without a specific ID.
+        DELETE (str): deletes an existing record.
+        UPDATE (str): updates or overwrites an existing record.
+        APPEND (str): creates or appends data to an existing record.
+    """
+
+    INDEX = "index"
+    CREATE = "create"
+    DELETE = "delete"
+    UPDATE = "update"
+    APPEND = "append"
+
+
+def enforce_query_checks(method):
+    """Enforces query argument type checking for methods using it."""
+
+    @functools.wraps(method)
+    def wrapper(*args, **kwargs):
+        """Wrap method execution."""
+        query = kwargs.pop("query", None)
+        self_ = args[0]
+
+        return method(*args, query=self_.validate_query(query), **kwargs)
+
+    return wrapper
+
+
+class BaseQuery(BaseModel):
+    """Base query model."""
+
+    class Config:
+        """Base query model configuration."""
+
+        extra = "forbid"
+
+    query_string: Optional[str]
+
+
+class BaseHTTP(ABC):
+    """Base HTTP backend interface."""
+
+    name = "base"
+    query = BaseQuery
+
+    def validate_query(self, query: Union[str, dict, BaseQuery] = None) -> BaseQuery:
+        """Validates and transforms the query."""
+        if query is None:
+            query = self.query()
+
+        if isinstance(query, str):
+            query = self.query(query_string=query)
+
+        if isinstance(query, dict):
+            try:
+                query = self.query(**query)
+            except ValidationError as err:
+                raise BackendParameterException(
+                    "The 'query' argument is expected to be a "
+                    f"{self.query.__name__} instance. {err.errors()}"
+                ) from err
+
+        if not isinstance(query, self.query):
+            raise BackendParameterException(
+                "The 'query' argument is expected to be a "
+                f"{self.query.__name__} instance."
+            )
+
+        logger.debug("Query: %s", str(query))
+
+        return query
+
+    @abstractmethod
+    def list(
+        self, target: str = None, details: bool = False, new: bool = False
+    ) -> Iterator[Union[str, dict]]:
+        """Lists containers in the data backend. E.g., collections, files, indexes."""
+
+    @abstractmethod
+    def status(self) -> HTTPBackendStatus:
+        """Implements HTTP backend check for server status."""
+
+    @abstractmethod
+    @enforce_query_checks
+    def read(  # pylint: disable=too-many-arguments
+        self,
+        query: Union[str, BaseQuery] = None,
+        target: str = None,
+        chunk_size: Union[None, int] = 500,
+        raw_output: bool = False,
+        ignore_errors: bool = False,
+    ) -> Iterator[Union[bytes, dict]]:
+        """Yields records read from the HTTP response results."""
+
+    @abstractmethod
+    def write(  # pylint: disable=too-many-arguments
+        self,
+        data: Union[List[bytes], List[dict]],
+        target: Union[None, str] = None,
+        chunk_size: Union[None, int] = 500,
+        ignore_errors: bool = False,
+        operation_type: Union[None, OperationType] = None,
+    ) -> int:
+        """Writes statements into the HTTP server given an input endpoint."""

--- a/src/ralph/backends/http/lrs.py
+++ b/src/ralph/backends/http/lrs.py
@@ -1,0 +1,275 @@
+"""LRS HTTP backend for Ralph."""
+
+import json
+import logging
+from itertools import chain
+from typing import Iterable, Iterator, List, Optional, Union
+from urllib.parse import ParseResult, parse_qs, urljoin, urlparse
+
+import httpx
+from httpx import Client, HTTPError, HTTPStatusError, RequestError
+from more_itertools import chunked
+from pydantic import AnyHttpUrl, BaseModel, parse_obj_as
+
+from ralph.conf import LRSHeaders, settings
+from ralph.exceptions import BackendException, BackendParameterException
+
+from .base import (
+    BaseHTTP,
+    BaseQuery,
+    HTTPBackendStatus,
+    OperationType,
+    enforce_query_checks,
+)
+
+lrs_settings = settings.BACKENDS.HTTP.LRS
+logger = logging.getLogger(__name__)
+
+
+class StatementResponse(BaseModel):
+    """Pydantic model for `get` statements response."""
+
+    statements: Union[List[dict], dict]
+    more: Optional[str]
+
+
+class LRSQuery(BaseQuery):
+    """LRS body query model."""
+
+    query: Optional[dict]
+
+
+class LRSHTTP(BaseHTTP):
+    """LRS HTTP backend."""
+
+    name = "lrs"
+    query = LRSQuery
+    default_operation_type = OperationType.CREATE
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        base_url: str = lrs_settings.BASE_URL,
+        username: str = lrs_settings.USERNAME,
+        password: str = lrs_settings.PASSWORD,
+        headers: LRSHeaders = lrs_settings.HEADERS,
+        status_endpoint: str = lrs_settings.STATUS_ENDPOINT,
+        statements_endpoint: str = lrs_settings.STATEMENTS_ENDPOINT,
+    ):
+        """Instantiates the LRS client.
+
+        Args:
+            base_url (AnyHttpUrl): LRS server URL.
+            username (str): Basic auth username for LRS authentication.
+            password (str): Basic auth password for LRS authentication.
+            headers (dict): Headers defined for the LRS server connection.
+            status_endpoint (str): Endpoint used to check server status.
+            statements_endpoint (str): Default endpoint for LRS statements resource.
+        """
+        self.base_url = parse_obj_as(AnyHttpUrl, base_url)
+        self.auth = (username, password)
+        self.headers = headers
+        self.status_endpoint = status_endpoint
+        self.statements_endpoint = statements_endpoint
+
+    def status(self):
+        """Implements HTTP backend check for server status."""
+        status_url = urljoin(self.base_url, self.status_endpoint)
+
+        try:
+            response = httpx.get(status_url)
+            response.raise_for_status()
+        except RequestError:
+            msg = "Unable to request the server"
+            logger.error(msg)
+            return HTTPBackendStatus.AWAY
+        except HTTPStatusError:
+            msg = "Response raised an HTTP status of 4xx or 5xx"
+            logger.error(msg)
+            return HTTPBackendStatus.ERROR
+
+        return HTTPBackendStatus.OK
+
+    def list(
+        self, target: str = None, details: bool = False, new: bool = False
+    ) -> Iterator[Union[str, dict]]:
+        # noqa: D205, D415
+        """LRS HTTP backend does not support `list` method,
+        calling this method will raise an error.
+        """
+        msg = "LRS HTTP backend does not support `list` method, cannot list from %s"
+        logger.error(msg, target)
+        raise NotImplementedError(msg % target)
+
+    @enforce_query_checks
+    def read(  # pylint: disable=too-many-arguments
+        self,
+        query: Union[str, LRSQuery] = None,
+        target: str = None,
+        chunk_size: Union[None, int] = 500,
+        raw_output: bool = False,
+        ignore_errors: bool = False,
+    ) -> Iterator[Union[bytes, dict]]:
+        """Get statements from LRS `target` endpoint.
+
+        The `read` method defined in the LRS specification returns `statements` array
+        and `more` IRL. The latter is required when the returned `statement` list has
+        been limited.
+
+        Args:
+            query (str, LRSQuery):  The query to select records to read.
+            target (str): Endpoint from which to read data (e.g. `/statements`).
+                If target is `None`, `/xAPI/statements` default endpoint is used.
+            chunk_size (int or None): The number of records or bytes to read in one
+                batch, depending on whether the records are dictionaries or bytes.
+            raw_output (bool): Controls whether to yield bytes or dictionaries.
+                If the records are dictionaries and `raw_output` is set to `True`, they
+                are encoded as JSON.
+                If the records are bytes and `raw_output` is set to `False`, they are
+                decoded as JSON by line.
+            ignore_errors (bool): If `True`, errors during the read operation
+                are be ignored and logged. If `False` (default), a `BackendException`
+                is raised if an error occurs.
+        """
+        if not target:
+            target = self.statements_endpoint
+
+        query_params = {}
+        if query.query:
+            query_params.update(query.query)
+
+        # Set chunk_size to limit parameter if not exist in the query
+        query_params.setdefault("limit", chunk_size)
+
+        # Create request URL
+        target = ParseResult(
+            scheme=urlparse(self.base_url).scheme,
+            netloc=urlparse(self.base_url).netloc,
+            path=target,
+            query="",
+            params="",
+            fragment="",
+        ).geturl()
+
+        def fetch_statements(params: dict):
+            while True:
+                with Client(auth=self.auth, headers=self.headers) as client:
+                    response = client.get(target, params=params)
+                    response.raise_for_status()
+
+                    statements_response = StatementResponse.parse_obj(response.json())
+                    statements = statements_response.statements
+                    statements = (
+                        [statements] if not isinstance(statements, list) else statements
+                    )
+                    if raw_output:
+                        for statement in statements:
+                            yield bytes(json.dumps(statement), encoding="utf-8")
+                    else:
+                        for statement in statements:
+                            yield statement
+
+                    if not statements_response.more:
+                        break
+
+                    params.update(parse_qs(urlparse(statements_response.more).query))
+
+        try:
+            yield from fetch_statements(params=query_params)
+        except HTTPError as error:
+            msg = "Failed to fetch statements."
+            logger.error("%s. %s", msg, error)
+            raise BackendException(msg, *error.args) from error
+
+    def write(  # pylint: disable=too-many-arguments
+        self,
+        data: Union[Iterable[bytes], Iterable[dict]],
+        target: Union[None, str] = None,
+        chunk_size: Union[None, int] = 500,
+        ignore_errors: bool = False,
+        operation_type: Union[None, OperationType] = None,
+    ) -> int:
+        """Writes `data` records to the `target` endpoint and returns their count.
+
+        Args:
+            data: (Iterable): The data to write.
+            target (str or None): Endpoint in which to write data (e.g. `/statements`).
+                If `target` is `None`, `/xAPI/statements` default endpoint is used.
+            chunk_size (int or None): The number of records or bytes to write in one
+                batch, depending on whether `data` contains dictionaries or bytes.
+                If `chunk_size` is `None`, a default value is used instead.
+            ignore_errors (bool): If `True`, errors during the write operation
+                are ignored and logged. If `False` (default), a `BackendException`
+                is raised if an error occurs.
+            operation_type (OperationType or None): The mode of the write operation.
+                If `operation_type` is `None`, the `default_operation_type` is used
+                instead. See `OperationType`.
+        """
+        statements_count = 0
+
+        data = iter(data)
+        try:
+            first_record = next(data)
+        except StopIteration:
+            logger.debug("Data Iterator is empty; skipping write to target.")
+            return statements_count
+
+        if not operation_type:
+            operation_type = self.default_operation_type
+
+        if operation_type in (
+            OperationType.APPEND,
+            OperationType.UPDATE,
+            OperationType.DELETE,
+        ):
+            msg = f"{operation_type.value} operation type is not supported."
+            logger.error(msg)
+            raise BackendParameterException(msg)
+
+        if not target:
+            target = self.statements_endpoint
+
+        target = ParseResult(
+            scheme=urlparse(self.base_url).scheme,
+            netloc=urlparse(self.base_url).netloc,
+            path=target,
+            query="",
+            params="",
+            fragment="",
+        ).geturl()
+
+        data = chain((first_record,), data)
+        if isinstance(first_record, dict):
+            data = self._parse_dict_to_bytes(data, ignore_errors)
+
+        logger.debug(
+            "Start writing to the %s endpoint (chunk size: %d)", target, chunk_size
+        )
+
+        with Client(auth=self.auth, headers=self.headers) as client:
+            for chunk in chunked(data, chunk_size):
+                request = client.post(target, content=chunk)
+                try:
+                    request.raise_for_status()
+                except HTTPError as error:
+                    msg = "Failed to post statements"
+                    logger.error("%s. %s", msg, error)
+                    raise BackendException(msg, *error.args) from error
+                statements_count += len(chunk)
+                logger.info("Posted %d statements", statements_count)
+
+        return statements_count
+
+    @staticmethod
+    def _parse_dict_to_bytes(
+        statements: Iterable[dict], ignore_errors: bool
+    ) -> Iterator[bytes]:
+        """Reads the `statements` Iterable and yields dictionaries."""
+        for statement in statements:
+            try:
+                yield bytes(json.dumps(statement), encoding="utf-8")
+            except TypeError as error:
+                msg = "Failed to encode JSON: %s, for document %s"
+                logger.error(msg, error, statement)
+                if ignore_errors:
+                    continue
+                raise BackendException(msg % (error, statement)) from error

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -134,7 +134,7 @@ class HeadersParametersParamType(CommaSeparatedKeyValueParamType):
     """Comma separated key=value parameter type for headers parameters."""
 
     def __init__(self, headers_parameters_type):
-        """Instantiates HeadersParametersParamType for a headers_paramters_type.
+        """Instantiates HeadersParametersParamType for a headers_parameters_type.
 
         Args:
             headers_parameters_type (any): Pydantic model used for headers parameters.

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -80,20 +80,6 @@ class InstantiableSettingsItem(BaseModel):
 # Active database backend Settings.
 
 
-class ClickhouseDatabaseBackendSettings(InstantiableSettingsItem):
-    """Pydantic model for ClickHouse database backend configuration settings."""
-
-    _class_path: str = "ralph.backends.database.clickhouse.ClickHouseDatabase"
-
-    HOST: str = "localhost"
-    PORT: int = 8123
-    DATABASE: str = "xapi"
-    EVENT_TABLE_NAME: str = "xapi_events_all"
-    USERNAME: str = None
-    PASSWORD: str = None
-    CLIENT_OPTIONS: dict = None
-
-
 class ClientOptions(BaseModel):
     """Pydantic model for additionnal client options."""
 
@@ -105,7 +91,7 @@ class ClickhouseClientOptions(ClientOptions):
     """Pydantic model for `clickhouse` client options."""
 
     date_time_input_format: str = "best_effort"
-    allow_experimental_object_type: Literal[0, 1] = 1
+    allow_experimental_object_type: Literal[0, 1] = None
 
 
 class ESClientOptions(ClientOptions):
@@ -113,6 +99,20 @@ class ESClientOptions(ClientOptions):
 
     ca_certs: Path = None
     verify_certs: bool = None
+
+
+class ClickhouseDatabaseBackendSettings(InstantiableSettingsItem):
+    """Pydantic model for ClickHouse database backend configuration settings."""
+
+    _class_path: str = "ralph.backends.database.clickhouse.ClickHouseDatabase"
+
+    HOST: str = "localhost"
+    PORT: int = 8123
+    DATABASE: str = "xapi"
+    EVENT_TABLE_NAME: str = "xapi_events_all"
+    USERNAME: str = None
+    PASSWORD: str = None
+    CLIENT_OPTIONS: ClickhouseClientOptions = None
 
 
 class MongoClientOptions(ClientOptions):

--- a/tests/backends/http/test_base.py
+++ b/tests/backends/http/test_base.py
@@ -1,0 +1,47 @@
+"""Tests for Ralph base HTTP backend."""
+
+from typing import Iterator, List, Union
+
+from ralph.backends.http.base import BaseHTTP, BaseQuery, OperationType
+
+
+def test_backends_http_base_abstract_interface_with_implemented_abstract_method():
+    """Tests the interface mechanism with properly implemented abstract methods."""
+
+    class GoodStorage(BaseHTTP):
+        """Correct implementation with required abstract methods."""
+
+        name = "good"
+
+        def status(self):
+            """Fakes the status method."""
+
+        def list(
+            self, target: str = None, details: bool = False, new: bool = False
+        ) -> Iterator[Union[str, dict]]:
+            """Fakes the list method."""
+
+        def read(  # pylint: disable=too-many-arguments
+            self,
+            query: Union[str, BaseQuery] = None,
+            target: str = None,
+            chunk_size: Union[None, int] = None,
+            raw_output: bool = False,
+            ignore_errors: bool = False,
+        ):
+            """Fakes the read method."""
+
+        def write(  # pylint: disable=too-many-arguments
+            self,
+            data: Union[List[bytes], List[dict]],
+            target: Union[None, str] = None,
+            chunk_size: Union[None, int] = 500,
+            ignore_errors: bool = False,
+            operation_type: Union[None, OperationType] = None,
+        ):
+            """Fakes the write method."""
+
+    GoodStorage()
+
+    assert GoodStorage.name == "good"
+    assert GoodStorage.query == BaseQuery

--- a/tests/backends/http/test_lrs.py
+++ b/tests/backends/http/test_lrs.py
@@ -1,0 +1,566 @@
+"""Tests for Ralph LRS HTTP backend."""
+
+import json
+import logging
+from urllib.parse import ParseResult, parse_qsl, urlencode, urljoin, urlparse
+from uuid import uuid4
+
+import pytest
+from httpx import HTTPStatusError, RequestError
+from pydantic import AnyHttpUrl
+from pytest_httpx import HTTPXMock
+
+from ralph.backends.http.base import HTTPBackendStatus
+from ralph.backends.http.lrs import LRSHTTP, LRSQuery, OperationType
+from ralph.conf import LRSHeaders
+from ralph.exceptions import BackendException, BackendParameterException
+
+
+def test_backends_http_lrs_http_instantiation():
+    """Test the LRS backend instantiation."""
+    assert LRSHTTP.name == "lrs"
+    assert LRSHTTP.query == LRSQuery
+
+    headers = LRSHeaders(
+        X_EXPERIENCE_API_VERSION="1.0.3", CONTENT_TYPE="application/json"
+    )
+    backend = LRSHTTP(
+        base_url="http://fake-lrs.com",
+        username="user",
+        password="pass",
+        headers=headers,
+        status_endpoint="/fake-status-endpoint",
+        statements_endpoint="/xAPI/statements",
+    )
+
+    assert isinstance(backend.base_url, AnyHttpUrl)
+    assert backend.auth == ("user", "pass")
+    assert backend.headers.CONTENT_TYPE == "application/json"
+    assert backend.headers.X_EXPERIENCE_API_VERSION == "1.0.3"
+    assert backend.status_endpoint == "/fake-status-endpoint"
+    assert backend.statements_endpoint == "/xAPI/statements"
+
+
+def test_backends_http_lrs_status_method_with_successful_request(httpx_mock: HTTPXMock):
+    """Tests the LRS backend status method returns `OK` when the request is
+    successful.
+    """
+    base_url = "http://fake-lrs.com"
+    status_endpoint = "/__heartbeat__"
+
+    backend = LRSHTTP(
+        base_url=base_url,
+        username="user",
+        password="pass",
+        status_endpoint=status_endpoint,
+    )
+
+    # Mock GET response of HTTPX
+    httpx_mock.add_response(
+        url=urljoin(base_url, status_endpoint), method="GET", status_code=200
+    )
+
+    status = backend.status()
+    assert status == HTTPBackendStatus.OK
+
+
+def test_backends_http_lrs_status_method_with_request_error(
+    httpx_mock: HTTPXMock, caplog
+):
+    """Tests the LRS backend status method returns `AWAY` when a `RequestError`
+    exception is caught.
+    """
+
+    base_url = "http://fake-lrs.com"
+    status_endpoint = "/__heartbeat__"
+
+    backend = LRSHTTP(
+        base_url=base_url,
+        username="user",
+        password="pass",
+        status_endpoint=status_endpoint,
+    )
+
+    httpx_mock.add_exception(RequestError("Test Request Error"))
+
+    status = backend.status()
+    assert (
+        "ralph.backends.http.lrs",
+        logging.ERROR,
+        "Unable to request the server",
+    ) in caplog.record_tuples
+    assert status == HTTPBackendStatus.AWAY
+
+
+def test_backends_http_lrs_status_method_with_http_status_error(
+    httpx_mock: HTTPXMock, caplog
+):
+    """Tests the LRS backend status method returns `ERROR` when an `HTTPStatusError`
+    is caught.
+    """
+
+    base_url = "http://fake-lrs.com"
+    status_endpoint = "/__heartbeat__"
+
+    backend = LRSHTTP(
+        base_url=base_url,
+        username="user",
+        password="pass",
+        status_endpoint=status_endpoint,
+    )
+
+    httpx_mock.add_exception(
+        HTTPStatusError("Test HTTP Status Error", request=None, response=None)
+    )
+
+    status = backend.status()
+    assert (
+        "ralph.backends.http.lrs",
+        logging.ERROR,
+        "Response raised an HTTP status of 4xx or 5xx",
+    ) in caplog.record_tuples
+    assert status == HTTPBackendStatus.ERROR
+
+
+def test_backends_http_lrs_list_method():
+    "Test the LRS backend `list` method raises a `NotImplementedError`."
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    msg = (
+        "LRS HTTP backend does not support `list` method, "
+        "cannot list from /xAPI/statements/"
+    )
+    with pytest.raises(NotImplementedError, match=msg):
+        backend.list(target=target)
+
+
+def test_backends_http_lrs_read_method_without_target(httpx_mock: HTTPXMock):
+    """Tests the LRS backend `read` method without target parameter value fetches
+    statements from '/xAPI/statements' default endpoint.
+    """
+
+    base_url = "http://fake-lrs.com"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    statements = {
+        "statements": [
+            {"id": str(uuid4()), "timestamp": "2022-06-22T08:31:38"},
+            {"id": str(uuid4()), "timestamp": "2022-07-22T08:31:38"},
+            {"id": str(uuid4()), "timestamp": "2022-08-22T08:31:38"},
+        ]
+    }
+
+    # Mock HTTPX GET
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=backend.statements_endpoint,
+            query=urlencode({"limit": 500}),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=statements,
+    )
+
+    result = list(backend.read())
+    assert result == statements["statements"]
+    assert len(result) == 3
+
+
+def test_backends_http_lrs_read_method_backend_error(httpx_mock: HTTPXMock):
+    """Test the LRS backend `read` method raises a `BackendException` when the server
+    returns an error.
+    """
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    # Mock GET response of HTTPX
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=target,
+            query=urlencode({"limit": 500}),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        status_code=500,
+    )
+
+    with pytest.raises(BackendException, match="Failed to fetch statements."):
+        list(backend.read(target=target))
+
+
+def test_backends_http_lrs_read_method_without_pagination(httpx_mock: HTTPXMock):
+    """Test the LRS backend `read` method when the request on the target endpoint
+    returns statements without pagination."""
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    statements = {
+        "statements": [
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/played"},
+                "timestamp": "2022-06-22T08:31:38",
+            },
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/played"},
+                "timestamp": "2022-07-22T08:31:38",
+            },
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/paused"},
+                "timestamp": "2022-08-22T08:31:38",
+            },
+        ]
+    }
+
+    # Mock GET response of HTTPX without query parameter
+    params = {"limit": 500}
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=target,
+            query=urlencode(params),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=statements,
+    )
+
+    # Return an iterable of dict
+    result = list(backend.read(target=target, raw_output=False))
+    assert result == statements["statements"]
+    assert len(result) == 3
+
+    # Return an iterable of bytes
+    result = list(backend.read(target=target, raw_output=True))
+    assert result == [
+        bytes(json.dumps(statement), encoding="utf-8")
+        for statement in statements["statements"]
+    ]
+    assert len(result) == 3
+
+    # Mock GET response of HTTPX with query parameter
+    query = LRSQuery(query={"verb": "https://w3id.org/xapi/video/verbs/played"})
+
+    statements_with_query_played_verb = {
+        "statements": [
+            raw for raw in statements["statements"] if "played" in raw["verb"]["id"]
+        ]
+    }
+
+    params.update(query.query)
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=target,
+            query=urlencode(params),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=statements_with_query_played_verb,
+    )
+    # Return an iterable of dict
+    result = list(backend.read(query=query, target=target, raw_output=False))
+    assert result == statements_with_query_played_verb["statements"]
+    assert len(result) == 2
+
+    # Return an iterable of bytes
+    result = list(backend.read(query=query, target=target, raw_output=True))
+    assert result == [
+        bytes(json.dumps(statement), encoding="utf-8")
+        for statement in statements_with_query_played_verb["statements"]
+    ]
+    assert len(result) == 2
+
+
+def test_backends_http_lrs_read_method_with_pagination(httpx_mock: HTTPXMock):
+    """Test the LRS backend `read` method when the request on the target endpoint
+    returns statements with pagination."""
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    more_target = "/xAPI/statements/?pit_id=fake-pit-id"
+    statements = {
+        "statements": [
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/played"},
+                "timestamp": "2022-06-22T08:31:38",
+            },
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/initialized"},
+                "timestamp": "2022-07-22T08:31:38",
+            },
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/paused"},
+                "timestamp": "2022-08-22T08:31:38",
+            },
+        ],
+        "more": more_target,
+    }
+    more_statements = {
+        "statements": [
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/seeked"},
+                "timestamp": "2022-09-22T08:31:38",
+            },
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/played"},
+                "timestamp": "2022-10-22T08:31:38",
+            },
+            {
+                "id": str(uuid4()),
+                "verb": {"id": "https://w3id.org/xapi/video/verbs/paused"},
+                "timestamp": "2022-11-22T08:31:38",
+            },
+        ]
+    }
+
+    # Mock GET response of HTTPX for target and "more" target without query parameter
+    params = {"limit": 500}
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=target,
+            query=urlencode(params),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=statements,
+    )
+    params.update(dict(parse_qsl(urlparse(more_target).query)))
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=urlparse(more_target).path,
+            query=urlencode(params),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=more_statements,
+    )
+
+    # Return an iterable of dict
+    result = list(backend.read(target=target, raw_output=False))
+    assert result == statements["statements"] + more_statements["statements"]
+    assert len(result) == 6
+
+    # Return an iterable of bytes
+    result = list(backend.read(target=target, raw_output=True))
+    assert result == [
+        bytes(json.dumps(statement), encoding="utf-8")
+        for statement in statements["statements"] + more_statements["statements"]
+    ]
+    assert len(result) == 6
+
+    # Mock GET response of HTTPX with query parameter
+    query_params = LRSQuery(query={"verb": "https://w3id.org/xapi/video/verbs/played"})
+
+    statements_with_query_played_verb = {
+        "statements": [
+            raw for raw in statements["statements"] if "played" in raw["verb"]["id"]
+        ],
+        "more": more_target,
+    }
+    more_statements_with_query_played_verb = {
+        "statements": [
+            raw
+            for raw in more_statements["statements"]
+            if "played" in raw["verb"]["id"]
+        ]
+    }
+    params = {"limit": 500}
+    params.update(query_params.query)
+
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=target,
+            query=urlencode(params),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=statements_with_query_played_verb,
+    )
+    params.update(dict(parse_qsl(urlparse(more_target).query)))
+
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=urlparse(more_target).path,
+            query=urlencode(params),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=more_statements_with_query_played_verb,
+    )
+
+    # Return an iterable of dict
+    result = list(backend.read(query=query_params, target=target, raw_output=False))
+    assert (
+        result
+        == statements_with_query_played_verb["statements"]
+        + more_statements_with_query_played_verb["statements"]
+    )
+    assert len(result) == 2
+
+    # Return an iterable of bytes
+    result = list(backend.read(query=query_params, target=target, raw_output=True))
+
+    assert result == [
+        bytes(json.dumps(statement), encoding="utf-8")
+        for statement in statements_with_query_played_verb["statements"]
+        + more_statements_with_query_played_verb["statements"]
+    ]
+    assert len(result) == 2
+
+
+def test_backends_http_lrs_write_method_without_operation(httpx_mock: HTTPXMock):
+    """Tests the LRS backend `write` method, given no operation_type should POST to
+    the LRS server.
+    """
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    data = [
+        {"id": str(uuid4()), "timestamp": "2022-06-22T08:31:38"},
+        {"id": str(uuid4()), "timestamp": "2022-07-22T08:31:38"},
+        {"id": str(uuid4()), "timestamp": "2022-08-22T08:31:38"},
+    ]
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    # Mock HTTPX POST
+    httpx_mock.add_response(url=urljoin(base_url, target), method="POST", json=data)
+
+    result = backend.write(target=target, data=data)
+    assert result == len(data)
+
+
+def test_backends_http_lrs_write_method_without_data():
+    """Tests the LRS backend `write` method returns null when no data to write
+    in the target endpoint are given.
+    """
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    result = backend.write(target=target, data=[])
+    assert result == 0
+
+
+@pytest.mark.parametrize(
+    "operation_type,error_msg",
+    [
+        (OperationType.APPEND, "append operation type is not supported."),
+        (OperationType.UPDATE, "update operation type is not supported."),
+        (OperationType.DELETE, "delete operation type is not supported."),
+    ],
+)
+def test_backends_http_lrs_write_method_with_unsupported_operation(
+    operation_type, error_msg
+):
+    """Tests the LRS backend `write` method, given an unsupported` `operation_type`,
+    should raise a `BackendParameterException`.
+    """
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements/"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    with pytest.raises(BackendParameterException, match=error_msg):
+        backend.write(target=target, data=[b"foo"], operation_type=operation_type)
+
+
+def test_backends_http_lrs_write_method_without_target(httpx_mock: HTTPXMock):
+    """Tests the LRS backend `write` method without target parameter value writes
+    statements to '/xAPI/statements' default endpoint."""
+
+    base_url = "http://fake-lrs.com"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    data = [
+        {"id": str(uuid4()), "timestamp": "2022-06-22T08:31:38"},
+        {"id": str(uuid4()), "timestamp": "2022-07-22T08:31:38"},
+        {"id": str(uuid4()), "timestamp": "2022-08-22T08:31:38"},
+    ]
+
+    # Mock HTTPX POST
+    httpx_mock.add_response(
+        url=urljoin(base_url, backend.statements_endpoint), method="POST", json=data
+    )
+
+    result = backend.write(data=data, operation_type=OperationType.CREATE)
+    assert result == len(data)
+
+
+def test_backends_http_lrs_write_method_with_create_or_index_operation(
+    httpx_mock: HTTPXMock,
+):
+    """Tests the `LRSHTTP.write` method with `CREATE` or `INDEX` operation_type writes
+    statements to the given target endpoint.
+    """
+
+    base_url = "http://fake-lrs.com"
+    target = "/xAPI/statements"
+
+    backend = LRSHTTP(base_url=base_url, username="user", password="pass")
+
+    data = [
+        {"id": str(uuid4()), "timestamp": "2022-06-22T08:31:38"},
+        {"id": str(uuid4()), "timestamp": "2022-07-22T08:31:38"},
+        {"id": str(uuid4()), "timestamp": "2022-08-22T08:31:38"},
+    ]
+
+    # Mock HTTPX POST
+    httpx_mock.add_response(url=urljoin(base_url, target), method="POST", json=data)
+
+    result = backend.write(
+        target=target, data=data, operation_type=OperationType.CREATE
+    )
+    assert result == len(data)
+
+    result = backend.write(target=target, data=data, operation_type=OperationType.INDEX)
+    assert result == len(data)

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -60,6 +60,7 @@ ES_TEST_HOSTS = os.environ.get(
     "RALPH_BACKENDS__DATABASE__ES__TEST_HOSTS", "http://localhost:9200"
 ).split(",")
 
+# Mongo backend defaults
 MONGO_TEST_COLLECTION = os.environ.get(
     "RALPH_BACKENDS__DATABASE__MONGO__TEST_COLLECTION", "marsha"
 )

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -27,7 +27,7 @@ from ralph.backends.database.es import ESDatabase
 from ralph.backends.database.mongo import MongoDatabase
 from ralph.backends.storage.s3 import S3Storage
 from ralph.backends.storage.swift import SwiftStorage
-from ralph.conf import Settings, settings
+from ralph.conf import ClickhouseClientOptions, Settings, settings
 
 # ClickHouse backend defaults
 CLICKHOUSE_TEST_DATABASE = os.environ.get(
@@ -203,10 +203,10 @@ def get_clickhouse_fixture(
     """Creates / deletes a ClickHouse test database + table and yields an
     instantiated client.
     """
-    client_options = {
-        "date_time_input_format": "best_effort",  # Allows RFC dates
-        "allow_experimental_object_type": 1,  # Allows JSON data type
-    }
+    client_options = ClickhouseClientOptions(
+        date_time_input_format="best_effort",  # Allows RFC dates
+        allow_experimental_object_type=1,  # Allows JSON data type
+    ).dict()
 
     client = clickhouse_connect.get_client(
         host=host,

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -105,7 +105,7 @@ def test_cli_fetch_command_usage():
     assert result.exit_code == 0
     assert (
         "Options:\n"
-        "  -b, --backend [es|mongo|clickhouse|ldp|fs|swift|s3|ws]\n"
+        "  -b, --backend [es|mongo|clickhouse|lrs|ldp|fs|swift|s3|ws]\n"
         "                                  Backend  [required]\n"
         "  ws backend: \n"
         "    --ws-uri TEXT\n"
@@ -136,6 +136,13 @@ def test_cli_fetch_command_usage():
         "    --ldp-application-secret TEXT\n"
         "    --ldp-application-key TEXT\n"
         "    --ldp-endpoint TEXT\n"
+        "  lrs backend: \n"
+        "    --lrs-statements-endpoint TEXT\n"
+        "    --lrs-status-endpoint TEXT\n"
+        "    --lrs-headers KEY=VALUE,KEY=VALUE\n"
+        "    --lrs-password TEXT\n"
+        "    --lrs-username TEXT\n"
+        "    --lrs-base-url TEXT\n"
         "  clickhouse backend: \n"
         "    --clickhouse-client-options KEY=VALUE,KEY=VALUE\n"
         "    --clickhouse-password TEXT\n"
@@ -155,6 +162,8 @@ def test_cli_fetch_command_usage():
         "    --es-index TEXT\n"
         "    --es-hosts VALUE1,VALUE2,VALUE3\n"
         "  -c, --chunk-size INTEGER        Get events by chunks of size #\n"
+        "  -t, --target TEXT               Endpoint from which to fetch events (e.g.\n"
+        "                                  `/statements`)\n"
         '  -q, --query \'{"KEY": "VALUE", "KEY": "VALUE"}\'\n'
         "                                  Query object as a JSON string (database\n"
         "                                  backends ONLY)\n"
@@ -164,8 +173,8 @@ def test_cli_fetch_command_usage():
     assert result.exit_code > 0
     assert (
         "Error: Missing option '-b' / '--backend'. "
-        "Choose from:\n\tes,\n\tmongo,\n\tclickhouse,\n\tldp,\n\tfs,\n\tswift,\n\ts3,"
-        "\n\tws\n"
+        "Choose from:\n\tes,\n\tmongo,\n\tclickhouse,\n\tlrs,\n\tldp,\n\tfs,\n\tswift,"
+        "\n\ts3,\n\tws\n"
     ) in result.output
 
 


### PR DESCRIPTION
## Purpose

In FUN perspective, we want to use our LRS in `warren` backend and intends to
make available `warren` for every one. Hence it should not directly depend on
the FUN made LRS. 

## Proposal

In the perspective of having a generic call to any LRS in data application, we
propose the implementation in the backends stack of `ralph` a new instance of
backend: the LRS one. It will allow anyone to be able to use any LRS in one's
application

Implementation to do list: 
- [x] add http base backend
- [x] test http base backend
- [x] add lrs backend (get, post methods)
- [x] test lrs backend
- [x] add development settings
- [x] update cli commands
- [x] update CI configuration
- [x] update documentation for `ralph`
- [x] update CHANGELOG.md
