### PR TITLE
👽️(backends) fix double quoting in ClickHouse backend server parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 ### Fixed
 
 - An issue with starting Ralph in pre-built Docker containers
+- Fix double quoting in ClickHouse backend server parameters
 
 ## [3.5.0] - 2023-03-08
 

--- a/src/ralph/backends/database/clickhouse.py
+++ b/src/ralph/backends/database/clickhouse.py
@@ -224,7 +224,6 @@ class ClickHouseDatabase(BaseDatabase):
 
     def query_statements_by_ids(self, ids: List[str]) -> List:
         """Returns the list of matching statement IDs from the database."""
-        ids = [f"'{id}'" for id in ids]
 
         def chunk_id_list(chunk_size=10000):
             for i in range(0, len(ids), chunk_size):

--- a/tests/models/test_converter.py
+++ b/tests/models/test_converter.py
@@ -372,7 +372,7 @@ def test_converter_convert_with_invalid_page_close_event_raises_an_exception(
             list(result)
 
 
-@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 @pytest.mark.parametrize("invalid_platform_url", ["", "not an URL"])
 @custom_given(UIPageClose)


### PR DESCRIPTION
## Purpose

In the current `clickhouse-connect` release (0.5.19) (see [CHANGELOG](https://github.com/ClickHouse/clickhouse-connect/blob/main/CHANGELOG.md#bug-fixes)), the quoting and escaping of array literals in server parameters is handled internally. Thus, we do not need to add quotes on our side.

## Proposal

- [x] remove quoting of `ids` in ClickHouse backend

