### PR TITLE
💥(history) change command history

### DIFF
--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -18,7 +18,7 @@ from ralph.backends.data.base import (
     DataBackendStatus,
     enforce_query_checks,
 )
-from ralph.backends.mixins import HistoryMixin
+from ralph.backends.mixins import HistoryEntry, HistoryMixin
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import now
@@ -196,17 +196,13 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
 
             # The file has been read, add a new entry to the history.
             self.append_to_history(
-                {
-                    "backend": self.name,
-                    "action": "read",
-                    # WARNING: previously only the file name was used as the ID
-                    # By changing this to the absolute file path, previously fetched
-                    # files will not be marked as read anymore.
-                    "id": str(path.absolute()),
-                    "filename": path.name,
-                    "size": path.stat().st_size,
-                    "timestamp": now(),
-                }
+                HistoryEntry(
+                    backend=self.name,
+                    action="read",
+                    id=str(path.absolute()),
+                    size=path.stat().st_size,
+                    timestamp=now(),
+                )
             )
 
     def write(  # pylint: disable=too-many-arguments
@@ -289,17 +285,14 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
 
         # The file has been created, add a new entry to the history.
         self.append_to_history(
-            {
-                "backend": self.name,
-                "action": "write",
-                # WARNING: previously only the file name was used as the ID
-                # By changing this to the absolute file path, previously written
-                # files will not be marked as written anymore.
-                "id": str(path.absolute()),
-                "filename": path.name,
-                "size": path.stat().st_size,
-                "timestamp": now(),
-            }
+            HistoryEntry(
+                backend=self.name,
+                action="write",
+                id=str(path.absolute()),
+                size=path.stat().st_size,
+                timestamp=now(),
+                operation_type=operation_type,
+            )
         )
         return 1
 

--- a/tests/backends/data/test_fs.py
+++ b/tests/backends/data/test_fs.py
@@ -10,6 +10,7 @@ import pytest
 
 from ralph.backends.data.base import BaseOperationType, BaseQuery, DataBackendStatus
 from ralph.backends.data.fs import FSDataBackend, FSDataBackendSettings
+from ralph.backends.mixins import HistoryEntry
 from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import now
 
@@ -214,7 +215,6 @@ def test_backends_data_fs_data_backend_list_method_with_history(fs_backend, fs):
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_1",
-            "filename": "file_1",
             "size": 0,
             "timestamp": "2020-10-07T16:37:25.887664+00:00",
         }
@@ -233,7 +233,6 @@ def test_backends_data_fs_data_backend_list_method_with_history(fs_backend, fs):
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_2",
-            "filename": "file_2",
             "size": 0,
             "timestamp": "2020-10-07T16:37:25.887664+00:00",
         }
@@ -252,7 +251,6 @@ def test_backends_data_fs_data_backend_list_method_with_history(fs_backend, fs):
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_3",
-            "filename": "file_3",
             "size": 0,
             "timestamp": "2020-10-07T16:37:25.887664+00:00",
         }
@@ -298,7 +296,6 @@ def test_backends_data_fs_data_backend_list_method_with_history_and_details(
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_1",
-            "filename": "file_1",
             "size": 0,
             "timestamp": "1970-01-01T00:00:01+00:00",
         }
@@ -321,7 +318,6 @@ def test_backends_data_fs_data_backend_list_method_with_history_and_details(
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_2",
-            "filename": "file_2",
             "size": 0,
             "timestamp": "1970-01-01T00:00:01+00:00",
         }
@@ -344,7 +340,6 @@ def test_backends_data_fs_data_backend_list_method_with_history_and_details(
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_3",
-            "filename": "file_3",
             "size": 0,
             "timestamp": "1970-01-01T00:00:01+00:00",
         }
@@ -392,9 +387,9 @@ def test_backends_data_fs_data_backend_read_method_with_raw_ouput(
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_3.txt",
-            "filename": "file_3.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         }
     ]
 
@@ -411,17 +406,17 @@ def test_backends_data_fs_data_backend_read_method_with_raw_ouput(
             "backend": "fs",
             "action": "read",
             "id": "/tmp/test_fs/file_1.txt",
-            "filename": "file_1.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
         {
             "backend": "fs",
             "action": "read",
             "id": "/tmp/test_fs/file_2.txt",
-            "filename": "file_2.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
     ]
 
@@ -438,10 +433,10 @@ def test_backends_data_fs_data_backend_read_method_with_raw_ouput(
             "backend": "fs",
             "action": "read",
             "id": "/foo/bar/file_4.txt",
-            "filename": "file_4.txt",
             "size": 3,
             "timestamp": frozen_now,
-        },
+            "operation_type": None,
+        }
     ]
 
     # Given a `chunk_size` and an absolute `target` path,
@@ -458,17 +453,17 @@ def test_backends_data_fs_data_backend_read_method_with_raw_ouput(
             "backend": "fs",
             "action": "read",
             "id": "/tmp/test_fs/file_1.txt",
-            "filename": "file_1.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
         {
             "backend": "fs",
             "action": "read",
             "id": "/tmp/test_fs/file_2.txt",
-            "filename": "file_2.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
     ]
 
@@ -512,9 +507,9 @@ def test_backends_data_fs_data_backend_read_method_without_raw_output(
             "backend": "fs",
             "action": "read",
             "id": "/foo/file_2.txt",
-            "filename": "file_2.txt",
             "size": 29,
             "timestamp": frozen_now,
+            "operation_type": None,
         }
     ]
 
@@ -531,9 +526,9 @@ def test_backends_data_fs_data_backend_read_method_without_raw_output(
             "backend": "fs",
             "action": "read",
             "id": "/tmp/test_fs/file_1.txt",
-            "filename": "file_1.txt",
             "size": 14,
             "timestamp": frozen_now,
+            "operation_type": None,
         }
     ]
 
@@ -550,9 +545,9 @@ def test_backends_data_fs_data_backend_read_method_without_raw_output(
             "backend": "fs",
             "action": "read",
             "id": "/foo/bar/file_3.txt",
-            "filename": "file_3.txt",
             "size": 44,
             "timestamp": frozen_now,
+            "operation_type": None,
         }
     ]
 
@@ -664,9 +659,9 @@ def test_backends_data_fs_data_backend_read_method_without_ignore_errors(
             "backend": "fs",
             "action": "read",
             "id": "/tmp/test_fs/file_1.txt",
-            "filename": "file_1.txt",
             "size": 14,
             "timestamp": frozen_now,
+            "operation_type": None,
         }
     ]
 
@@ -810,17 +805,17 @@ def test_backends_data_fs_data_backend_write_method_with_update_operation(
             "backend": "fs",
             "action": "read",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": 7,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
         {
             "backend": "fs",
             "action": "write",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": BaseOperationType.UPDATE.value,
         },
     ]
     assert list(backend.read(query="foo.txt", raw_output=True)) == [b"bar"]
@@ -836,17 +831,17 @@ def test_backends_data_fs_data_backend_write_method_with_update_operation(
             "backend": "fs",
             "action": "write",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": 0,
             "timestamp": frozen_now,
+            "operation_type": BaseOperationType.UPDATE.value,
         },
         {
             "backend": "fs",
             "action": "read",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": 0,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
     ]
 
@@ -861,17 +856,17 @@ def test_backends_data_fs_data_backend_write_method_with_update_operation(
             "backend": "fs",
             "action": "write",
             "id": "/foo/bar.txt",
-            "filename": "bar.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": BaseOperationType.UPDATE.value,
         },
         {
             "backend": "fs",
             "action": "read",
             "id": "/foo/bar.txt",
-            "filename": "bar.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
     ]
 
@@ -919,25 +914,25 @@ def test_backends_data_fs_data_backend_write_method_with_append_operation(
             "backend": "fs",
             "action": "read",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": 3,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
         {
             "backend": "fs",
             "action": "write",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": len(expected[0]),
             "timestamp": frozen_now,
+            "operation_type": BaseOperationType.APPEND.value,
         },
         {
             "backend": "fs",
             "action": "read",
             "id": "/foo/foo.txt",
-            "filename": "foo.txt",
             "size": len(expected[0]),
             "timestamp": frozen_now,
+            "operation_type": None,
         },
     ]
 
@@ -973,16 +968,16 @@ def test_backends_data_fs_data_backend_write_method_without_target(
             "backend": "fs",
             "action": "write",
             "id": f"/{expected_filename}",
-            "filename": expected_filename,
             "size": 6,
             "timestamp": frozen_now,
+            "operation_type": BaseOperationType.CREATE.value,
         },
         {
             "backend": "fs",
             "action": "read",
             "id": f"/{expected_filename}",
-            "filename": expected_filename,
             "size": 6,
             "timestamp": frozen_now,
+            "operation_type": None,
         },
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -607,12 +607,12 @@ def test_cli_list_command_with_fs_backend(fs, monkeypatch):
     ]
     archive_list_details = [
         {
-            "filename": "file1",
+            "id": "file1",
             "modified_at": "1604661859",
             "size": 350,
         },
         {
-            "filename": "file2",
+            "id": "file2",
             "created_at": "1604935848",
             "size": 25000,
         },


### PR DESCRIPTION
## Purpose

Add a common HistoryEntry pydantic model for command history.

## Proposal
Each backend will be adapted to use HistoryEntry when merged:
- [x] fs
- [ ] s3
- [ ] mongo
- [ ] es
- [ ] clickhouse
- [ ] ldp
- [ ] swift

