### PR TITLE
🐛(backends) fix startup hang when ClickHouse is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- An issue Ralph starting when ClickHouse is down
+
 ### Changed
 
 - Upgrade `httpx` to `0.24.0`


### PR DESCRIPTION
## Purpose

During Ralph startup, when ClickHouse was not running Ralph would fail to connect and hang, never recovering. This change allows Ralph to start even without ClickHouse running and connect whenever it can.
