### PR TITLE
🔖(patch) bump release to 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Fixed
-
-- An issue Ralph starting when ClickHouse is down
+## [3.5.1] - 2023-04-18
 
 ### Changed
 
@@ -23,6 +21,7 @@ and this project adheres to
 
 - An issue with starting Ralph in pre-built Docker containers
 - Fix double quoting in ClickHouse backend server parameters
+- An issue Ralph starting when ClickHouse is down
 
 ## [3.5.0] - 2023-03-08
 
@@ -276,7 +275,8 @@ and this project adheres to
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.5.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.5.1...master
+[3.5.1]: https://github.com/openfun/ralph/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/openfun/ralph/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/openfun/ralph/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/openfun/ralph/compare/v3.2.1...v3.3.0

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,5 +1,5 @@
 metadata:
   name: ralph
-  version: 3.5.0
+  version: 3.5.1
 source:
   path: src/tray

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.5.0
+version = 3.5.1
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5.0"
+appVersion: "3.5.1"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.5.0
+  version: 3.5.1


### PR DESCRIPTION
### Changed:

- Upgrade `httpx` to `0.24.0`
- Upgrade `fastapi` to `0.95.1`
- Upgrade `sentry_sdk` to `1.19.1`
- Upgrade `uvicorn` to `0.21.1`

### Fixed:

- An issue with starting Ralph in pre-built Docker containers
- Fix double quoting in ClickHouse backend server parameters
- An issue Ralph starting when ClickHouse is down