### PR TITLE
🐛(api) fix `more` irl on second request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ as per the xAPI specification
 - Use batch/v1 api in cronjob_pipeline manifest
 - Use autoscaling/v2 in HorizontalPodAutoscaler manifest
 
+### Fixed
+
+- Fix the `more` IRL building in LRS `/statements` GET requests
+
 ## [3.5.1] - 2023-04-18
 
 ### Changed

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime
 from typing import List, Literal, Optional, Union
+from urllib.parse import ParseResult, urlencode
 from uuid import UUID, uuid4
 
 from fastapi import (
@@ -246,14 +247,26 @@ async def get(
     response = {}
     if len(query_result.statements) == limit:
         # Search after relies on sorting info located in the last hit
-        path = request.url.components.path
-        query = request.url.components.query
+        path = request.url.path
+        query = dict(request.query_params)
+
+        query.update(
+            {
+                "pit_id": query_result.pit_id,
+                "search_after": query_result.search_after,
+            }
+        )
+
         response.update(
             {
-                "more": (
-                    f"{path}{query + '&' if query else '?'}pit_id={query_result.pit_id}"
-                    f"&search_after={query_result.search_after}"
-                )
+                "more": ParseResult(
+                    scheme="",
+                    netloc="",
+                    path=path,
+                    params="",
+                    query=urlencode(query),
+                    fragment="",
+                ).geturl(),
             }
         )
 


### PR DESCRIPTION
## Purpose
Following #315, making a second GET request to the `more` irl, or querying with a query parameter, was failing due to a missing `?` after the endpoint name.

## Proposal

- [x] '?' should now be present for every `more` irl generated, even when query parameters are passed. 
- [x] Tests updated to cover this issue 