### PR TITLE
(backends) Unify data backends clickhouse

### DIFF
--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -1,0 +1,473 @@
+"""ClickHouse data backend for Ralph."""
+
+import json
+import logging
+from datetime import datetime
+from io import IOBase
+from itertools import chain
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Union,
+)
+from uuid import UUID, uuid4
+
+import clickhouse_connect
+from clickhouse_connect.driver.exceptions import ClickHouseError
+from pydantic import BaseModel, Json, ValidationError
+
+from ralph.backends.data.base import (
+    BaseDataBackend,
+    BaseDataBackendSettings,
+    BaseOperationType,
+    BaseQuery,
+    DataBackendStatus,
+    enforce_query_checks,
+)
+from ralph.conf import BaseSettingsConfig, ClientOptions
+from ralph.exceptions import BackendException, BackendParameterException
+
+logger = logging.getLogger(__name__)
+
+
+class ClickHouseInsert(BaseModel):
+    """Model to validate required fields for ClickHouse insertion."""
+
+    event_id: UUID
+    emission_time: datetime
+
+
+class ClickHouseClientOptions(ClientOptions):
+    """Pydantic model for `clickhouse` client options."""
+
+    date_time_input_format: str = "best_effort"
+    allow_experimental_object_type: Literal[0, 1] = 1
+
+
+class InsertTuple(NamedTuple):
+    """Named tuple for ClickHouse insertion."""
+
+    event_id: UUID
+    emission_time: datetime
+    event: dict
+    event_str: str
+
+
+class ClickHouseDataBackendSettings(BaseDataBackendSettings):
+    """Represent the ClickHouse data backend default configuration.
+
+    Attributes:
+        HOST (str): ClickHouse server host to connect to.
+        PORT (int): ClickHouse server port to connect to.
+        DATABASE (str): ClickHouse database to connect to.
+        EVENT_TABLE_NAME (str): Table where events live.
+        USERNAME (str): ClickHouse username to connect as (optional).
+        PASSWORD (str): Password for the given ClickHouse username (optional).
+        CLIENT_OPTIONS (ClickHouseClientOptions): A dictionary of valid options for the
+            ClickHouse client connection.
+        DEFAULT_CHUNK_SIZE (int): The default chunk size for reading/writing.
+        LOCALE_ENCODING (str): The locale encoding to use when none is provided.
+    """
+
+    class Config(BaseSettingsConfig):
+        """Pydantic Configuration."""
+
+        env_prefix = "RALPH_BACKENDS__DATA__CLICKHOUSE__"
+
+    HOST: str = "localhost"
+    PORT: int = 8123
+    DATABASE: str = "xapi"
+    EVENT_TABLE_NAME: str = "xapi_events_all"
+    USERNAME: str = None
+    PASSWORD: str = None
+    CLIENT_OPTIONS: ClickHouseClientOptions = ClickHouseClientOptions()
+    DEFAULT_CHUNK_SIZE: int = 500
+    LOCALE_ENCODING: str = "utf8"
+
+
+class BaseClickHouseQuery(BaseQuery):
+    """Base ClickHouse query model."""
+
+    select: Union[str, List[str]] = "event"
+    where: Optional[Union[str, List[str]]]
+    parameters: Optional[Dict]
+    limit: Optional[int]
+    sort: Optional[str]
+    column_oriented: Optional[bool] = False
+
+
+class ClickHouseQuery(BaseClickHouseQuery):
+    """ClickHouse query model."""
+
+    # pylint: disable=unsubscriptable-object
+    query_string: Optional[Json[BaseClickHouseQuery]]
+
+
+class ClickHouseDataBackend(BaseDataBackend):
+    """ClickHouse database backend."""
+
+    name = "clickhouse"
+    query_model = ClickHouseQuery
+    default_operation_type = BaseOperationType.CREATE
+    settings_class = ClickHouseDataBackendSettings
+
+    def __init__(self, settings: settings_class = None):
+        """Instantiate the ClickHouse configuration.
+
+        Args:
+            settings (ClickHouseDataBackendSettings or None): The ClickHouse
+                data backend settings.
+        """
+        self.settings = settings if settings else self.settings_class()
+        self.database = self.settings.DATABASE
+        self.event_table_name = self.settings.EVENT_TABLE_NAME
+        self.default_chunk_size = self.settings.DEFAULT_CHUNK_SIZE
+        self.locale_encoding = self.settings.LOCALE_ENCODING
+        self._client = None
+
+    @property
+    def client(self):
+        """Create a ClickHouse client if it doesn't exist.
+
+        We do this here so that we don't interrupt initialization in the case
+        where ClickHouse is not running when Ralph starts up, which will cause
+        Ralph to hang. This client is HTTP, so not actually stateful. Ralph
+        should be able to gracefully deal with ClickHouse outages at all other
+        times.
+        """
+        if not self._client:
+            self._client = clickhouse_connect.get_client(
+                host=self.settings.HOST,
+                port=self.settings.PORT,
+                database=self.database,
+                username=self.settings.USERNAME,
+                password=self.settings.PASSWORD,
+                settings=self.settings.CLIENT_OPTIONS.dict(),
+            )
+        return self._client
+
+    def status(self) -> DataBackendStatus:
+        """Check ClickHouse connection status.
+
+        Return:
+            DataBackendStatus: The status of the data backend.
+        """
+        try:
+            self.client.query("SELECT 1")
+        except ClickHouseError:
+            return DataBackendStatus.AWAY
+
+        return DataBackendStatus.OK
+
+    def list(
+        self, target: str = None, details: bool = False, new: bool = False
+    ) -> Iterator[Union[str, dict]]:
+        """List tables for a given database.
+
+        Args:
+            target (str): The database name to list tables from.
+            details (bool): Get detailed table information instead of just ids.
+            new (bool): Given the history, list only not already fetched archives.
+
+        Yield:
+            str: The next table name. (If `details` is False).
+            dict: The next table name. (If `details` is True).
+
+        Raise:
+            BackendException: If a failure during table names retrieval occurs.
+        """
+        sql = f"SHOW TABLES FROM {target if target else self.database}"
+
+        try:
+            tables = self.client.query(sql).named_results()
+        except (ClickHouseError, IndexError, TypeError, ValueError) as error:
+            msg = "Failed to read tables: %s"
+            logger.error(msg, error)
+            raise BackendException(msg % error) from error
+
+        for table in tables:
+            if details:
+                yield table
+            else:
+                yield str(table.get("name"))
+
+    @enforce_query_checks
+    def read(
+        self,
+        *,
+        query: Union[str, ClickHouseQuery] = None,
+        target: str = None,
+        chunk_size: Union[None, int] = None,
+        raw_output: bool = False,
+        ignore_errors: bool = False,
+    ) -> Iterator[Union[bytes, dict]]:
+        """Read documents matching the query in the target table and yield them.
+
+        Args:
+            query (str or ClickHouseQuery): The query to use when fetching documents.
+            target (str or None): The target table name to query.
+                If target is `None`, the `event_table_name` is used instead.
+            chunk_size (int or None): The chunk size for reading batches of documents.
+                If chunk_size is `None` it defaults to `default_chunk_size`.
+            raw_output (bool): Controls whether to yield dictionaries or bytes.
+            ignore_errors (bool): If `True`, errors during the encoding operation
+                will be ignored and logged. If `False` (default), a `BackendException`
+                will be raised if an error occurs.
+
+        Yield:
+            bytes: The next raw document if `raw_output` is True.
+            dict: The next JSON parsed document if `raw_output` is False.
+
+        Raise:
+            BackendException: If a failure occurs during ClickHouse connection.
+        """
+        if target is None:
+            target = self.event_table_name
+
+        if chunk_size is None:
+            chunk_size = self.default_chunk_size
+
+        query = (
+            BaseClickHouseQuery(query.query_string)
+            if query.query_string
+            else query.copy(exclude={"query_string"})
+        )
+
+        if isinstance(query.select, str):
+            query.select = [query.select]
+        select = ",".join(query.select)
+        sql = f"SELECT {select} FROM {target}"  # nosec
+
+        if query.where:
+            if isinstance(query.where, str):
+                query.where = [query.where]
+            filter_str = "\nWHERE 1=1 AND "
+            filter_str += """
+            AND
+            """.join(
+                query.where
+            )
+            sql += filter_str
+
+        if query.sort:
+            sql += f"\nORDER BY {query.sort}"
+
+        if query.limit:
+            sql += f"\nLIMIT {query.limit}"
+
+        reader = self._read_raw if raw_output else lambda _: _
+
+        logger.debug(
+            "Start reading the %s table of the %s database (chunk size: %d)",
+            target,
+            self.database,
+            chunk_size,
+        )
+        try:
+            result = self.client.query(
+                sql,
+                parameters=query.parameters,
+                settings={"buffer_size": chunk_size},
+                column_oriented=query.column_oriented,
+            ).named_results()
+            for statement in result:
+                try:
+                    yield reader(statement)
+                except (TypeError, ValueError) as error:
+                    msg = "Failed to encode document %s: %s"
+                    if ignore_errors:
+                        logger.warning(msg, statement, error)
+                        continue
+                    logger.error(msg, statement, error)
+                    raise BackendException(msg % (statement, error)) from error
+        except (ClickHouseError, IndexError, TypeError, ValueError) as error:
+            msg = "Failed to read documents: %s"
+            logger.error(msg, error)
+            raise BackendException(msg % error) from error
+
+    def write(  # pylint: disable=too-many-arguments
+        self,
+        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
+        target: Union[None, str] = None,
+        chunk_size: Union[None, int] = None,
+        ignore_errors: bool = False,
+        operation_type: Union[None, BaseOperationType] = None,
+    ) -> int:
+        """Write `data` documents to the `target` table and return their count.
+
+        Args:
+            data: (Iterable or IOBase): The data containing documents to write.
+            target (str or None): The target table name.
+                If target is `None`, the `event_table_name` is used instead.
+            chunk_size (int or None): The number of documents to write in one batch.
+                If `chunk_size` is `None` it defaults to `default_chunk_size`.
+            ignore_errors (bool): If `True`, errors during the write operation
+                will be ignored and logged. If `False` (default), a `BackendException`
+                will be raised if an error occurs.
+            operation_type (BaseOperationType or None): The mode of the write operation.
+                If `operation_type` is `None`, the `default_operation_type` is used
+                instead. See `BaseOperationType`.
+
+        Return:
+            int: The number of written documents.
+
+        Raise:
+            BackendException: If a failure occurs while writing to ClickHouse or
+                during document decoding and `ignore_errors` is set to `False`.
+            BackendParameterException: If the `operation_type` is `APPEND`, `UPDATE`
+                or `DELETE` as it is not supported.
+        """
+        target = target if target else self.event_table_name
+        if not operation_type:
+            operation_type = self.default_operation_type
+        if not chunk_size:
+            chunk_size = self.default_chunk_size
+        logger.debug(
+            "Start writing to the %s table of the %s database (chunk size: %d)",
+            target,
+            self.database,
+            chunk_size,
+        )
+
+        data = iter(data)
+        try:
+            first_record = next(data)
+        except StopIteration:
+            logger.info("Data Iterator is empty; skipping write to target.")
+            return 0
+
+        data = chain([first_record], data)
+        if isinstance(first_record, bytes):
+            data = self._parse_bytes_to_dict(data, ignore_errors)
+
+        if operation_type not in [BaseOperationType.CREATE, BaseOperationType.INDEX]:
+            msg = "%s operation_type is not allowed."
+            logger.error(msg, operation_type.name)
+            raise BackendParameterException(msg % operation_type.name)
+
+        # operation_type is either CREATE or INDEX
+        count = 0
+        batch = []
+
+        for insert_tuple in self._to_insert_tuples(
+            data,
+            ignore_errors=ignore_errors,
+        ):
+            batch.append(insert_tuple)
+            if len(batch) < chunk_size:
+                continue
+
+            count += self._bulk_import(
+                batch,
+                ignore_errors=ignore_errors,
+                event_table_name=target,
+            )
+            batch = []
+
+        # Edge case: if the total number of documents is lower than the chunk size
+        if len(batch) > 0:
+            count += self._bulk_import(
+                batch,
+                ignore_errors=ignore_errors,
+                event_table_name=target,
+            )
+
+        logger.info("Inserted a total of %d documents with success", count)
+
+        return count
+
+    @staticmethod
+    def _to_insert_tuples(
+        data: Iterable[dict],
+        ignore_errors: bool = False,
+    ) -> Generator[InsertTuple, None, None]:
+        """Convert `data` dictionaries to insert tuples."""
+        for statement in data:
+            try:
+                insert = ClickHouseInsert(
+                    event_id=statement.get("id", str(uuid4())),
+                    emission_time=statement["timestamp"],
+                )
+            except (KeyError, ValidationError) as error:
+                msg = "Statement %s has an invalid 'id' or 'timestamp' field"
+                if ignore_errors:
+                    logger.warning(msg, statement)
+                    continue
+                logger.error(msg, statement)
+                raise BackendException(msg % statement) from error
+
+            insert_tuple = InsertTuple(
+                insert.event_id,
+                insert.emission_time,
+                statement,
+                json.dumps(statement),
+            )
+
+            yield insert_tuple
+
+    def _bulk_import(
+        self, batch: list, ignore_errors: bool = False, event_table_name: str = None
+    ):
+        """Insert a batch of documents into the selected database table."""
+        try:
+            found_ids = {document.event_id for document in batch}
+
+            if len(found_ids) != len(batch):
+                raise BackendException("Duplicate IDs found in batch")
+
+            self.client.insert(
+                event_table_name,
+                batch,
+                column_names=[
+                    "event_id",
+                    "emission_time",
+                    "event",
+                    "event_str",
+                ],
+                # Allow ClickHouse to buffer the insert, and wait for the
+                # buffer to flush. Should be configurable, but I think these are
+                # reasonable defaults.
+                settings={"async_insert": 1, "wait_for_async_insert": 1},
+            )
+        except (ClickHouseError, BackendException) as error:
+            if not ignore_errors:
+                raise BackendException(*error.args) from error
+            logger.warning(
+                "Bulk import failed for current chunk but you choose to ignore it.",
+            )
+            # There is no current way of knowing how many rows from the batch
+            # succeeded, we assume 0 here.
+            return 0
+
+        inserted_count = len(batch)
+        logger.debug("Inserted %d documents chunk with success", inserted_count)
+
+        return inserted_count
+
+    @staticmethod
+    def _parse_bytes_to_dict(
+        raw_documents: Iterable[bytes], ignore_errors: bool
+    ) -> Iterator[dict]:
+        """Read the `raw_documents` Iterable and yield dictionaries."""
+        for raw_document in raw_documents:
+            try:
+                yield json.loads(raw_document)
+            except (TypeError, json.JSONDecodeError) as error:
+                if ignore_errors:
+                    logger.warning(
+                        "Raised error: %s, for document %s", error, raw_document
+                    )
+                    continue
+                logger.error("Raised error: %s, for document %s", error, raw_document)
+                raise error
+
+    def _read_raw(self, document: Dict[str, Any]) -> bytes:
+        """Read the `documents` Iterable and yield bytes."""
+        return json.dumps(document).encode(self.locale_encoding)

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -1,0 +1,177 @@
+"""ClickHouse LRS backend for Ralph."""
+
+import logging
+from typing import Iterator, List
+
+from ralph.backends.data.clickhouse import (
+    ClickHouseDataBackend,
+    ClickHouseDataBackendSettings,
+)
+from ralph.backends.lrs.base import (
+    AgentParameters,
+    BaseLRSBackend,
+    BaseLRSBackendSettings,
+    StatementParameters,
+    StatementQueryResult,
+)
+from ralph.exceptions import BackendException, BackendParameterException
+
+logger = logging.getLogger(__name__)
+
+
+class ClickHouseLRSBackendSettings(
+    BaseLRSBackendSettings, ClickHouseDataBackendSettings
+):
+    """Represent the ClickHouse data backend default configuration.
+
+    Attributes:
+        IDS_CHUNK_SIZE (int): The chunk size for querying by ids.
+    """
+
+    IDS_CHUNK_SIZE: int = 10000
+
+
+class ClickHouseLRSBackend(BaseLRSBackend, ClickHouseDataBackend):
+    """ClickHouse LRS backend implementation."""
+
+    settings_class = ClickHouseLRSBackendSettings
+
+    def query_statements(self, params: StatementParameters) -> StatementQueryResult:
+        """Return the statements query payload using xAPI parameters."""
+        ch_params = params.dict(exclude_none=True)
+        where = []
+
+        if params.statementId:
+            where.append("event_id = {statementId:UUID}")
+
+        self._add_agent_filters(ch_params, where, params.agent, "actor")
+        ch_params.pop("agent", None)
+
+        self._add_agent_filters(ch_params, where, params.authority, "authority")
+        ch_params.pop("authority", None)
+
+        if params.verb:
+            where.append("event.verb.id = {verb:String}")
+
+        if params.activity:
+            where.append("event.object.objectType = 'Activity'")
+            where.append("event.object.id = {activity:String}")
+
+        if params.since:
+            where.append("emission_time > {since:DateTime64(6)}")
+
+        if params.until:
+            where.append("emission_time <= {until:DateTime64(6)}")
+
+        if params.search_after:
+            search_order = ">" if params.ascending else "<"
+
+            where.append(
+                f"(emission_time {search_order} "
+                "{search_after:DateTime64(6)}"
+                " OR "
+                "(emission_time = {search_after:DateTime64(6)}"
+                " AND "
+                f"event_id {search_order} "
+                "{pit_id:UUID}"
+                "))"
+            )
+
+        sort_order = "ASCENDING" if params.ascending else "DESCENDING"
+        order_by = f"emission_time {sort_order}, event_id {sort_order}"
+
+        query = {
+            "select": ["event_id", "emission_time", "event"],
+            "where": where,
+            "parameters": ch_params,
+            "limit": params.limit,
+            "sort": order_by,
+        }
+        try:
+            clickhouse_response = list(
+                self.read(
+                    query=query,
+                    target=self.event_table_name,
+                    ignore_errors=True,
+                )
+            )
+        except (BackendException, BackendParameterException) as error:
+            logger.error("Failed to read from ClickHouse")
+            raise error
+
+        new_search_after = None
+        new_pit_id = None
+
+        if clickhouse_response:
+            # Our search after string is a combination of event timestamp and
+            # event id, so that we can avoid losing events when they have the
+            # same timestamp, and also avoid sending the same event twice.
+            new_search_after = clickhouse_response[-1]["emission_time"].isoformat()
+            new_pit_id = str(clickhouse_response[-1]["event_id"])
+
+        return StatementQueryResult(
+            statements=[document["event"] for document in clickhouse_response],
+            search_after=new_search_after,
+            pit_id=new_pit_id,
+        )
+
+    def query_statements_by_ids(self, ids: List[str]) -> Iterator[dict]:
+        """Yield statements with matching ids from the backend."""
+
+        def chunk_id_list(chunk_size=self.settings.IDS_CHUNK_SIZE):
+            for i in range(0, len(ids), chunk_size):
+                yield ids[i : i + chunk_size]
+
+        query = {
+            "select": "event",
+            "where": "event_id IN ({ids:Array(String)})",
+            "parameters": {"ids": ["1"]},
+            "column_oriented": True,
+        }
+        try:
+            for chunk_ids in chunk_id_list():
+                query["parameters"]["ids"] = chunk_ids
+                yield from self.read(
+                    query=query,
+                    target=self.event_table_name,
+                    ignore_errors=True,
+                )
+        except (BackendException, BackendParameterException) as error:
+            msg = "Failed to read from ClickHouse"
+            logger.error(msg)
+            raise error
+
+    @staticmethod
+    def _add_agent_filters(
+        ch_params: dict,
+        where: list,
+        agent_params: AgentParameters,
+        target_field: str,
+    ):
+        """Add filters relative to agents to `where`."""
+        if not agent_params:
+            return
+        if agent_params.mbox:
+            ch_params[f"{target_field}__mbox"] = agent_params.mbox
+            where.append(f"event.{target_field}.mbox = {{{target_field}__mbox:String}}")
+        elif agent_params.mbox_sha1sum:
+            ch_params[f"{target_field}__mbox_sha1sum"] = agent_params.mbox_sha1sum
+            where.append(
+                f"event.{target_field}.mbox_sha1sum = {{{target_field}__mbox_sha1sum:String}}"  # noqa: E501 # pylint: disable=line-too-long
+            )
+        elif agent_params.openid:
+            ch_params[f"{target_field}__openid"] = agent_params.openid
+            where.append(
+                f"event.{target_field}.openid = {{{target_field}__openid:String}}"
+            )
+        elif agent_params.account__name:
+            ch_params[f"{target_field}__account_name"] = agent_params.account__name
+            where.append(
+                f"event.{target_field}.account_name = {{{target_field}__account_name:String}}"  # noqa: E501 # pylint: disable=line-too-long
+            )
+            ch_params[
+                f"{target_field}__account_homepage"
+            ] = agent_params.account__home_page
+            where.append(
+                f"event.{target_field}.account_homepage = {{{target_field}__account_homepage:String}}"  # noqa: E501 # pylint: disable=line-too-long
+            )

--- a/tests/backends/data/test_clickhouse.py
+++ b/tests/backends/data/test_clickhouse.py
@@ -1,0 +1,628 @@
+"""Tests for Ralph clickhouse data backend."""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from clickhouse_connect.driver.exceptions import ClickHouseError
+from clickhouse_connect.driver.httpclient import HttpClient
+
+from ralph.backends.data.base import BaseOperationType, DataBackendStatus
+from ralph.backends.data.clickhouse import (
+    ClickHouseDataBackend,
+    ClickHouseDataBackendSettings,
+    ClickHouseQuery,
+)
+from ralph.exceptions import BackendException, BackendParameterException
+
+from tests.fixtures.backends import (
+    CLICKHOUSE_TEST_DATABASE,
+    CLICKHOUSE_TEST_HOST,
+    CLICKHOUSE_TEST_PORT,
+    CLICKHOUSE_TEST_TABLE_NAME,
+)
+
+
+def test_backends_data_clickhouse_data_backend_default_instantiation(monkeypatch, fs):
+    # pylint: disable=invalid-name
+    """Test the `ClickHouseDataBackend` default instantiation."""
+    fs.create_file(".env")
+    backend_settings_names = [
+        "HOST",
+        "PORT",
+        "DATABASE",
+        "EVENT_TABLE_NAME",
+        "USERNAME",
+        "PASSWORD",
+        "CLIENT_OPTIONS",
+        "DEFAULT_CHUNK_SIZE",
+        "LOCALE_ENCODING",
+    ]
+    for name in backend_settings_names:
+        monkeypatch.delenv(f"RALPH_BACKENDS__DATA__CLICKHOUSE__{name}", raising=False)
+
+    assert ClickHouseDataBackend.name == "clickhouse"
+    assert ClickHouseDataBackend.query_model == ClickHouseQuery
+    assert ClickHouseDataBackend.default_operation_type == BaseOperationType.CREATE
+    assert ClickHouseDataBackend.settings_class == ClickHouseDataBackendSettings
+    backend = ClickHouseDataBackend()
+    assert backend.event_table_name == "xapi_events_all"
+    assert backend.default_chunk_size == 500
+    assert backend.locale_encoding == "utf8"
+
+
+def test_backends_data_clickhouse_data_backend_instantiation_with_settings():
+    """Test the `ClickHouseDataBackend` instantiation."""
+    settings = ClickHouseDataBackendSettings(
+        HOST=CLICKHOUSE_TEST_HOST,
+        PORT=CLICKHOUSE_TEST_PORT,
+        DATABASE=CLICKHOUSE_TEST_DATABASE,
+        EVENT_TABLE_NAME=CLICKHOUSE_TEST_TABLE_NAME,
+        USERNAME="default",
+        PASSWORD="",
+        CLIENT_OPTIONS={
+            "date_time_input_format": "test_format",
+            "allow_experimental_object_type": 0,
+        },
+        DEFAULT_CHUNK_SIZE=1000,
+        LOCALE_ENCODING="utf-16",
+    )
+    backend = ClickHouseDataBackend(settings)
+
+    assert isinstance(backend.client, HttpClient)
+    assert backend.event_table_name == CLICKHOUSE_TEST_TABLE_NAME
+    assert backend.default_chunk_size == 1000
+    assert backend.locale_encoding == "utf-16"
+
+
+def test_backends_data_clickhouse_data_backend_status(
+    clickhouse, clickhouse_backend, monkeypatch
+):
+    """Test the `ClickHouseDataBackend.status` method."""
+    # pylint: disable=unused-argument
+
+    backend = clickhouse_backend()
+
+    assert backend.status() == DataBackendStatus.OK
+
+    def mock_query(*_, **__):
+        """Mock the ClickHouseClient.query method."""
+        raise ClickHouseError("Something is wrong")
+
+    monkeypatch.setattr(backend.client, "query", mock_query)
+    assert backend.status() == DataBackendStatus.AWAY
+
+
+def test_backends_data_clickhouse_data_backend_read_method_with_raw_output(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.read` method."""
+    # pylint: disable=unused-argument, protected-access
+    # Create records
+    date_1 = (datetime.now() - timedelta(seconds=3)).isoformat()
+    date_2 = (datetime.now() - timedelta(seconds=2)).isoformat()
+    date_3 = (datetime.now() - timedelta(seconds=1)).isoformat()
+
+    statements = [
+        {"id": str(uuid.uuid4()), "bool": 1, "timestamp": date_1},
+        {"id": str(uuid.uuid4()), "bool": 0, "timestamp": date_2},
+        {"id": str(uuid.uuid4()), "bool": 1, "timestamp": date_3},
+    ]
+
+    backend = clickhouse_backend()
+    backend.write(statements)
+
+    results = list(backend.read())
+    assert len(results) == 3
+    assert results[0]["event"] == statements[0]
+    assert results[1]["event"] == statements[1]
+    assert results[2]["event"] == statements[2]
+
+    results = list(backend.read(chunk_size=10))
+    assert len(results) == 3
+    assert results[0]["event"] == statements[0]
+    assert results[1]["event"] == statements[1]
+    assert results[2]["event"] == statements[2]
+
+    results = list(backend.read(raw_output=True))
+    assert len(results) == 3
+    assert isinstance(results[0], bytes)
+    assert json.loads(results[0])["event"] == statements[0]
+
+
+# pylint: disable=unused-argument
+def test_backends_data_clickhouse_data_backend_read_method_with_a_custom_query(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.read` method with a custom query."""
+    date_1 = (datetime.now() - timedelta(seconds=3)).isoformat()
+    date_2 = (datetime.now() - timedelta(seconds=2)).isoformat()
+    date_3 = (datetime.now() - timedelta(seconds=1)).isoformat()
+
+    statements = [
+        {"id": str(uuid.uuid4()), "bool": 1, "timestamp": date_1},
+        {"id": str(uuid.uuid4()), "bool": 0, "timestamp": date_2},
+        {"id": str(uuid.uuid4()), "bool": 1, "timestamp": date_3},
+    ]
+
+    backend = clickhouse_backend()
+    documents = list(
+        backend._to_insert_tuples(statements)  # pylint: disable=protected-access
+    )
+
+    backend.write(statements)
+
+    # Test filtering
+    query = ClickHouseQuery(where="event.bool = 1")
+    results = list(backend.read(query=query, chunk_size=None))
+    assert len(results) == 2
+    assert results[0]["event"] == statements[0]
+    assert results[1]["event"] == statements[2]
+
+    # Test select fields
+    query = ClickHouseQuery(select=["event_id", "event.bool"])
+    results = list(backend.read(query=query))
+    assert len(results) == 3
+    assert len(results[0]) == 2
+    assert results[0]["event_id"] == documents[0][0]
+    assert results[0]["event.bool"] == statements[0]["bool"]
+    assert results[1]["event_id"] == documents[1][0]
+    assert results[1]["event.bool"] == statements[1]["bool"]
+    assert results[2]["event_id"] == documents[2][0]
+    assert results[2]["event.bool"] == statements[2]["bool"]
+
+    # Test both
+    query = ClickHouseQuery(where="event.bool = 0", select=["event_id", "event.bool"])
+    results = list(backend.read(query=query))
+    assert len(results) == 1
+    assert len(results[0]) == 2
+    assert results[0]["event_id"] == documents[1][0]
+    assert results[0]["event.bool"] == statements[1]["bool"]
+
+    # Test sort
+    query = ClickHouseQuery(sort="emission_time DESCENDING")
+    results = list(backend.read(query=query))
+    assert len(results) == 3
+    assert results[0]["event"] == statements[2]
+    assert results[1]["event"] == statements[1]
+    assert results[2]["event"] == statements[0]
+
+    # Test limit
+    query = ClickHouseQuery(limit=1)
+    results = list(backend.read(query=query))
+    assert len(results) == 1
+    assert results[0]["event"] == statements[0]
+
+    # Test parameters
+    query = ClickHouseQuery(
+        where="event.bool = {event_bool:Bool}",
+        parameters={"event_bool": 0, "format": "exact"},
+    )
+    results = list(backend.read(query=query))
+    assert len(results) == 1
+    assert results[0]["event"] == statements[1]
+
+
+def test_backends_data_clickhouse_data_backend_read_method_with_failures(
+    monkeypatch, caplog, clickhouse, clickhouse_backend
+):  # pylint: disable=unused-argument
+    """Test the `ClickHouseDataBackend.read` method with failures."""
+    backend = clickhouse_backend()
+
+    statement = {"id": str(uuid.uuid4()), "timestamp": str(datetime.utcnow())}
+    document = {"event": statement}
+    backend.write([statement])
+
+    # JSON encoding error
+    def mock_read_raw(*args, **kwargs):
+        """Mock the `ClickHouseDataBackend._read_raw` method."""
+        raise TypeError("Error")
+
+    monkeypatch.setattr(backend, "_read_raw", mock_read_raw)
+
+    msg = f"Failed to encode document {document}: Error"
+
+    # Not ignoring errors
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            BackendException,
+            match=msg,
+        ):
+            list(backend.read(raw_output=True, ignore_errors=False))
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.ERROR,
+        msg,
+    ) in caplog.record_tuples
+
+    caplog.clear()
+
+    # Ignoring errors
+    with caplog.at_level(logging.WARNING):
+        list(backend.read(raw_output=True, ignore_errors=True))
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.WARNING,
+        msg,
+    ) in caplog.record_tuples
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.ERROR,
+        msg,
+    ) not in caplog.record_tuples
+
+    # ClickHouse error during query should raise even when ignoring errors
+    def mock_query(*_, **__):
+        """Mock the ClickHouseClient.query method."""
+        raise ClickHouseError("Something is wrong")
+
+    monkeypatch.setattr(backend.client, "query", mock_query)
+
+    msg = "Failed to read documents: Something is wrong"
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            BackendException,
+            match=msg,
+        ):
+            list(backend.read(ignore_errors=True))
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.ERROR,
+        msg,
+    ) in caplog.record_tuples
+
+
+def test_backends_data_clickhouse_data_backend_list_method(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.list` method."""
+
+    backend = clickhouse_backend()
+
+    assert list(backend.list(details=True)) == [{"name": CLICKHOUSE_TEST_TABLE_NAME}]
+    assert list(backend.list(details=False)) == [CLICKHOUSE_TEST_TABLE_NAME]
+
+
+def test_backends_data_clickhouse_data_backend_list_method_with_failure(
+    monkeypatch, caplog, clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.list` method with a failure."""
+    # pylint: disable=unused-argument
+    backend = clickhouse_backend()
+
+    def mock_query(*_, **__):
+        """Mock the ClickHouseClient.query method."""
+        raise ClickHouseError("Something is wrong")
+
+    monkeypatch.setattr(backend.client, "query", mock_query)
+
+    with caplog.at_level(logging.ERROR):
+        msg = "Failed to read tables: Something is wrong"
+        with pytest.raises(
+            BackendException,
+            match=msg,
+        ):
+            list(backend.list())
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.ERROR,
+        msg,
+    ) in caplog.record_tuples
+
+
+def test_backends_data_clickhouse_data_backend_write_method_with_invalid_timestamp(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method with an invalid timestamp."""
+    # pylint: disable=unused-argument
+    valid_timestamp = (datetime.now() - timedelta(seconds=3)).isoformat()
+    invalid_timestamp = "This is not a valid timestamp!"
+    invalid_statement = {
+        "id": str(uuid.uuid4()),
+        "bool": 0,
+        "timestamp": invalid_timestamp,
+    }
+
+    statements = [
+        {"id": str(uuid.uuid4()), "bool": 1, "timestamp": valid_timestamp},
+        invalid_statement,
+    ]
+
+    backend = clickhouse_backend()
+
+    msg = f"Statement {invalid_statement} has an invalid 'id' or 'timestamp' field"
+    with pytest.raises(
+        BackendException,
+        match=msg,
+    ):
+        backend.write(statements, ignore_errors=False)
+
+
+def test_backends_data_clickhouse_data_backend_write_method_no_timestamp(
+    caplog, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method when a statement has no
+    timestamp.
+    """
+    statement = {"id": str(uuid.uuid4())}
+
+    backend = clickhouse_backend()
+
+    msg = f"Statement {statement} has an invalid 'id' or 'timestamp' field"
+
+    # Without ignoring errors
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            BackendException,
+            match=msg,
+        ):
+            backend.write([statement], ignore_errors=False)
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.ERROR,
+        f"Statement {statement} has an invalid 'id' or 'timestamp' field",
+    ) in caplog.record_tuples
+
+    caplog.clear()
+
+    # Ignoring errors
+    with caplog.at_level(logging.WARNING):
+        backend.write([statement], ignore_errors=True)
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.WARNING,
+        f"Statement {statement} has an invalid 'id' or 'timestamp' field",
+    ) in caplog.record_tuples
+
+    assert (
+        "ralph.backends.data.clickhouse",
+        logging.ERROR,
+        f"Statement {statement} has an invalid 'id' or 'timestamp' field",
+    ) not in caplog.record_tuples
+
+
+def test_backends_data_clickhouse_data_backend_write_method_with_duplicated_key(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method with duplicated key
+    conflict.
+    """
+    # pylint: disable=unused-argument
+    backend = clickhouse_backend()
+
+    timestamp = {"timestamp": "2022-06-27T15:36:50"}
+    dupe_id = str(uuid.uuid4())
+    statements = [
+        {"id": str(uuid.uuid4()), **timestamp},
+        {"id": dupe_id, **timestamp},
+        {"id": dupe_id, **timestamp},
+    ]
+
+    # No way of knowing how many write succeeded when there is an error
+    assert backend.write(statements, ignore_errors=True) == 0
+
+    with pytest.raises(BackendException, match="Duplicate IDs found in batch"):
+        backend.write(statements, ignore_errors=False)
+
+
+def test_backends_data_clickhouse_data_backend_write_method_chunks_on_error(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method imports partial chunks
+    while raising BulkWriteError and ignoring errors.
+    """
+    # pylint: disable=unused-argument
+    backend = clickhouse_backend()
+
+    # Identical statement ID produces the same ObjectId, leading to a
+    # duplicated key write error while trying to bulk import this batch
+    timestamp = {"timestamp": "2022-06-27T15:36:50"}
+    dupe_id = str(uuid.uuid4())
+    statements = [
+        {"id": str(uuid.uuid4()), **timestamp},
+        {"id": dupe_id, **timestamp},
+        {"id": str(uuid.uuid4()), **timestamp},
+        {"id": str(uuid.uuid4()), **timestamp},
+        {"id": dupe_id, **timestamp},
+    ]
+    assert backend.write(statements, ignore_errors=True) == 0
+
+
+def test_backends_data_clickhouse_data_backend_write_method(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method."""
+
+    sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    native_statements = [
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow() - timedelta(seconds=1)},
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow()},
+    ]
+    statements = [
+        {"id": str(x["id"]), "timestamp": x["timestamp"].isoformat()}
+        for x in native_statements
+    ]
+    backend = clickhouse_backend()
+    count = backend.write(statements, target=CLICKHOUSE_TEST_TABLE_NAME)
+
+    assert count == 2
+
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 2
+
+    sql = f"""SELECT * FROM {CLICKHOUSE_TEST_TABLE_NAME} ORDER BY event.timestamp"""
+    result = list(clickhouse.query(sql).named_results())
+
+    assert result[0]["event_id"] == native_statements[0]["id"]
+    assert result[0]["emission_time"] == native_statements[0]["timestamp"]
+    assert result[0]["event"] == statements[0]
+
+    assert result[1]["event_id"] == native_statements[1]["id"]
+    assert result[1]["emission_time"] == native_statements[1]["timestamp"]
+    assert result[1]["event"] == statements[1]
+
+
+def test_backends_data_clickhouse_data_backend_write_method_bytes(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method."""
+
+    sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    native_statements = [
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow() - timedelta(seconds=1)},
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow()},
+    ]
+    statements = [
+        {"id": str(x["id"]), "timestamp": x["timestamp"].isoformat()}
+        for x in native_statements
+    ]
+
+    backend = clickhouse_backend()
+    byte_data = []
+    for item in statements:
+        json_str = json.dumps(item, separators=(",", ":"), ensure_ascii=False)
+        byte_data.append(json_str.encode("utf-8"))
+    count = backend.write(byte_data, target=CLICKHOUSE_TEST_TABLE_NAME)
+
+    assert count == 2
+
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 2
+
+    sql = f"""SELECT * FROM {CLICKHOUSE_TEST_TABLE_NAME} ORDER BY event.timestamp"""
+    result = list(clickhouse.query(sql).named_results())
+
+    assert result[0]["event_id"] == native_statements[0]["id"]
+    assert result[0]["emission_time"] == native_statements[0]["timestamp"]
+    assert result[0]["event"] == statements[0]
+
+    assert result[1]["event_id"] == native_statements[1]["id"]
+    assert result[1]["emission_time"] == native_statements[1]["timestamp"]
+    assert result[1]["event"] == statements[1]
+
+
+def test_backends_data_clickhouse_data_backend_write_method_bytes_failed(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method."""
+
+    sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    backend = clickhouse_backend()
+
+    byte_data = []
+    json_str = "failed_json_str"
+    byte_data.append(json_str.encode("utf-8"))
+
+    count = 0
+    with pytest.raises(json.JSONDecodeError):
+        count = backend.write(byte_data)
+
+    assert count == 0
+
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    count = backend.write(byte_data, ignore_errors=True)
+    assert count == 0
+
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+
+def test_backends_data_clickhouse_data_backend_write_method_empty(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method."""
+
+    sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    backend = clickhouse_backend()
+    count = backend.write([], target=CLICKHOUSE_TEST_TABLE_NAME)
+
+    assert count == 0
+
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+
+def test_backends_data_clickhouse_data_backend_write_method_wrong_operation_type(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method."""
+
+    sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    native_statements = [
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow() - timedelta(seconds=1)},
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow()},
+    ]
+    statements = [
+        {"id": str(x["id"]), "timestamp": x["timestamp"].isoformat()}
+        for x in native_statements
+    ]
+
+    backend = clickhouse_backend()
+    with pytest.raises(
+        BackendParameterException,
+        match=f"{BaseOperationType.APPEND.name} operation_type is not allowed.",
+    ):
+        backend.write(data=statements, operation_type=BaseOperationType.APPEND)
+
+
+def test_backends_data_clickhouse_data_backend_write_method_with_custom_chunk_size(
+    clickhouse, clickhouse_backend
+):
+    """Test the `ClickHouseDataBackend.write` method with a custom chunk_size."""
+
+    sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 0
+
+    native_statements = [
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow() - timedelta(seconds=1)},
+        {"id": uuid.uuid4(), "timestamp": datetime.utcnow()},
+    ]
+    statements = [
+        {"id": str(x["id"]), "timestamp": x["timestamp"].isoformat()}
+        for x in native_statements
+    ]
+
+    backend = clickhouse_backend()
+    count = backend.write(statements, chunk_size=1)
+    assert count == 2
+
+    result = clickhouse.query(sql).result_set
+    assert result[0][0] == 2
+
+    sql = f"""SELECT * FROM {CLICKHOUSE_TEST_TABLE_NAME} ORDER BY event.timestamp"""
+    result = list(clickhouse.query(sql).named_results())
+
+    assert result[0]["event_id"] == native_statements[0]["id"]
+    assert result[0]["emission_time"] == native_statements[0]["timestamp"]
+    assert result[0]["event"] == statements[0]
+
+    assert result[1]["event_id"] == native_statements[1]["id"]
+    assert result[1]["emission_time"] == native_statements[1]["timestamp"]
+    assert result[1]["event"] == statements[1]

--- a/tests/backends/lrs/test_clickhouse.py
+++ b/tests/backends/lrs/test_clickhouse.py
@@ -1,0 +1,368 @@
+"""Tests for Ralph clickhouse database backend."""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from clickhouse_connect.driver.exceptions import ClickHouseError
+
+from ralph.backends.lrs.base import StatementParameters
+from ralph.exceptions import BackendException
+
+
+@pytest.mark.parametrize(
+    "params,expected_params",
+    [
+        # 0. Default query.
+        (
+            {},
+            {
+                "where": [],
+                "params": {"format": "exact"},
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # 1. Query by statementId.
+        (
+            {"statementId": "test_id"},
+            {
+                "where": ["event_id = {statementId:UUID}"],
+                "params": {"statementId": "test_id", "format": "exact"},
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # # 2. Query by statementId and agent with mbox IFI.
+        (
+            {"statementId": "test_id", "agent": {"mbox": "mailto:foo@bar.baz"}},
+            {
+                "where": [
+                    "event_id = {statementId:UUID}",
+                    "event.actor.mbox = {actor__mbox:String}",
+                ],
+                "params": {
+                    "statementId": "test_id",
+                    "actor__mbox": "mailto:foo@bar.baz",
+                    "format": "exact",
+                },
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # # 3. Query by statementId and agent with mbox_sha1sum IFI.
+        (
+            {
+                "statementId": "test_id",
+                "agent": {"mbox_sha1sum": "a7a5b7462b862c8c8767d43d43e865ffff754a64"},
+            },
+            {
+                "where": [
+                    "event_id = {statementId:UUID}",
+                    "event.actor.mbox_sha1sum = {actor__mbox_sha1sum:String}",
+                ],
+                "params": {
+                    "statementId": "test_id",
+                    "actor__mbox_sha1sum": "a7a5b7462b862c8c8767d43d43e865ffff754a64",
+                    "format": "exact",
+                },
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # 4. Query by statementId and agent with openid IFI.
+        (
+            {
+                "statementId": "test_id",
+                "agent": {"openid": "http://toby.openid.example.org/"},
+            },
+            {
+                "where": [
+                    "event_id = {statementId:UUID}",
+                    "event.actor.openid = {actor__openid:String}",
+                ],
+                "params": {
+                    "statementId": "test_id",
+                    "actor__openid": "http://toby.openid.example.org/",
+                    "format": "exact",
+                },
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # 5. Query by statementId and agent with account IFI.
+        (
+            {
+                "statementId": "test_id",
+                "agent": {
+                    "account__home_page": "http://www.example.com",
+                    "account__name": "13936749",
+                },
+                "ascending": True,
+            },
+            {
+                "where": [
+                    "event_id = {statementId:UUID}",
+                    "event.actor.account_name = {actor__account_name:String}",
+                    "event.actor.account_homepage = {actor__account_homepage:String}",
+                ],
+                "params": {
+                    "statementId": "test_id",
+                    "actor__account_name": "13936749",
+                    "actor__account_homepage": "http://www.example.com",
+                    "ascending": True,
+                    "format": "exact",
+                },
+                "limit": None,
+                "sort": "emission_time ASCENDING, event_id ASCENDING",
+            },
+        ),
+        # 6. Query by verb and activity with limit.
+        (
+            {
+                "verb": "http://adlnet.gov/expapi/verbs/attended",
+                "activity": "http://www.example.com/meetings/34534",
+                "limit": 100,
+            },
+            {
+                "where": [
+                    "event.verb.id = {verb:String}",
+                    "event.object.objectType = 'Activity'",
+                    "event.object.id = {activity:String}",
+                ],
+                "params": {
+                    "verb": "http://adlnet.gov/expapi/verbs/attended",
+                    "activity": "http://www.example.com/meetings/34534",
+                    "limit": 100,
+                    "format": "exact",
+                },
+                "limit": 100,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # 7. Query by timerange (with since/until).
+        (
+            {
+                "since": "2021-06-24T00:00:20.194929+00:00",
+                "until": "2023-06-24T00:00:20.194929+00:00",
+            },
+            {
+                "where": [
+                    "emission_time > {since:DateTime64(6)}",
+                    "emission_time <= {until:DateTime64(6)}",
+                ],
+                "params": {
+                    "since": datetime(
+                        2021, 6, 24, 0, 0, 20, 194929, tzinfo=timezone.utc
+                    ),
+                    "until": datetime(
+                        2023, 6, 24, 0, 0, 20, 194929, tzinfo=timezone.utc
+                    ),
+                    "format": "exact",
+                },
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+        # 8. Query with pagination and pit_id.
+        (
+            {"search_after": "1686557542970|0", "pit_id": "46ToAwMDaWR5BXV1a"},
+            {
+                "where": [
+                    (
+                        "(emission_time < {search_after:DateTime64(6)}"
+                        " OR "
+                        "(emission_time = {search_after:DateTime64(6)}"
+                        " AND "
+                        "event_id < {pit_id:UUID}))"
+                    ),
+                ],
+                "params": {
+                    "search_after": "1686557542970|0",
+                    "pit_id": "46ToAwMDaWR5BXV1a",
+                    "format": "exact",
+                },
+                "limit": None,
+                "sort": "emission_time DESCENDING, event_id DESCENDING",
+            },
+        ),
+    ],
+)
+def test_backends_database_clickhouse_query_statements(
+    params,
+    expected_params,
+    monkeypatch,
+    clickhouse,
+    clickhouse_lrs_backend,
+):
+    """Test the ClickHouse backend query_statements method, given a search query
+    failure, should raise a BackendException and log the error.
+    """
+    # pylint: disable=unused-argument
+
+    def mock_read(query, target, ignore_errors):
+        """Mock the `ClickHouseDataBackend.read` method."""
+
+        assert query == {
+            "select": ["event_id", "emission_time", "event"],
+            "where": expected_params["where"],
+            "parameters": expected_params["params"],
+            "limit": expected_params["limit"],
+            "sort": expected_params["sort"],
+        }
+
+        return {}
+
+    backend = clickhouse_lrs_backend()
+    monkeypatch.setattr(backend, "read", mock_read)
+
+    backend.query_statements(StatementParameters(**params))
+
+
+def test_backends_lrs_clickhouse_lrs_backend_query_statements(
+    clickhouse, clickhouse_lrs_backend
+):
+    """Test the `ClickHouseLRSBackend.query_statements` method, given a query,
+    should return matching statements.
+    """
+    # pylint: disable=unused-argument, invalid-name
+    backend = clickhouse_lrs_backend()
+
+    # Insert documents
+    date_str = "09-19-2022"
+    datetime_object = datetime.strptime(date_str, "%m-%d-%Y").utcnow()
+    test_id = str(uuid.uuid4())
+    statements = [
+        {
+            "id": test_id,
+            "timestamp": datetime_object.isoformat(),
+            "actor": {"account": {"name": "test_name"}},
+            "verb": {"id": "verb_id"},
+            "object": {"id": "http://example.com", "objectType": "Activity"},
+        },
+    ]
+
+    success = backend.write(statements, chunk_size=1)
+    assert success == 1
+
+    # Check the expected search query results.
+    result = backend.query_statements(
+        StatementParameters(statementId=test_id, limit=10)
+    )
+    assert result.statements == statements
+
+
+def test_backends_lrs_clickhouse_lrs_backend__find(clickhouse, clickhouse_lrs_backend):
+    """Test the `ClickHouseLRSBackend._find` method, given a query,
+    should return matching statements.
+    """
+    # pylint: disable=unused-argument, invalid-name
+    backend = clickhouse_lrs_backend()
+
+    # Insert documents
+    date_str = "09-19-2022"
+    datetime_object = datetime.strptime(date_str, "%m-%d-%Y").utcnow()
+    statements = [
+        {
+            "id": str(uuid.uuid4()),
+            "timestamp": datetime_object.isoformat(),
+            "actor": {"account": {"name": "test_name"}},
+            "verb": {"id": "verb_id"},
+            "object": {"id": "http://example.com", "objectType": "Activity"},
+        },
+    ]
+
+    success = backend.write(statements, chunk_size=1)
+    assert success == 1
+
+    # Check the expected search query results.
+    result = backend.query_statements(StatementParameters())
+    assert result.statements == statements
+
+
+def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids(
+    clickhouse, clickhouse_lrs_backend
+):
+    """Test the `ClickHouseLRSBackend.query_statements_by_ids` method, given
+    a list of ids, should return matching statements.
+    """
+    # pylint: disable=unused-argument
+    backend = clickhouse_lrs_backend()
+
+    # Insert documents
+    date_str = "09-19-2022"
+    datetime_object = datetime.strptime(date_str, "%m-%d-%Y").utcnow()
+    test_id = str(uuid.uuid4())
+    statements = [
+        {
+            "id": test_id,
+            "timestamp": datetime_object.isoformat(),
+            "actor": {"account": {"name": "test_name"}},
+            "verb": {"id": "verb_id"},
+            "object": {"id": "http://example.com", "objectType": "Activity"},
+        },
+    ]
+
+    count = backend.write(statements, chunk_size=1)
+    assert count == 1
+
+    # Check the expected search query results.
+    result = list(backend.query_statements_by_ids([test_id]))
+    assert result[0]["event"] == statements[0]
+
+
+def test_backends_lrs_clickhouse_lrs_backend_query_statements_client_failure(
+    clickhouse, clickhouse_lrs_backend, monkeypatch, caplog
+):
+    """Test the `ClickHouseLRSBackend.query_statements`, given a client query
+    failure, should raise a `BackendException` and log the error.
+    """
+    # pylint: disable=invalid-name,unused-argument
+
+    def mock_query(*args, **kwargs):
+        """Mock the clickhouse_connect.client.search method."""
+        raise ClickHouseError("Query error")
+
+    backend = clickhouse_lrs_backend()
+    monkeypatch.setattr(backend.client, "query", mock_query)
+
+    caplog.set_level(logging.ERROR)
+
+    msg = "Failed to read documents: Query error"
+    with pytest.raises(BackendException, match=msg):
+        next(backend.query_statements(StatementParameters()))
+
+    assert (
+        "ralph.backends.lrs.clickhouse",
+        logging.ERROR,
+        "Failed to read from ClickHouse",
+    ) in caplog.record_tuples
+
+
+def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids_client_failure(
+    clickhouse, clickhouse_lrs_backend, monkeypatch, caplog
+):
+    """Test the `ClickHouseLRSBackend.query_statements_by_ids`, given a client
+    query failure, should raise a `BackendException` and log the error.
+    """
+    # pylint: disable=invalid-name,unused-argument
+
+    def mock_query(*args, **kwargs):
+        """Mock the clickhouse_connect.client.search method."""
+        raise ClickHouseError("Query error")
+
+    backend = clickhouse_lrs_backend()
+    monkeypatch.setattr(backend.client, "query", mock_query)
+
+    caplog.set_level(logging.ERROR)
+
+    msg = "Failed to read documents: Query error"
+    with pytest.raises(BackendException, match=msg):
+        next(backend.query_statements_by_ids(["test_id"]))
+
+    assert (
+        "ralph.backends.lrs.clickhouse",
+        logging.ERROR,
+        "Failed to read from ClickHouse",
+    ) in caplog.record_tuples

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from .fixtures.auth import (  # noqa: F401
 )
 from .fixtures.backends import (  # noqa: F401
     clickhouse,
+    clickhouse_backend,
+    clickhouse_lrs_backend,
     es,
     es_data_stream,
     es_forwarding,

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -21,6 +21,7 @@ from httpx import AsyncClient, ConnectError
 from pymongo import MongoClient
 from pymongo.errors import CollectionInvalid
 
+from ralph.backends.data.clickhouse import ClickHouseDataBackend
 from ralph.backends.data.fs import FSDataBackend, FSDataBackendSettings
 from ralph.backends.data.ldp import LDPDataBackend
 from ralph.backends.data.s3 import S3DataBackend, S3DataBackendSettings
@@ -28,6 +29,7 @@ from ralph.backends.data.swift import SwiftDataBackend, SwiftDataBackendSettings
 from ralph.backends.database.clickhouse import ClickHouseDatabase
 from ralph.backends.database.es import ESDatabase
 from ralph.backends.database.mongo import MongoDatabase
+from ralph.backends.lrs.clickhouse import ClickHouseLRSBackend
 from ralph.backends.storage.s3 import S3Storage
 from ralph.backends.storage.swift import SwiftStorage
 from ralph.conf import ClickhouseClientOptions, Settings, core_settings
@@ -337,6 +339,59 @@ def ldp_backend(settings_fs):
         return LDPDataBackend(settings)
 
     return get_ldp_data_backend
+
+
+@pytest.fixture
+def clickhouse_backend():
+    """Return the `get_clickhouse_data_backend` function."""
+    # pylint: disable=invalid-name,redefined-outer-name
+
+    def get_clickhouse_data_backend():
+        """Return an instance of ClickHouseDataBackend."""
+        settings = ClickHouseDataBackend.settings_class(
+            HOST=CLICKHOUSE_TEST_HOST,
+            PORT=CLICKHOUSE_TEST_PORT,
+            DATABASE=CLICKHOUSE_TEST_DATABASE,
+            EVENT_TABLE_NAME=CLICKHOUSE_TEST_TABLE_NAME,
+            USERNAME="default",
+            PASSWORD="",
+            CLIENT_OPTIONS={
+                "date_time_input_format": "best_effort",
+                "allow_experimental_object_type": 1,
+            },
+            DEFAULT_CHUNK_SIZE=500,
+            LOCALE_ENCODING="utf8",
+        )
+        return ClickHouseDataBackend(settings)
+
+    return get_clickhouse_data_backend
+
+
+@pytest.fixture
+def clickhouse_lrs_backend():
+    """Return the `get_clickhouse_lrs_backend` function."""
+    # pylint: disable=invalid-name,redefined-outer-name
+
+    def get_clickhouse_lrs_backend():
+        """Return an instance of ClickHouseLRSBackend."""
+        settings = ClickHouseLRSBackend.settings_class(
+            HOST=CLICKHOUSE_TEST_HOST,
+            PORT=CLICKHOUSE_TEST_PORT,
+            DATABASE=CLICKHOUSE_TEST_DATABASE,
+            EVENT_TABLE_NAME=CLICKHOUSE_TEST_TABLE_NAME,
+            USERNAME="default",
+            PASSWORD="",
+            CLIENT_OPTIONS={
+                "date_time_input_format": "best_effort",
+                "allow_experimental_object_type": 1,
+            },
+            DEFAULT_CHUNK_SIZE=500,
+            LOCALE_ENCODING="utf8",
+            IDS_CHUNK_SIZE=10000,
+        )
+        return ClickHouseLRSBackend(settings)
+
+    return get_clickhouse_lrs_backend
 
 
 @pytest.fixture


### PR DESCRIPTION
## Purpose

Storage and Database backends had similar interfaces and usage, a new Data backend interface has been created.

## Proposal

Update Clickhouse backend to follow new Data backend interface.
Add pydantic model for a history entry.

- [x] Add ClickhouseDataBackend
- [x] Add tests for Clickhouse
