### PR TITLE
(api) Implement scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
 
 ### Changed
+
+- Add pre-processing to enrich incoming statements
+- Changed `authenticated_user` to `authenticate_user`
 
 - Upgrade `sentry_sdk` to `1.20.0`
 - LRS `/statements` `GET` method returns a code 400 with certain parameters
 as per the xAPI specification
+
+- Add `mine` option to `GET /statements`
+- Add scope mechanism to restrict endpoint access
 
 ## [3.5.1] - 2023-04-18
 

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -5,7 +5,7 @@ from fastapi import Depends, FastAPI
 from ralph.conf import settings
 
 from .. import __version__
-from .auth import AuthenticatedUser, authenticated_user
+from .auth import AuthenticatedUser, authenticate_user
 from .routers import health, statements
 
 if settings.SENTRY_DSN is not None:
@@ -23,6 +23,6 @@ app.include_router(health.router)
 
 
 @app.get("/whoami")
-async def whoami(user: AuthenticatedUser = Depends(authenticated_user)):
+async def whoami(user: AuthenticatedUser = Depends(authenticate_user)):
     """Return the current user's username along with their scopes."""
     return {"username": user.username, "scopes": user.scopes}

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -63,6 +63,7 @@ class StatementParameters:
     format: Optional[Literal["ids", "exact", "canonical"]] = "exact"
     attachments: Optional[bool] = False
     ascending: Optional[bool] = False
+    mine: Optional[bool] = True
     search_after: Optional[str] = None
     pit_id: Optional[str] = None
 

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -1,6 +1,7 @@
 """Utilities for Ralph."""
 
 import datetime
+from dateutil.parser import parse
 import logging
 import operator
 from functools import reduce
@@ -92,3 +93,42 @@ def set_dict_value_from_path(dict_: dict, path: List[str], value: any):
     for key in path[:-1]:
         dict_ = dict_.setdefault(key, {})
     dict_[path[-1]] = value
+
+
+def _assert_statements_are_equivalent(statement_1: dict, statement_2: dict):  
+    """Check if statements are identical on fields not modified on input by the LRS.
+    
+    Fields not being compared are: "timestamp", "stored", "authority".
+    """
+    fields = ["actor", "verb", "object", "id", "result", "context", "attachements"]
+    assert all(statement_1.get(field) == statement_2.get(field) for field in fields)
+
+def assert_statement_get_responses_are_equivalent(response_1: dict, response_2: dict):
+    """Check if responses to GET /statements are equivalent.
+    
+    Compare if all statements in response are equivelent, meaning that all
+    fields not modified by the LRS are equal.
+    """
+
+    assert response_1.keys() == response_2.keys()
+
+    def _all_but_statements(response):
+        return {key: val for key, val in response.items() if key != "statements"}
+    
+    print('yolo yolo')
+    print(_all_but_statements(response_1))
+    print(_all_but_statements(response_2))
+    assert _all_but_statements(response_1) == _all_but_statements(response_2)
+
+    # Assert the statements part of the response is equivalent
+    assert "statements" in response_1.keys()
+    assert len(response_1["statements"]) == len(response_2["statements"])
+    for statement_1, statement_2 in zip(response_1["statements"], response_2["statements"]):
+        _assert_statements_are_equivalent(statement_1, statement_2)
+    
+def string_is_date(string):
+    try: 
+        parse(string)
+        return True
+    except:
+        return False

--- a/tests/api/test_scopes.py
+++ b/tests/api/test_scopes.py
@@ -1,0 +1,167 @@
+"""All tests relative to scopes and permissions."""
+
+from uuid import uuid4
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from ralph.api import app
+
+from tests.fixtures.auth import create_user
+
+client = TestClient(app)
+
+
+
+
+@pytest.mark.parametrize("user_scopes,query_options,is_authorized", [
+    (["statements/read/mine"], "", False),
+    (["statements/read/mine"], "?mine=True", True),
+
+    (["all"], "", True),
+    (["all"], "?mine=True", True),
+    (["all/read"], "", True),
+    (["statements/read"], "", True),
+    (["statements/read/mine", "statements/read"], "", True),
+])
+def test_api_statements_get_statements_scopes_mine(fs, user_scopes, query_options, is_authorized):
+    """Test that users with scopes limited to `statements/read/mine` are forced 
+    to use `mine` option in when querying `GET /statements`.
+    """
+
+    # Check for scope /statements/read/mine without `mine` option
+    user = "ralph"
+    pwd = "admin"
+    
+    auth_credentials =  create_user(fs, user, pwd, user_scopes)
+
+    statement = {"place": "holder"}
+
+    response = client.get(
+        f"/xAPI/statements/{query_options}",
+        headers={"Authorization": f"Basic {auth_credentials}"}
+    )
+    print('yolo')
+    print(user_scopes)
+    print(response.content)
+    if is_authorized:
+        assert response.status_code != 400
+    else:
+        assert response.status_code == 400
+        # TODO: add assertion on message
+
+
+
+@pytest.mark.parametrize("user_scopes,is_authorized", [
+    (["statements/read/mine"], False),
+    (["define"], False),
+    (["profile/read"], False),
+    (["statements/read"], False),
+    (["all/read"], False),
+
+    (["statements/write"], True),
+    (["all"], True),
+    (["profile/read", "all"], True),
+])
+def test_api_statements_put_statements_scopes(fs, user_scopes, is_authorized):
+    """Test PUT statements response code with authorized and unauthorized scopes.
+    
+    NB: This test ONLY covers endpoint access control. It does NOT cover any type 
+    of permissions as to the content that can be written.
+    """
+
+    user = "ralph"
+    pwd = "admin"
+    auth_credentials =  create_user(fs, user, pwd, user_scopes)
+
+    statement = {"place": "holder"}
+
+    response = client.put(
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+    
+    if is_authorized:
+        assert response.status_code != 401
+    else:
+        assert response.status_code == 401
+        assert response.json() == {
+            "detail": "User scopes do not allow access to the requested endpoint"
+        }
+
+@pytest.mark.parametrize("user_scopes,is_authorized", [
+    (["statements/read/mine"], False),
+    (["define"], False),
+    (["profile/read"], False),
+    (["statements/read"], False),
+    (["all/read"], False),
+
+    (["statements/write"], True),
+    (["all"], True),
+    (["profile/read", "all"], True),
+])
+def test_api_statements_post_statements_scopes(fs, user_scopes, is_authorized):
+    """Test POST statements response code with authorized and unauthorized scopes.
+    
+    NB: This test ONLY covers endpoint access control. It does NOT cover any type 
+    of permissions as to the content that can be written.
+    """
+
+    user = "ralph"
+    pwd = "admin"
+    auth_credentials =  create_user(fs, user, pwd, user_scopes)
+
+    statement = {"place": "holder"}
+
+    response = client.post(
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+    
+    if is_authorized:
+        assert response.status_code != 401
+    else:
+        assert response.status_code == 401
+        assert response.json() == {
+            "detail": "User scopes do not allow access to the requested endpoint"
+        }
+
+
+@pytest.mark.parametrize("user_scopes,is_authorized", [
+    (["define"], False),
+    (["profile/read"], False),
+    (["statements/write"], False),
+
+    (["statements/read/mine"], True),
+    (["statements/read"], True),
+    (["all/read"], True),
+    (["all"], True),
+    (["profile/read", "all"], True),
+])
+def test_api_statements_get_statements_scopes(fs, user_scopes, is_authorized):
+    """Test GET statements response code with authorized and unauthorized scopes.
+    """
+
+    user = "ralph"
+    pwd = "admin"
+    auth_credentials =  create_user(fs, user, pwd, user_scopes)
+
+    statement = {"place": "holder"}
+
+    response = client.get(
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {auth_credentials}"}
+    )
+    
+    if is_authorized:
+        assert response.status_code != 401
+    else:
+        assert response.status_code == 401
+        assert response.json() == {
+            "detail": "User scopes do not allow access to the requested endpoint"
+        }
+
+

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -104,9 +104,13 @@ def test_api_statements_get_statements(
             "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
         },
         {
+            "id": "a2956991-200b-40a7-9548-293cdcc06c4b",
+            "timestamp": (datetime.now() - timedelta(hours=2)).isoformat(),
+        },
+        {
             "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
             "timestamp": datetime.now().isoformat(),
-        },
+        }
     ]
     insert_statements_and_monkeypatch_backend(statements)
 
@@ -117,7 +121,8 @@ def test_api_statements_get_statements(
         )
 
         assert response.status_code == 200
-        assert response.json() == {"statements": [statements[1], statements[0]]}
+        # Confirm that results are in descending order
+        assert response.json() == {"statements": [statements[2], statements[0], statements[1]]}
 
 
 def test_api_statements_get_statements_ascending(
@@ -134,6 +139,10 @@ def test_api_statements_get_statements_ascending(
             "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
         },
         {
+            "id": "a2956991-200b-40a7-9548-293cdcc06c4b",
+            "timestamp": (datetime.now() - timedelta(hours=2)).isoformat(),
+        },
+        {
             "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
             "timestamp": datetime.now().isoformat(),
         },
@@ -146,7 +155,7 @@ def test_api_statements_get_statements_ascending(
     )
 
     assert response.status_code == 200
-    assert response.json() == {"statements": [statements[0], statements[1]]}
+    assert response.json() == {"statements": [statements[1], statements[0], statements[2]]}
 
 
 def test_api_statements_get_statements_by_statement_id(

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -118,10 +118,12 @@ def test_api_statements_post_pre_processing(
     assert "id" in response.json()['statements'][0]
 
     # Test pre-processing: timestamp
-    assert string_is_date(response.json()["statements"][0].get("timestamp"))
+    assert "timestamp" in response.json()["statements"][0]
+    assert string_is_date(response.json()["statements"][0]["timestamp"])
 
     # Test pre-processing: stored
-    assert string_is_date(response.json()["statements"][0].get("stored"))
+    assert "stored" in response.json()["statements"][0]
+    assert string_is_date(response.json()["statements"][0]["stored"])
 
     # Test pre-processing: authority
     # TODO

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -12,6 +12,7 @@ from ralph.backends.database.es import ESDatabase
 from ralph.backends.database.mongo import MongoDatabase
 from ralph.conf import XapiForwardingConfigurationSettings
 from ralph.exceptions import BackendException
+from ralph.utils import assert_statement_get_responses_are_equivalent, string_is_date
 
 from tests.fixtures.backends import (
     ES_TEST_FORWARDING_INDEX,
@@ -27,7 +28,6 @@ from tests.fixtures.backends import (
 )
 
 client = TestClient(app)
-
 
 @pytest.mark.parametrize(
     "backend",
@@ -70,7 +70,62 @@ def test_api_statements_post_single_statement_directly(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
+)
+# pylint: disable=too-many-arguments
+def test_api_statements_post_pre_processing(
+    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+):
+    """Tests the post statements pre-processing."""
+    # pylint: disable=invalid-name,unused-argument
+
+    monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
+    statement = {
+        "actor": {
+            "account": {
+                "homePage": "https://example.com/homepage/",
+                "name": str(uuid4()),
+            },
+            "objectType": "Agent",
+        },
+        "id": str(uuid4()),
+        "object": {"id": "https://example.com/object-id/1/"},
+        "timestamp": "2022-06-22T08:31:38Z",
+        "verb": {"id": "https://example.com/verb-id/1/"},
+    }
+
+    response = client.post(
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [statement["id"]]
+
+    es.indices.refresh()
+
+    response = client.get(
+        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+    )
+
+    # Test pre-processing: id
+    assert "id" in response.json()['statements'][0]
+
+    # Test pre-processing: timestamp
+    assert string_is_date(response.json()["statements"][0].get("timestamp"))
+
+    # Test pre-processing: stored
+    assert string_is_date(response.json()["statements"][0].get("stored"))
+
+    # Test pre-processing: authority
+    # TODO
+
 
 
 @pytest.mark.parametrize(
@@ -107,6 +162,12 @@ def test_api_statements_post_single_statement_no_trailing_slash(
 
     assert response.status_code == 200
     assert response.json() == [statement["id"]]
+
+    response = client.get(
+        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+    )
+    assert response.status_code == 200
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
 
 
 @pytest.mark.parametrize(
@@ -149,7 +210,7 @@ def test_api_statements_post_statements_list_of_one(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
 
 
 @pytest.mark.parametrize(
@@ -212,8 +273,7 @@ def test_api_statements_post_statements_list(
     assert get_response.status_code == 200
     # Update statements with the generated id.
     statements[1] = dict(statements[1], **{"id": generated_id})
-    assert get_response.json() == {"statements": statements}
-
+    assert_statement_get_responses_are_equivalent(get_response.json(), {"statements": statements})
 
 @pytest.mark.parametrize(
     "backend",
@@ -261,7 +321,8 @@ def test_api_statements_post_statements_list_with_duplicates(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": []}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": []})
+
 
 
 @pytest.mark.parametrize(
@@ -316,7 +377,7 @@ def test_api_statements_post_statements_list_with_duplicate_of_existing_statemen
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
 
 
 @pytest.mark.parametrize(
@@ -567,7 +628,8 @@ async def test_post_statements_list_with_statement_forwarding(
                 headers={"Authorization": f"Basic {auth_credentials}"},
             )
             assert response.status_code == 200
-            assert response.json() == {"statements": [statement]}
+            assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
     # The statement should also be stored on the receiving client
     async with AsyncClient() as receiving_client:
@@ -576,7 +638,8 @@ async def test_post_statements_list_with_statement_forwarding(
             headers={"Authorization": f"Basic {auth_credentials}"},
         )
         assert response.status_code == 200
-        assert response.json() == {"statements": [statement]}
+        assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
     # Stop receiving LRS client
     await lrs_context.__aexit__(None, None, None)

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -11,6 +11,7 @@ from ralph.backends.database.es import ESDatabase
 from ralph.backends.database.mongo import MongoDatabase
 from ralph.conf import XapiForwardingConfigurationSettings
 from ralph.exceptions import BackendException
+from ralph.utils import assert_statement_get_responses_are_equivalent, string_is_date
 
 from tests.fixtures.backends import (
     ES_TEST_FORWARDING_INDEX,
@@ -68,7 +69,63 @@ def test_api_statements_put_single_statement_directly(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
+)
+# pylint: disable=too-many-arguments
+def test_api_statements_put_pre_processing(
+    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+):
+    """Tests the put statements pre-processing."""
+    # pylint: disable=invalid-name,unused-argument
+
+    monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
+    statement = {
+        "actor": {
+            "account": {
+                "homePage": "https://example.com/homepage/",
+                "name": str(uuid4()),
+            },
+            "objectType": "Agent",
+        },
+        "id": str(uuid4()),
+        "object": {"id": "https://example.com/object-id/1/"},
+        "timestamp": "2022-06-22T08:31:38Z",
+        "verb": {"id": "https://example.com/verb-id/1/"},
+    }
+
+    response = client.put(
+        f"/xAPI/statements/?statementId={statement['id']}",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+
+    assert response.status_code == 204
+
+    es.indices.refresh()
+
+    response = client.get(
+        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+    )
+
+    # Test pre-processing: id
+    assert "id" in response.json()['statements'][0]
+
+    # Test pre-processing: timestamp
+    assert "timestamp" in response.json()["statements"][0]
+    assert string_is_date(response.json()["statements"][0]["timestamp"])
+
+    # Test pre-processing: stored
+    assert "stored" in response.json()["statements"][0]
+    assert string_is_date(response.json()["statements"][0]["stored"])
+
+    # Test pre-processing: authority
+    # TODO
+
 
 
 @pytest.mark.parametrize(
@@ -231,7 +288,8 @@ def test_api_statements_put_statement_duplicate_of_existing_statement(
         headers={"Authorization": f"Basic {auth_credentials}"},
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
 
 @pytest.mark.parametrize(
@@ -484,7 +542,8 @@ async def test_put_statement_with_statement_forwarding(
                 headers={"Authorization": f"Basic {auth_credentials}"},
             )
             assert response.status_code == 200
-            assert response.json() == {"statements": [statement]}
+            assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
     # The statement should also be stored on the receiving client
     async with AsyncClient() as receiving_client:
@@ -493,7 +552,8 @@ async def test_put_statement_with_statement_forwarding(
             headers={"Authorization": f"Basic {auth_credentials}"},
         )
         assert response.status_code == 200
-        assert response.json() == {"statements": [statement]}
+        assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
     # Stop receiving LRS client
     await lrs_context.__aexit__(None, None, None)

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -1,37 +1,55 @@
 """Test fixtures related to authentication on the API."""
 import base64
 import json
+import os
 
 import bcrypt
 import pytest
 
+from ralph.api.auth import get_stored_credentials
 from ralph.conf import settings
 
 
-# pylint: disable=invalid-name
-@pytest.fixture
-def auth_credentials(fs):
-    """Sets up the credentials file for request authentication.
-
-    Returns:
-        credentials (str): auth parameters that need to be passed
-            through headers to authenticate the request.
-    """
-    credential_bytes = base64.b64encode("ralph:admin".encode("utf-8"))
+def create_user(fs, user, pwd, scopes):
+    """Create a user in the (fake) file system"""
+    credential_bytes = base64.b64encode(f"{user}:{pwd}".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
+    auth_file_path = settings.AUTH_FILE #settings.APP_DIR / "auth.json"
 
-    auth_file_path = settings.APP_DIR / "auth.json"
+    # Clear lru_cache to allow for auth testing within same function
+    get_stored_credentials.cache_clear()
+
     fs.create_file(
         auth_file_path,
         contents=json.dumps(
             [
                 {
-                    "username": "ralph",
-                    "hash": bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode("UTF-8"),
-                    "scopes": ["ralph_test_scope"],
+                    "username": user,
+                    "hash": bcrypt.hashpw(bytes(pwd.encode("utf-8")), bcrypt.gensalt()).decode("UTF-8"),
+                    "scopes": scopes,
                 }
             ]
         ),
     )
+    return credentials 
+
+# pylint: disable=invalid-name
+@pytest.fixture
+def auth_credentials(fs, user_scopes=['all']):
+    """Sets up the credentials file for request authentication.
+
+    Args:
+        fs: fixture provided by pyfakefs (not called in the code)
+
+    Returns:
+        credentials (str): auth parameters that need to be passed
+            through headers to authenticate the request.
+    """
+
+    user = "ralph"
+    pwd = "admin"
+    #scopes = ["statements/read", "statements/write"]
+
+    credentials = create_user(fs, user, pwd, user_scopes)
 
     return credentials

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,9 +120,14 @@ def test_utils_set_dict_value_from_path_updating_fields():
 
 
 def test_utils_assert_statement_get_responses_are_equivalent():
-    """Test the equivalency assertion for get responses."""
+    """Test the equivalency assertion for get responses.
+    
+    Equivalency (term NOT in specifaction) means that two statements have 
+    identical values on all fields except `authority`, `stored` and `timestamp`
+    (where the value may or may not be identical).
+    """
     statement_1 = {
-        "actor": "actor_1",
+        "actor": {"actor_field": "actor_1"},
         "verb": "verb_1",
         "object": "object_1",
         "id": "id_1",
@@ -136,7 +141,7 @@ def test_utils_assert_statement_get_responses_are_equivalent():
     }
 
     statement_2 = {
-        "actor": "actor_1",
+        "actor": {"actor_field": "actor_1"},
         "verb": "verb_1",
         "object": "object_1",
         "id": "id_1",
@@ -150,7 +155,7 @@ def test_utils_assert_statement_get_responses_are_equivalent():
     }
 
     statement_3 = {
-        "actor": "actor_3",
+        "actor": {"actor_field": "actor_3"},
         "verb": "verb_1",
         "object": "object_1",
         "id": "id_1",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,3 +117,68 @@ def test_utils_set_dict_value_from_path_updating_fields():
     dictionary = {"foo": {"bar": "bar_value"}}
     ralph_utils.set_dict_value_from_path(dictionary, ["foo", "bar"], "baz")
     assert dictionary == {"foo": {"bar": "baz"}}
+
+
+def test_utils_assert_statement_get_responses_are_equivalent():
+    """Test the equivalency assertion for get responses."""
+    statement_1 = {
+        "actor": "actor_1",
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+
+        "timestamp": "timestamp_1",
+        "stored": "stored_1",
+        "authority": "authority_1"
+    }
+
+    statement_2 = {
+        "actor": "actor_1",
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+
+        "timestamp": "timestamp_2",
+        "stored": "stored_2",
+        "authority": "authority_2",
+    }
+
+    statement_3 = {
+        "actor": "actor_3",
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+
+        "timestamp": "timestamp_1",
+        "stored": "stored_1",
+        "authority": "authority_1",
+    }
+
+    get_response_1 = {"statements": [statement_1]}
+    get_response_2 = {"statements": [statement_2]}
+    get_response_3 = {"statements": [statement_3]}
+
+    # Test that statements 1 and 2 are equivalent
+    ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_2)
+
+    # Test that statements 1 and 3 are NOT equivalent
+    with pytest.raises(AssertionError):
+        ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_3)
+
+
+def test_utils_string_is_date():
+    """Test that strings representing dates are properly identified."""
+    string = '2022-06-22T08:31:38Z'
+    assert ralph_utils.string_is_date(string)
+
+    string = '40223-06-22T08:31:38Z'
+    assert not ralph_utils.string_is_date(string)


### PR DESCRIPTION
# STALE BRANCH, PR KEPT OPEN FOR REFERENCE

## Purpose

Currently, the API has no restriction to the data / endpoints available. All authenticated users have unlimited read and write access, through all endpoints. The purpose, of this PR, (initiated by #288) is to add security mechanism including scopes and permissions. The xAPI specification suggests [these scopes](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#details-15).

**NB:** The term "scope" is used losely, as the authentification mode (for now) is Basic Auth ("scope" is usually used in the context of OAuth). We use the term in a similar sense but applied to a user. (eg. "a user has the right to access scope `/statements/read/mine`"). 

## Proposal

Adding scopes is relatively straightforward except for the scope `/statements/read/mine`, which requires to add a notion of belonging to the statements being stored. This notion is [covered by the xAPI specification](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#231-statement-immutability) under the name "Authority", which is a field that SHOULD be created by the LRS upon receiving statements and populated with the requesting user account information. This `authority`  field may then be used to filter incoming queries and/or results. 

The proposed solution (a first pass) includes pre-processing the data to add "Authority", implementing scopes, and adding a permissions mechanism which forces user to query using an `authority` field, when the broadest scope available is `/statements/read/mine`.

The proposed pre-processing also handles annex [LRS conformity issues,](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#231-statement-immutability) by adding to the statements the fields `timestamp`, `stored` and `id` (when not present).

Description...

- [x] Add statement pre-processing on `POST` and `PUT` for `timestamp`, `stored`, `id`
- [x] Test pre-processing for `timestamp`, `stored`, `id`  for `PUT`
- [x] Test pre-processing for `timestamp`, `stored`, `id`  for `POST`
- [x] Refactor endpoint tests to work with pre-processing (`GET`, `POST`, `PUT`)
- [x] Test new helper functions in utils
- [x] Add authority to databases and query statements
- [x] Decide whether or not to authorize same authority for different users
- [x] Test querying by authority
- [x] Add statement pre-processing on `POST` and `PUT` for `authority` (separate as it is a more complex issue)
- [x] Test pre-processing for `authority` for `POST`
- [x] Test pre-processing for `authority` for `PUT`
- [x] Add "scope" (see above) mechanism to auth, to restrict access to endpoints
- [ ] Test "scope" mechanism (especially test permissions vulnerabilities)
- [ ] Add permissions mechanism to get
- [ ] Test permission mechanism
- [ ] Update CHANGELOG
 
