### PR TITLE
⬆️(tray) upgrade deprecated api in k8s manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Upgrade `sentry_sdk` to `1.20.0`
 - LRS `/statements` `GET` method returns a code 400 with certain parameters
 as per the xAPI specification
+- Use batch/v1 api in cronjob_pipeline manifest
 
 ## [3.5.1] - 2023-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - LRS `/statements` `GET` method returns a code 400 with certain parameters
 as per the xAPI specification
 - Use batch/v1 api in cronjob_pipeline manifest
+- Use autoscaling/v2 in HorizontalPodAutoscaler manifest
 
 ## [3.5.1] - 2023-04-18
 

--- a/src/helm/ralph/templates/hpa.yaml
+++ b/src/helm/ralph/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "ralph.fullname" . }}

--- a/src/tray/templates/services/app/cronjob_pipeline.yml.j2
+++ b/src/tray/templates/services/app/cronjob_pipeline.yml.j2
@@ -1,9 +1,9 @@
 {% if ralph_cronjobs | length > 0 %}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJobList
 items:
 {% for cronjob in ralph_cronjobs %}
-  - apiVersion: batch/v1beta1
+  - apiVersion: batch/v1
     kind: CronJob
     metadata:
       name: "ralph-{{ cronjob.name }}"


### PR DESCRIPTION
## Purpose

The batch/v1beta1 API is deprecated since kubernets 1.21 and is removed
in version 1.25. We can upgrade the manifests to use the batch/v1 api now.

Also, the autoscaling/v2beta1 API is deprecated since kubernetes 1.23 and is
removed in version 1.25. We can upgrade the manifests to use the
autoscaling/v2 api now.

## Proposal

- [x] use batch/v1 api in cronjob_pipeline manifest
- [x] use autoscaling/v2 api in HorizontalPodAutoscaler manifest 

