### PR TITLE
Integrate mypy for Python type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,11 @@ lint-pydocstyle: ## lint Python docstrings with pydocstyle
 	@$(COMPOSE_TEST_RUN_APP) pydocstyle
 .PHONY: lint-pydocstyle
 
+lint-mypy: ## lint back-end python sources with mypy
+	@echo 'lint:mypy started…'
+	@$(COMPOSE_TEST_RUN_APP) mypy
+.PHONY: lint-mypy
+
 logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app
 .PHONY: logs

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ dev =
     mkdocs-material==9.4.6
     mkdocstrings[python-legacy]==0.23.0
     moto==4.2.6
+    mypy==1.2.0
     pydocstyle==6.3.0
     pyfakefs==5.3.0
     pylint==3.0.2
@@ -92,6 +93,10 @@ dev =
     pytest-httpx<0.23.0 # pin as Python 3.7 and 3.8 is no longer supported from release 0.23.0
     requests-mock==1.11.0
     responses<0.23.2 # pin until boto3 supports urllib3>=2
+    types-python-dateutil == 2.8.19.14
+    types-python-jose == 3.3.4.8
+    types-requests<2.31.0.7
+    types-cachetools == 5.3.0.6
 ci =
     twine==4.0.2
 lrs =
@@ -134,16 +139,49 @@ exclude =
     node_modules,
     */migrations/*
 
-[pydocstyle]
-convention = google
-match_dir = ^(?!tests|venv|build|scripts).*
-match = ^(?!(setup)\.(py)$).*\.(py)$
-
 [isort]
 known_ralph=ralph
 sections=FUTURE,STDLIB,THIRDPARTY,RALPH,FIRSTPARTY,LOCALFOLDER
 skip_glob=venv,*/.conda/*
 profile=black
+
+[pydocstyle]
+convention = google
+match_dir = ^(?!tests|venv|build|scripts).*
+match = ^(?!(setup)\.(py)$).*\.(py)$
+
+[mypy]
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_defs = True
+files=src/ralph/**/*.py
+plugins = pydantic.mypy
+
+[mypy-rfc3987.*]
+ignore_missing_imports = True
+
+[mypy-requests_toolbelt.*]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-boto3.*]
+ignore_missing_imports = True
+
+[mypy-clickhouse_connect.*]
+ignore_missing_imports = True
+
+[mypy-ovh.*]
+ignore_missing_imports = True
+
+[mypy-swiftclient.service.*]
+ignore_missing_imports = True
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
 
 [tool:pytest]
 addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=ralph

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,5 +1,6 @@
 """Main module for Ralph's LRS API."""
 from functools import lru_cache
+from typing import Any, Dict, List, Union
 from urllib.parse import urlparse
 
 import sentry_sdk
@@ -14,12 +15,14 @@ from .routers import health, statements
 
 
 @lru_cache(maxsize=None)
-def get_health_check_routes():
+def get_health_check_routes() -> List:
     """Return the health check routes."""
     return [route.path for route in health.router.routes]
 
 
-def filter_transactions(event, hint):  # pylint: disable=unused-argument
+def filter_transactions(
+    event: Dict, hint  # pylint: disable=unused-argument
+) -> Union[Dict, None]:
     """Filter transactions for Sentry."""
     url = urlparse(event["request"]["url"])
 
@@ -47,6 +50,6 @@ app.include_router(health.router)
 @app.get("/whoami")
 async def whoami(
     user: AuthenticatedUser = Depends(get_authenticated_user),
-):
+) -> Dict[str, Any]:
     """Return the current user's username along with their scopes."""
     return {"agent": user.agent, "scopes": user.scopes}

--- a/src/ralph/api/auth/basic.py
+++ b/src/ralph/api/auth/basic.py
@@ -4,7 +4,7 @@ import logging
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
-from typing import List, Union
+from typing import Any, Iterator, List, Optional
 
 import bcrypt
 from cachetools import TTLCache, cached
@@ -53,21 +53,21 @@ class ServerUsersCredentials(BaseModel):
 
     __root__: List[UserCredentials]
 
-    def __add__(self, other):  # noqa: D105
+    def __add__(self, other) -> Any:  # noqa: D105
         return ServerUsersCredentials.parse_obj(self.__root__ + other.__root__)
 
-    def __getitem__(self, item: int):  # noqa: D105
+    def __getitem__(self, item: int) -> UserCredentials:  # noqa: D105
         return self.__root__[item]
 
-    def __len__(self):  # noqa: D105
+    def __len__(self) -> int:  # noqa: D105
         return len(self.__root__)
 
-    def __iter__(self):  # noqa: D105
+    def __iter__(self) -> Iterator[UserCredentials]:  # noqa: D105
         return iter(self.__root__)
 
     @root_validator
     @classmethod
-    def ensure_unique_username(cls, values):
+    def ensure_unique_username(cls, values: Any) -> Any:
         """Every username should be unique among registered users."""
         usernames = [entry.username for entry in values.get("__root__")]
         if len(usernames) != len(set(usernames)):
@@ -111,7 +111,7 @@ def get_stored_credentials(auth_file: Path) -> ServerUsersCredentials:
     else None,
 )
 def get_basic_auth_user(
-    credentials: Union[HTTPBasicCredentials, None] = Depends(security),
+    credentials: Optional[HTTPBasicCredentials] = Depends(security),
     security_scopes: SecurityScopes = SecurityScopes([]),
 ) -> AuthenticatedUser:
     """Checks valid auth parameters.

--- a/src/ralph/api/auth/oidc.py
+++ b/src/ralph/api/auth/oidc.py
@@ -2,7 +2,7 @@
 
 import logging
 from functools import lru_cache
-from typing import Optional
+from typing import Dict, Optional
 
 import requests
 from fastapi import Depends, HTTPException, status
@@ -54,7 +54,7 @@ class IDToken(BaseModel):
 
 
 @lru_cache()
-def discover_provider(base_url: AnyUrl) -> dict:
+def discover_provider(base_url: AnyUrl) -> Dict:
     """Discover the authentication server (or OpenId Provider) configuration."""
     try:
         response = requests.get(f"{base_url}{OPENID_CONFIGURATION_PATH}", timeout=5)
@@ -72,7 +72,7 @@ def discover_provider(base_url: AnyUrl) -> dict:
 
 
 @lru_cache()
-def get_public_keys(jwks_uri: AnyUrl) -> dict:
+def get_public_keys(jwks_uri: AnyUrl) -> Dict:
     """Retrieve the public keys used by the provider server for signing."""
     try:
         response = requests.get(jwks_uri, timeout=5)

--- a/src/ralph/api/forwarding.py
+++ b/src/ralph/api/forwarding.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @lru_cache
 def get_active_xapi_forwardings() -> List[XapiForwardingConfigurationSettings]:
     """Return a list of active xAPI forwarding configuration settings."""
-    active_forwardings = []
+    active_forwardings: List = []
     if not settings.XAPI_FORWARDINGS:
         logger.info("No xAPI forwarding configured; forwarding is disabled.")
         return active_forwardings
@@ -34,7 +34,7 @@ def get_active_xapi_forwardings() -> List[XapiForwardingConfigurationSettings]:
 
 async def forward_xapi_statements(
     statements: Union[dict, List[dict]], method: Literal["post", "put"]
-):
+) -> None:
     """Forward xAPI statements."""
     for forwarding in get_active_xapi_forwardings():
         transport = AsyncHTTPTransport(retries=forwarding.max_retries)

--- a/src/ralph/api/routers/health.py
+++ b/src/ralph/api/routers/health.py
@@ -22,7 +22,7 @@ BACKEND_CLIENT: Union[BaseLRSBackend, BaseAsyncLRSBackend] = get_backend_instanc
 
 
 @router.get("/__lbheartbeat__")
-async def lbheartbeat():
+async def lbheartbeat() -> None:
     """Load balancer heartbeat.
 
     Returns a 200 when the server is running.
@@ -31,7 +31,7 @@ async def lbheartbeat():
 
 
 @router.get("/__heartbeat__")
-async def heartbeat():
+async def heartbeat() -> JSONResponse:
     """Application heartbeat.
 
     Returns a 200 if all checks are successful.

--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -3,7 +3,7 @@
 import logging
 from io import IOBase
 from itertools import chain
-from typing import Iterable, Iterator, Union
+from typing import Iterable, Iterator, Optional, Union
 
 from elasticsearch import ApiError, AsyncElasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, async_streaming_bulk
@@ -30,7 +30,7 @@ class AsyncESDataBackend(BaseAsyncDataBackend):
     query_model = ESQuery
     settings_class = ESDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[ESDataBackendSettings] = None):
         """Instantiate the asynchronous Elasticsearch client.
 
         Args:
@@ -70,7 +70,7 @@ class AsyncESDataBackend(BaseAsyncDataBackend):
         return DataBackendStatus.ERROR
 
     async def list(
-        self, target: str = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List available Elasticsearch indices, data streams and aliases.
 
@@ -113,8 +113,8 @@ class AsyncESDataBackend(BaseAsyncDataBackend):
     async def read(
         self,
         *,
-        query: Union[str, ESQuery] = None,
-        target: str = None,
+        query: Optional[Union[str, ESQuery]] = None,
+        target: Optional[str] = None,
         chunk_size: Union[None, int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -4,7 +4,7 @@ import json
 import logging
 from io import IOBase
 from itertools import chain
-from typing import Any, Dict, Iterable, Iterator, Union
+from typing import Any, Dict, Iterable, Iterator, Optional, Union
 
 from bson.errors import BSONError
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -36,7 +36,7 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend):
     query_model = MongoQuery
     settings_class = MongoDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[MongoDataBackendSettings] = None):
         """Instantiate the asynchronous MongoDB client.
 
         Args:
@@ -74,7 +74,7 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend):
         return DataBackendStatus.OK
 
     async def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List collections in the target database.
 
@@ -118,9 +118,9 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend):
     async def read(
         self,
         *,
-        query: Union[str, MongoQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, MongoQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -179,10 +179,10 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend):
     async def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write data documents to the target collection and return their count.
 

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum, unique
 from io import IOBase
-from typing import Iterable, Iterator, Union
+from typing import Iterable, Iterator, Optional, Union
 
 from pydantic import BaseModel, BaseSettings, ValidationError
 
@@ -89,7 +89,7 @@ class BaseDataBackend(ABC):
     settings_class = BaseDataBackendSettings
 
     @abstractmethod
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[BaseDataBackendSettings] = None):
         """Instantiate the data backend.
 
         Args:
@@ -137,7 +137,7 @@ class BaseDataBackend(ABC):
 
     @abstractmethod
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List containers in the data backend. E.g., collections, files, indexes.
 
@@ -161,9 +161,9 @@ class BaseDataBackend(ABC):
     def read(
         self,
         *,
-        query: Union[str, BaseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -199,10 +199,10 @@ class BaseDataBackend(ABC):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write `data` records to the `target` container and return their count.
 
@@ -262,7 +262,7 @@ class BaseAsyncDataBackend(ABC):
     settings_class = BaseDataBackendSettings
 
     @abstractmethod
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[BaseDataBackendSettings] = None):
         """Instantiate the data backend.
 
         Args:
@@ -310,7 +310,7 @@ class BaseAsyncDataBackend(ABC):
 
     @abstractmethod
     async def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List containers in the data backend. E.g., collections, files, indexes.
 
@@ -334,9 +334,9 @@ class BaseAsyncDataBackend(ABC):
     async def read(
         self,
         *,
-        query: Union[str, BaseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -372,10 +372,10 @@ class BaseAsyncDataBackend(ABC):
     async def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write `data` records to the `target` container and return their count.
 

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -5,7 +5,17 @@ import logging
 from datetime import datetime
 from io import IOBase
 from itertools import chain
-from typing import Any, Dict, Generator, Iterable, Iterator, List, NamedTuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Union,
+)
 from uuid import UUID, uuid4
 
 import clickhouse_connect
@@ -107,7 +117,7 @@ class ClickHouseDataBackend(BaseDataBackend):
     default_operation_type = BaseOperationType.CREATE
     settings_class = ClickHouseDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[ClickHouseDataBackendSettings] = None):
         """Instantiate the ClickHouse configuration.
 
         Args:
@@ -156,7 +166,7 @@ class ClickHouseDataBackend(BaseDataBackend):
         return DataBackendStatus.OK
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List tables for a given database.
 
@@ -191,9 +201,9 @@ class ClickHouseDataBackend(BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, ClickHouseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, ClickHouseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -285,10 +295,10 @@ class ClickHouseDataBackend(BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write `data` documents to the `target` table and return their count.
 
@@ -420,7 +430,10 @@ class ClickHouseDataBackend(BaseDataBackend):
             yield insert_tuple
 
     def _bulk_import(
-        self, batch: list, ignore_errors: bool = False, event_table_name: str = None
+        self,
+        batch: list,
+        ignore_errors: bool = False,
+        event_table_name: Optional[str] = None,
     ):
         """Insert a batch of documents into the selected database table."""
         try:

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -4,7 +4,7 @@ import logging
 from io import IOBase
 from itertools import chain
 from pathlib import Path
-from typing import Iterable, Iterator, List, Literal, Union
+from typing import Iterable, Iterator, List, Literal, Optional, Union
 
 from elasticsearch import ApiError, Elasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, streaming_bulk
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 class ESClientOptions(ClientOptions):
     """Elasticsearch additional client options."""
 
-    ca_certs: Path = None
-    verify_certs: bool = None
+    ca_certs: Optional[Path] = None
+    verify_certs: Optional[bool] = None
 
 
 class ESDataBackendSettings(BaseDataBackendSettings):
@@ -116,7 +116,7 @@ class ESDataBackend(BaseDataBackend):
     query_model = ESQuery
     settings_class = ESDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[ESDataBackendSettings] = None):
         """Instantiate the Elasticsearch data backend.
 
         Args:
@@ -156,7 +156,7 @@ class ESDataBackend(BaseDataBackend):
         return DataBackendStatus.ERROR
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List available Elasticsearch indices, data streams and aliases.
 
@@ -199,9 +199,9 @@ class ESDataBackend(BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, ESQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, ESQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -277,10 +277,10 @@ class ESDataBackend(BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write data documents to the target index and return their count.
 

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from io import IOBase
 from itertools import chain
 from pathlib import Path
-from typing import IO, Iterable, Iterator, Union
+from typing import IO, Iterable, Iterator, Optional, Union
 from uuid import uuid4
 
 from ralph.backends.data.base import (
@@ -56,7 +56,7 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
     default_operation_type = BaseOperationType.CREATE
     settings_class = FSDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[FSDataBackendSettings] = None):
         """Create the default target directory if it does not exist.
 
         Args:
@@ -90,7 +90,7 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
         return DataBackendStatus.OK
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List files and directories in the target directory.
 
@@ -110,7 +110,7 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
         Raises:
             BackendParameterException: If the `target` argument is not a directory path.
         """
-        target = Path(target) if target else self.default_directory
+        target: Path = Path(target) if target else self.default_directory
         if not target.is_absolute() and target != self.default_directory:
             target = self.default_directory / target
         try:
@@ -145,9 +145,9 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, BaseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -218,10 +218,10 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write data records to the target file and return their count.
 

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -1,7 +1,7 @@
 """OVH's LDP data backend for Ralph."""
 
 import logging
-from typing import Iterable, Iterator, Literal, Union
+from typing import Iterable, Iterator, Literal, Optional, Union
 
 import ovh
 import requests
@@ -40,10 +40,10 @@ class LDPDataBackendSettings(BaseDataBackendSettings):
 
         env_prefix = "RALPH_BACKENDS__DATA__LDP__"
 
-    APPLICATION_KEY: str = None
-    APPLICATION_SECRET: str = None
-    CONSUMER_KEY: str = None
-    DEFAULT_STREAM_ID: str = None
+    APPLICATION_KEY: Optional[str] = None
+    APPLICATION_SECRET: Optional[str] = None
+    CONSUMER_KEY: Optional[str] = None
+    DEFAULT_STREAM_ID: Optional[str] = None
     ENDPOINT: Literal[
         "ovh-eu",
         "ovh-us",
@@ -53,8 +53,8 @@ class LDPDataBackendSettings(BaseDataBackendSettings):
         "soyoustart-eu",
         "soyoustart-ca",
     ] = "ovh-eu"
-    REQUEST_TIMEOUT: int = None
-    SERVICE_NAME: str = None
+    REQUEST_TIMEOUT: Optional[int] = None
+    SERVICE_NAME: Optional[str] = None
 
 
 class LDPDataBackend(HistoryMixin, BaseDataBackend):
@@ -63,7 +63,7 @@ class LDPDataBackend(HistoryMixin, BaseDataBackend):
     name = "ldp"
     settings_class = LDPDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[LDPDataBackendSettings] = None):
         """Instantiate the OVH LDP client.
 
         Args:
@@ -101,7 +101,7 @@ class LDPDataBackend(HistoryMixin, BaseDataBackend):
         return DataBackendStatus.OK
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List archives for a given target stream_id.
 
@@ -150,9 +150,9 @@ class LDPDataBackend(HistoryMixin, BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, BaseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = 4096,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = 4096,
         raw_output: bool = True,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -217,10 +217,10 @@ class LDPDataBackend(HistoryMixin, BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Iterable[Union[bytes, dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """LDP data backend is read-only, calling this method will raise an error."""
         msg = "LDP data backend is read-only, cannot write to %s"

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -7,7 +7,7 @@ import logging
 import struct
 from io import IOBase
 from itertools import chain
-from typing import Generator, Iterable, Iterator, List, Tuple, Union
+from typing import Generator, Iterable, Iterator, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from bson.errors import BSONError
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 class MongoClientOptions(ClientOptions):
     """MongoDB additional client options."""
 
-    document_class: str = None
-    tz_aware: bool = None
+    document_class: Optional[str] = None
+    tz_aware: Optional[bool] = None
 
 
 class MongoDataBackendSettings(BaseDataBackendSettings):
@@ -96,7 +96,7 @@ class MongoDataBackend(BaseDataBackend):
     query_model = MongoQuery
     settings_class = MongoDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[MongoDataBackendSettings] = None):
         """Instantiate the MongoDB client.
 
         Args:
@@ -135,7 +135,7 @@ class MongoDataBackend(BaseDataBackend):
         return DataBackendStatus.OK
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List collections in the `target` database.
 
@@ -174,9 +174,9 @@ class MongoDataBackend(BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, MongoQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, MongoQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -231,10 +231,10 @@ class MongoDataBackend(BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write `data` documents to the `target` collection and return their count.
 
@@ -397,7 +397,7 @@ class MongoDataBackend(BaseDataBackend):
             yield document
 
     @staticmethod
-    def _bulk_import(batch: list, ignore_errors: bool, collection: Collection):
+    def _bulk_import(batch: List, ignore_errors: bool, collection: Collection) -> int:
         """Insert a `batch` of documents into the MongoDB `collection`."""
         try:
             new_documents = collection.insert_many(batch)
@@ -414,7 +414,7 @@ class MongoDataBackend(BaseDataBackend):
         return inserted_count
 
     @staticmethod
-    def _bulk_delete(batch: list, ignore_errors: bool, collection: Collection):
+    def _bulk_delete(batch: List, ignore_errors: bool, collection: Collection) -> int:
         """Delete a `batch` of documents from the MongoDB `collection`."""
         try:
             deleted_documents = collection.delete_many({"_source.id": {"$in": batch}})
@@ -431,7 +431,7 @@ class MongoDataBackend(BaseDataBackend):
         return deleted_count
 
     @staticmethod
-    def _bulk_update(batch: list, ignore_errors: bool, collection: Collection):
+    def _bulk_update(batch: List, ignore_errors: bool, collection: Collection) -> int:
         """Update a `batch` of documents into the MongoDB `collection`."""
         try:
             updated_documents = collection.bulk_write(batch)

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -4,7 +4,7 @@ import json
 import logging
 from io import IOBase
 from itertools import chain
-from typing import Iterable, Iterator, Union
+from typing import Iterable, Iterator, Optional, Union
 from uuid import uuid4
 
 import boto3
@@ -72,7 +72,7 @@ class S3DataBackend(HistoryMixin, BaseDataBackend):
     default_operation_type = BaseOperationType.CREATE
     settings_class = S3DataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[S3DataBackendSettings] = None):
         """Instantiate the AWS S3 client."""
         self.settings = settings if settings else self.settings_class()
 
@@ -109,7 +109,7 @@ class S3DataBackend(HistoryMixin, BaseDataBackend):
         return DataBackendStatus.OK
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List objects for the target bucket.
 
@@ -157,9 +157,9 @@ class S3DataBackend(HistoryMixin, BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, BaseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -230,10 +230,10 @@ class S3DataBackend(HistoryMixin, BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write `data` records to the `target` bucket and return their count.
 

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -4,7 +4,7 @@ import json
 import logging
 from functools import cached_property
 from io import IOBase
-from typing import Iterable, Iterator, Union
+from typing import Iterable, Iterator, Optional, Union
 from uuid import uuid4
 
 from swiftclient.service import ClientException, Connection
@@ -71,7 +71,7 @@ class SwiftDataBackend(HistoryMixin, BaseDataBackend):
     default_operation_type = BaseOperationType.CREATE
     settings_class = SwiftDataBackendSettings
 
-    def __init__(self, settings: Union[settings_class, None] = None):
+    def __init__(self, settings: Optional[SwiftDataBackendSettings] = None):
         """Prepares the options for the SwiftService."""
         self.settings = settings if settings else self.settings_class()
 
@@ -120,7 +120,7 @@ class SwiftDataBackend(HistoryMixin, BaseDataBackend):
         return DataBackendStatus.OK
 
     def list(
-        self, target: Union[str, None] = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List files for the target container.
 
@@ -162,9 +162,9 @@ class SwiftDataBackend(HistoryMixin, BaseDataBackend):
     def read(
         self,
         *,
-        query: Union[str, BaseQuery] = None,
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = 500,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = 500,
         raw_output: bool = False,
         ignore_errors: bool = False,
     ) -> Iterator[Union[bytes, dict]]:
@@ -241,10 +241,10 @@ class SwiftDataBackend(HistoryMixin, BaseDataBackend):
     def write(  # pylint: disable=too-many-arguments, disable=too-many-branches
         self,
         data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Union[str, None] = None,
-        chunk_size: Union[int, None] = None,
+        target: Optional[str] = None,
+        chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
-        operation_type: Union[BaseOperationType, None] = None,
+        operation_type: Optional[BaseOperationType] = None,
     ) -> int:
         """Write `data` records to the `target` container and returns their count.
 

--- a/src/ralph/backends/http/async_lrs.py
+++ b/src/ralph/backends/http/async_lrs.py
@@ -106,7 +106,7 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
     settings_class = LRSHTTPBackendSettings
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, settings: settings_class = None
+        self, settings: Optional[LRSHTTPBackendSettings] = None
     ):
         """Instantiate the LRS HTTP (basic auth) backend client.
 
@@ -119,7 +119,7 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
         self.base_url = parse_obj_as(AnyHttpUrl, self.settings.BASE_URL)
         self.auth = (self.settings.USERNAME, self.settings.PASSWORD)
 
-    async def status(self):
+    async def status(self) -> HTTPBackendStatus:
         """HTTP backend check for server status."""
         status_url = urljoin(self.base_url, self.settings.STATUS_ENDPOINT)
 
@@ -139,7 +139,7 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
         return HTTPBackendStatus.OK
 
     async def list(
-        self, target: str = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """Raise error for unsupported `list` method."""
         msg = "LRS HTTP backend does not support `list` method, cannot list from %s"
@@ -150,8 +150,8 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
     @enforce_query_checks
     async def read(  # pylint: disable=too-many-arguments
         self,
-        query: Union[str, LRSStatementsQuery] = None,
-        target: str = None,
+        query: Optional[Union[str, LRSStatementsQuery]] = None,
+        target: Optional[str] = None,
         chunk_size: Optional[PositiveInt] = 500,
         raw_output: bool = False,
         ignore_errors: bool = False,

--- a/src/ralph/backends/http/base.py
+++ b/src/ralph/backends/http/base.py
@@ -85,7 +85,9 @@ class BaseHTTPBackend(ABC):
     name = "base"
     query = BaseQuery
 
-    def validate_query(self, query: Union[str, dict, BaseQuery] = None) -> BaseQuery:
+    def validate_query(
+        self, query: Optional[Union[str, dict, BaseQuery]] = None
+    ) -> BaseQuery:
         """Validate and transforms the query."""
         if query is None:
             query = self.query()
@@ -114,7 +116,7 @@ class BaseHTTPBackend(ABC):
 
     @abstractmethod
     async def list(
-        self, target: str = None, details: bool = False, new: bool = False
+        self, target: Optional[str] = None, details: bool = False, new: bool = False
     ) -> Iterator[Union[str, dict]]:
         """List containers in the data backend. E.g., collections, files, indexes."""
 
@@ -126,8 +128,8 @@ class BaseHTTPBackend(ABC):
     @enforce_query_checks
     async def read(  # pylint: disable=too-many-arguments
         self,
-        query: Union[str, BaseQuery] = None,
-        target: str = None,
+        query: Optional[Union[str, BaseQuery]] = None,
+        target: Optional[str] = None,
         chunk_size: Optional[PositiveInt] = 500,
         raw_output: bool = False,
         ignore_errors: bool = False,

--- a/src/ralph/backends/http/lrs.py
+++ b/src/ralph/backends/http/lrs.py
@@ -1,7 +1,9 @@
 """LRS HTTP backend for Ralph."""
 import asyncio
+from typing import Iterator, Union
 
 from ralph.backends.http.async_lrs import AsyncLRSHTTPBackend
+from ralph.backends.http.base import HTTPBackendStatus
 
 
 def _ensure_running_loop_uniqueness(func):
@@ -33,21 +35,21 @@ class LRSHTTPBackend(AsyncLRSHTTPBackend):
     name = "lrs"
 
     @_ensure_running_loop_uniqueness
-    def status(self, *args, **kwargs):
+    def status(self, *args, **kwargs) -> HTTPBackendStatus:
         """HTTP backend check for server status."""
         return asyncio.get_event_loop().run_until_complete(
             super().status(*args, **kwargs)
         )
 
     @_ensure_running_loop_uniqueness
-    def list(self, *args, **kwargs):
+    def list(self, *args, **kwargs) -> Iterator[Union[str, dict]]:
         """Raise error for unsupported `list` method."""
         return asyncio.get_event_loop().run_until_complete(
             super().list(*args, **kwargs)
         )
 
     @_ensure_running_loop_uniqueness
-    def read(self, *args, **kwargs):
+    def read(self, *args, **kwargs) -> Iterator[Union[bytes, dict]]:
         """Get statements from LRS `target` endpoint.
 
         See AsyncLRSHTTP.read for more information.
@@ -61,7 +63,7 @@ class LRSHTTPBackend(AsyncLRSHTTPBackend):
             pass
 
     @_ensure_running_loop_uniqueness
-    def write(self, *args, **kwargs):
+    def write(self, *args, **kwargs) -> int:
         """Write `data` records to the `target` endpoint and return their count.
 
         See AsyncLRSHTTP.write for more information.

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -1,7 +1,7 @@
 """ClickHouse LRS backend for Ralph."""
 
 import logging
-from typing import Iterator, List
+from typing import Generator, Iterator, List
 
 from ralph.backends.data.clickhouse import (
     ClickHouseDataBackend,
@@ -118,7 +118,7 @@ class ClickHouseLRSBackend(BaseLRSBackend, ClickHouseDataBackend):
     def query_statements_by_ids(self, ids: List[str]) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
 
-        def chunk_id_list(chunk_size=self.settings.IDS_CHUNK_SIZE):
+        def chunk_id_list(chunk_size: int = self.settings.IDS_CHUNK_SIZE) -> Generator:
             for i in range(0, len(ids), chunk_size):
                 yield ids[i : i + chunk_size]
 
@@ -148,7 +148,7 @@ class ClickHouseLRSBackend(BaseLRSBackend, ClickHouseDataBackend):
         where: list,
         agent_params: AgentParameters,
         target_field: str,
-    ):
+    ) -> None:
         """Add filters relative to agents to `where`."""
         if not agent_params:
             return

--- a/src/ralph/backends/lrs/es.py
+++ b/src/ralph/backends/lrs/es.py
@@ -91,7 +91,7 @@ class ESLRSBackend(BaseLRSBackend, ESDataBackend):
     @staticmethod
     def _add_agent_filters(
         es_query_filters: list, agent_params: AgentParameters, target_field: str
-    ):
+    ) -> None:
         """Add filters relative to agents to `es_query_filters`."""
         if not agent_params:
             return

--- a/src/ralph/backends/lrs/fs.py
+++ b/src/ralph/backends/lrs/fs.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 from io import IOBase
-from typing import Iterable, List, Literal, Union
+from typing import Iterable, List, Literal, Optional, Union
 from uuid import UUID
 
 from ralph.backends.data.base import BaseOperationType
@@ -99,7 +99,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
 
     @staticmethod
     def _add_filter_by_agent(
-        filters: list, agent: Union[AgentParameters, None], related: Union[bool, None]
+        filters: list, agent: Optional[AgentParameters], related: Optional[bool]
     ) -> None:
         """Add agent filters to `filters` if `agent` is set."""
         if not agent:
@@ -122,7 +122,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
     @staticmethod
     def _add_filter_by_authority(
         filters: list,
-        authority: Union[AgentParameters, None],
+        authority: Optional[AgentParameters],
     ) -> None:
         """Add authority filters to `filters` if `authority` is set."""
         if not authority:
@@ -147,7 +147,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
         )
 
     @staticmethod
-    def _add_filter_by_id(filters: list, statement_id: Union[str, None]) -> None:
+    def _add_filter_by_id(filters: list, statement_id: Optional[str]) -> None:
         """Add the `match_statement_id` filter if `statement_id` is set."""
 
         def match_statement_id(statement: dict) -> bool:
@@ -169,8 +169,8 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
     @staticmethod
     def _add_filter_by_mbox(
         filters: list,
-        mbox: Union[str, None],
-        related: Union[bool, None] = False,
+        mbox: Optional[str],
+        related: Optional[bool] = False,
         field: Literal["actor", "authority"] = "actor",
     ) -> None:
         """Add the `match_mbox` filter if `mbox` is set."""
@@ -196,8 +196,8 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
     @staticmethod
     def _add_filter_by_sha1sum(
         filters: list,
-        sha1sum: Union[str, None],
-        related: Union[bool, None] = False,
+        sha1sum: Optional[str],
+        related: Optional[bool] = False,
         field: Literal["actor", "authority"] = "actor",
     ) -> None:
         """Add the `match_sha1sum` filter if `sha1sum` is set."""
@@ -223,8 +223,8 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
     @staticmethod
     def _add_filter_by_openid(
         filters: list,
-        openid: Union[str, None],
-        related: Union[bool, None] = False,
+        openid: Optional[str],
+        related: Optional[bool] = False,
         field: Literal["actor", "authority"] = "actor",
     ) -> None:
         """Add the `match_openid` filter if `openid` is set."""
@@ -250,9 +250,9 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
     @staticmethod
     def _add_filter_by_account(
         filters: list,
-        name: Union[str, None],
-        home_page: Union[str, None],
-        related: Union[bool, None] = False,
+        name: Optional[str],
+        home_page: Optional[str],
+        related: Optional[bool] = False,
         field: Literal["actor", "authority"] = "actor",
     ) -> None:
         """Add the `match_account` filter if `name` or `home_page` is set."""
@@ -278,7 +278,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
             filters.append(match_related_account if related else match_account)
 
     @staticmethod
-    def _add_filter_by_verb(filters: list, verb_id: Union[str, None]) -> None:
+    def _add_filter_by_verb(filters: list, verb_id: Optional[str]) -> None:
         """Add the `match_verb_id` filter if `verb_id` is set."""
 
         def match_verb_id(statement: dict) -> bool:
@@ -290,7 +290,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
 
     @staticmethod
     def _add_filter_by_activity(
-        filters: list, object_id: Union[str, None], related: Union[bool, None]
+        filters: list, object_id: Optional[str], related: Optional[bool]
     ) -> None:
         """Add the `match_object_id` filter if `object_id` is set."""
 
@@ -322,7 +322,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
 
     @staticmethod
     def _add_filter_by_timestamp_since(
-        filters: list, timestamp: Union[datetime, None]
+        filters: list, timestamp: Optional[datetime]
     ) -> None:
         """Add the `match_since` filter if `timestamp` is set."""
         if isinstance(timestamp, str):
@@ -343,7 +343,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
 
     @staticmethod
     def _add_filter_by_timestamp_until(
-        filters: list, timestamp: Union[datetime, None]
+        filters: list, timestamp: Optional[datetime]
     ) -> None:
         """Add the `match_until` function if `timestamp` is set."""
         if isinstance(timestamp, str):
@@ -363,9 +363,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
             filters.append(match_until)
 
     @staticmethod
-    def _add_filter_by_search_after(
-        filters: list, search_after: Union[str, None]
-    ) -> None:
+    def _add_filter_by_search_after(filters: list, search_after: Optional[str]) -> None:
         """Add the `match_search_after` filter if `search_after` is set."""
         search_after_state = {"state": False}
 
@@ -382,7 +380,7 @@ class FSLRSBackend(BaseLRSBackend, FSDataBackend):
 
     @staticmethod
     def _add_filter_by_registration(
-        filters: list, registration: Union[UUID, None]
+        filters: list, registration: Optional[UUID]
     ) -> None:
         """Add the `match_registration` filter if `registration` is set."""
         registration_str = str(registration)

--- a/src/ralph/backends/lrs/mongo.py
+++ b/src/ralph/backends/lrs/mongo.py
@@ -103,7 +103,7 @@ class MongoLRSBackend(BaseLRSBackend, MongoDataBackend):
     @staticmethod
     def _add_agent_filters(
         mongo_query_filters: dict, agent_params: AgentParameters, target_field: str
-    ):
+    ) -> None:
         """Add filters relative to agents to mongo_query_filters.
 
         Args:

--- a/src/ralph/backends/stream/base.py
+++ b/src/ralph/backends/stream/base.py
@@ -27,5 +27,5 @@ class BaseStreamBackend(ABC):
     settings_class = BaseStreamBackendSettings
 
     @abstractmethod
-    def stream(self, target: BinaryIO):
+    def stream(self, target: BinaryIO) -> None:
         """Read records and stream them to target."""

--- a/src/ralph/backends/stream/ws.py
+++ b/src/ralph/backends/stream/ws.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import BinaryIO
+from typing import BinaryIO, Optional
 
 import websockets
 
@@ -25,7 +25,7 @@ class WSStreamBackendSettings(BaseStreamBackendSettings):
 
         env_prefix = "RALPH_BACKENDS__STREAM__WS__"
 
-    URI: str = None
+    URI: Optional[str] = None
 
 
 class WSStreamBackend(BaseStreamBackend):
@@ -34,7 +34,7 @@ class WSStreamBackend(BaseStreamBackend):
     name = "ws"
     settings_class = WSStreamBackendSettings
 
-    def __init__(self, settings: settings_class = None):
+    def __init__(self, settings: Optional[WSStreamBackendSettings] = None):
         """Instantiate the websocket client.
 
         Args:
@@ -43,13 +43,13 @@ class WSStreamBackend(BaseStreamBackend):
         """
         self.settings = settings if settings else self.settings_class()
 
-    def stream(self, target: BinaryIO):
+    def stream(self, target: BinaryIO) -> None:
         """Stream websocket content to target."""
         # pylint: disable=no-member
 
         logger.debug("Streaming from websocket uri: %s", self.settings.URI)
 
-        async def _stream():
+        async def _stream() -> None:
             async with websockets.connect(self.settings.URI) as websocket:
                 while event := await websocket.recv():
                     target.write(bytes(f"{event}" + "\n", encoding="utf-8"))

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -7,7 +7,7 @@ import sys
 from inspect import isasyncgen, isclass, iscoroutinefunction
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import List
+from typing import Any, Optional, Sequence
 
 import bcrypt
 
@@ -115,7 +115,7 @@ class CommaSeparatedKeyValueParamType(click.ParamType):
 class ClientOptionsParamType(CommaSeparatedKeyValueParamType):
     """Comma separated key=value parameter type for client options."""
 
-    def __init__(self, client_options_type):
+    def __init__(self, client_options_type: Any) -> None:
         """Instantiates ClientOptionsParamType for a client_options_type.
 
         Args:
@@ -137,7 +137,7 @@ class ClientOptionsParamType(CommaSeparatedKeyValueParamType):
 class HeadersParametersParamType(CommaSeparatedKeyValueParamType):
     """Comma separated key=value parameter type for headers parameters."""
 
-    def __init__(self, headers_parameters_type):
+    def __init__(self, headers_parameters_type: Any) -> None:
         """Instantiates HeadersParametersParamType for a headers_parameters_type.
 
         Args:
@@ -200,7 +200,7 @@ def cli(verbosity=None):
             handler.setLevel(level)
 
 
-def backends_options(name=None, backend_types: List[BaseModel] = None):
+def backends_options(name=None, backend_types: Optional[Sequence[BaseModel]] = None):
     """Backend-related options decorator for Ralph commands."""
 
     def wrapper(command):

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -1,13 +1,20 @@
 """Configurations for Ralph."""
 
 import io
+import sys
 from enum import Enum
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Sequence, Union
 
-try:
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, BaseSettings, Extra, root_validator
+
+from ralph.exceptions import ConfigurationException
+
+from .utils import import_string
+
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     from typing_extensions import Literal
 
 try:
@@ -19,12 +26,6 @@ except ImportError:
     from unittest.mock import Mock
 
     get_app_dir = Mock(return_value=".")
-
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, BaseSettings, Extra, root_validator
-
-from ralph.exceptions import ConfigurationException
-
-from .utils import import_string
 
 MODEL_PATH_SEPARATOR = "__"
 
@@ -56,7 +57,7 @@ class CommaSeparatedTuple(str):
 
     @classmethod
     def __get_validators__(cls):  # noqa: D105
-        def validate(value: Union[str, Tuple[str], List[str]]) -> Tuple[str]:
+        def validate(value: Union[str, Sequence[str]]) -> Sequence[str]:
             """Check whether the value is a comma separated string or a list/tuple."""
             if isinstance(value, (tuple, list)):
                 return tuple(value)

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -1,9 +1,11 @@
 """Ralph tracking logs filters."""
 
+from typing import Any, Union
+
 from .exceptions import EventKeyError
 
 
-def anonymous(event):
+def anonymous(event: dict) -> Union[dict, Any]:
     """Remove anonymous events.
 
     Args:

--- a/src/ralph/logger.py
+++ b/src/ralph/logger.py
@@ -6,7 +6,7 @@ from ralph.conf import settings
 from ralph.exceptions import ConfigurationException
 
 
-def configure_logging():
+def configure_logging() -> None:
     """Set up Ralph logging configuration."""
     try:
         dictConfig(settings.LOGGING)

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -1,16 +1,17 @@
 """Base event model definitions."""
 
+import sys
 from datetime import datetime
 from ipaddress import IPv4Address
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from pydantic import AnyHttpUrl, BaseModel, constr
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseModelWithConfig(BaseModel):

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,15 +1,16 @@
 """Browser event model definitions."""
 
+import sys
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import AnyUrl, constr
 
 from .base import BaseEdxModel
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseBrowserModel(BaseEdxModel):

--- a/src/ralph/models/edx/converters/xapi/base.py
+++ b/src/ralph/models/edx/converters/xapi/base.py
@@ -1,5 +1,6 @@
 """Base xAPI Converter."""
 
+from typing import Set
 from uuid import UUID, uuid5
 
 from ralph.exceptions import ConfigurationException
@@ -27,7 +28,7 @@ class BaseXapiConverter(BaseConversionSet):
             raise ConfigurationException("Invalid UUID namespace") from err
         super().__init__()
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         return {
             ConversionItem(

--- a/src/ralph/models/edx/converters/xapi/enrollment.py
+++ b/src/ralph/models/edx/converters/xapi/enrollment.py
@@ -1,4 +1,5 @@
 """Enrollment event xAPI Converter."""
+from typing import Set
 
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.enrollment.statements import (
@@ -13,7 +14,7 @@ from .base import BaseXapiConverter
 class LMSBaseXapiConverter(BaseXapiConverter):
     """Base LMS xAPI Converter."""
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/converters/xapi/navigational.py
+++ b/src/ralph/models/edx/converters/xapi/navigational.py
@@ -1,4 +1,5 @@
 """Navigational event xAPI Converter."""
+from typing import Set
 
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.navigational.statements import UIPageClose
@@ -19,7 +20,7 @@ class UIPageCloseToPageTerminated(BaseXapiConverter):
     __src__ = UIPageClose
     __dest__ = PageTerminated
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union({ConversionItem("object__id", "page")})

--- a/src/ralph/models/edx/converters/xapi/server.py
+++ b/src/ralph/models/edx/converters/xapi/server.py
@@ -1,5 +1,7 @@
 """Server event xAPI Converter."""
 
+from typing import Set
+
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.server import Server
 from ralph.models.xapi.navigation.statements import PageViewed
@@ -16,7 +18,7 @@ class ServerEventToPageViewed(BaseXapiConverter):
     __src__ = Server
     __dest__ = PageViewed
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/converters/xapi/video.py
+++ b/src/ralph/models/edx/converters/xapi/video.py
@@ -1,4 +1,5 @@
 """Video event xAPI Converter."""
+from typing import Set
 
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.video.statements import (
@@ -32,7 +33,7 @@ from .base import BaseXapiConverter
 class VideoBaseXapiConverter(BaseXapiConverter):
     """Base Video xAPI Converter."""
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -70,7 +71,7 @@ class UILoadVideoToVideoInitialized(VideoBaseXapiConverter):
     __src__ = UILoadVideo
     __dest__ = VideoInitialized
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -100,7 +101,7 @@ class UIPlayVideoToVideoPlayed(VideoBaseXapiConverter):
     __src__ = UIPlayVideo
     __dest__ = VideoPlayed
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -123,7 +124,7 @@ class UIPauseVideoToVideoPaused(VideoBaseXapiConverter):
     __src__ = UIPauseVideo
     __dest__ = VideoPaused
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -154,7 +155,7 @@ class UIStopVideoToVideoTerminated(VideoBaseXapiConverter):
     __src__ = UIStopVideo
     __dest__ = VideoTerminated
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -193,7 +194,7 @@ class UISeekVideoToVideoSeeked(VideoBaseXapiConverter):
     __src__ = UISeekVideo
     __dest__ = VideoSeeked
 
-    def _get_conversion_items(self):
+    def _get_conversion_items(self) -> Set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/enrollment/fields/contexts.py
+++ b/src/ralph/models/edx/enrollment/fields/contexts.py
@@ -1,13 +1,14 @@
 """Enrollment event models context fields definitions."""
 
+import sys
 from typing import Union
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from ...base import BaseContextField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class EdxCourseEnrollmentUpgradeClickedContextField(BaseContextField):

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -1,13 +1,14 @@
 """Enrollment models event field definition."""
 
+import sys
 from typing import Union
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from ...base import AbstractBaseEventField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class EnrollmentEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/enrollment/statements.py
+++ b/src/ralph/models/edx/enrollment/statements.py
@@ -1,11 +1,7 @@
 """Enrollment event model definitions."""
 
+import sys
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json
 
@@ -18,6 +14,11 @@ from .fields.contexts import (
     EdxCourseEnrollmentUpgradeSucceededContextField,
 )
 from .fields.events import EnrollmentEventField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class EdxCourseEnrollmentActivated(BaseServerModel):

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -1,11 +1,7 @@
 """Navigational event model definitions."""
 
+import sys
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json, validator
 
@@ -13,6 +9,11 @@ from ralph.models.selector import selector
 
 from ..browser import BaseBrowserModel
 from .fields.events import NavigationalEventField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class UIPageClose(BaseBrowserModel):
@@ -76,7 +77,9 @@ class UISeqNext(BaseBrowserModel):
 
     @validator("event")
     @classmethod
-    def validate_next_jump_event_field(cls, value):
+    def validate_next_jump_event_field(
+        cls, value: Union[Json[NavigationalEventField], NavigationalEventField]
+    ) -> Union[Json[NavigationalEventField], NavigationalEventField]:
         """Check that event.new is equal to event.old + 1."""
         if value.new != value.old + 1:
             raise ValueError("event.new - event.old should be equal to 1")
@@ -106,7 +109,9 @@ class UISeqPrev(BaseBrowserModel):
 
     @validator("event")
     @classmethod
-    def validate_prev_jump_event_field(cls, value):
+    def validate_prev_jump_event_field(
+        cls, value: Union[Json[NavigationalEventField], NavigationalEventField]
+    ) -> Union[Json[NavigationalEventField], NavigationalEventField]:
         """Check that event.new is equal to event.old - 1."""
         if value.new != value.old - 1:
             raise ValueError("event.old - event.new should be equal to 1")

--- a/src/ralph/models/edx/open_response_assessment/fields/events.py
+++ b/src/ralph/models/edx/open_response_assessment/fields/events.py
@@ -1,18 +1,18 @@
 """Open Response Assessment events model event fields definitions."""
 
+import sys
 from datetime import datetime
 from typing import Dict, List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from uuid import UUID
 
 from pydantic import constr
 
 from ralph.models.edx.base import AbstractBaseEventField, BaseModelWithConfig
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class ORAGetPeerSubmissionEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/open_response_assessment/statements.py
+++ b/src/ralph/models/edx/open_response_assessment/statements.py
@@ -1,12 +1,7 @@
 """Open Response Assessment events model definitions."""
 
+import sys
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 
 from pydantic import Json
 
@@ -25,6 +20,11 @@ from .fields.events import (
     ORASubmitFeedbackOnAssessmentsEventField,
     ORAUploadFileEventField,
 )
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class ORAGetPeerSubmission(BaseServerModel):

--- a/src/ralph/models/edx/peer_instruction/statements.py
+++ b/src/ralph/models/edx/peer_instruction/statements.py
@@ -1,11 +1,7 @@
 """Peer instruction events model definitions."""
 
+import sys
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json
 
@@ -13,6 +9,11 @@ from ralph.models.selector import selector
 
 from ..server import BaseServerModel
 from .fields.events import PeerInstructionEventField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class PeerInstructionAccessed(BaseServerModel):

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -1,16 +1,17 @@
 """Problem interaction events model event fields definitions."""
 
+import sys
 from datetime import datetime
 from typing import Dict, List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import constr
 
 from ...base import AbstractBaseEventField, BaseModelWithConfig
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class QueueState(BaseModelWithConfig):

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -1,11 +1,7 @@
 """Problem interaction events model definitions."""
 
+import sys
 from typing import List, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json
 
@@ -28,6 +24,11 @@ from .fields.events import (
     UIProblemResetEventField,
     UIProblemShowEventField,
 )
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class EdxProblemHintDemandhintDisplayed(BaseServerModel):

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -1,18 +1,19 @@
 """Server event model definitions."""
 
+import sys
 from pathlib import Path
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json
 
 from ralph.models.selector import LazyModelField, selector
 
 from .base import AbstractBaseEventField, BaseEdxModel
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseServerModel(BaseEdxModel):

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -1,15 +1,16 @@
 """Textbook interaction event fields definitions."""
 
+import sys
 from typing import Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Field, constr
 
 from ...base import AbstractBaseEventField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 # pylint: disable=line-too-long

--- a/src/ralph/models/edx/textbook_interaction/statements.py
+++ b/src/ralph/models/edx/textbook_interaction/statements.py
@@ -1,11 +1,7 @@
 """Textbook interaction event model definitions."""
 
+import sys
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json
 
@@ -28,6 +24,11 @@ from .fields.events import (
     TextbookPdfZoomButtonsChangedEventField,
     TextbookPdfZoomMenuChangedEventField,
 )
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class UIBook(BaseBrowserModel):

--- a/src/ralph/models/edx/video/fields/events.py
+++ b/src/ralph/models/edx/video/fields/events.py
@@ -1,11 +1,13 @@
 """Video event fields definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+import sys
 
 from ...base import AbstractBaseEventField
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class VideoBaseEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/video/statements.py
+++ b/src/ralph/models/edx/video/statements.py
@@ -1,11 +1,7 @@
 """Video event model definitions."""
 
+import sys
 from typing import Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Json
 
@@ -22,6 +18,11 @@ from ralph.models.edx.video.fields.events import (
 from ralph.models.selector import selector
 
 from ..browser import BaseBrowserModel
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class UILoadVideo(BaseBrowserModel):

--- a/src/ralph/models/selector.py
+++ b/src/ralph/models/selector.py
@@ -6,7 +6,7 @@ from importlib import import_module
 from inspect import getmembers, isclass
 from itertools import chain
 from types import ModuleType
-from typing import Any, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -21,7 +21,7 @@ class LazyModelField:
 
     path: Tuple[str]
 
-    def __init__(self, path: str):
+    def __init__(self, path: str) -> None:
         """Initialize Lazy Model Field."""
         object.__setattr__(self, "path", tuple(path.split(MODEL_PATH_SEPARATOR)))
 
@@ -33,7 +33,7 @@ class Rule:
     field: LazyModelField
     value: Union[LazyModelField, Any]  # pylint: disable=unsubscriptable-object
 
-    def check(self, event):
+    def check(self, event: Dict) -> bool:
         """Check if event matches the rule.
 
         Args:
@@ -46,7 +46,7 @@ class Rule:
         return event_value == expected_value
 
 
-def selector(**filters):
+def selector(**filters: Any) -> List[Rule]:
     """Return a list of rules that should match in order to select an event.
 
     Args:
@@ -66,13 +66,13 @@ class ModelSelector:
         decision_tree (dict): Stores the rule checking order for model selection.
     """
 
-    def __init__(self, module="ralph.models.edx"):
+    def __init__(self, module: str = "ralph.models.edx") -> None:
         """Instantiates ModelSelector."""
         self.model_rules = ModelSelector.build_model_rules(import_module(module))
         self.decision_tree = self.get_decision_tree(self.model_rules)
 
     @staticmethod
-    def build_model_rules(module: ModuleType):
+    def build_model_rules(module: ModuleType) -> Dict:
         """Build the model_rules dictionary.
 
         Using BaseModel classes defined in the module.
@@ -83,7 +83,7 @@ class ModelSelector:
                 model_rules[class_] = class_.__selector__
         return model_rules
 
-    def get_first_model(self, event: dict):
+    def get_first_model(self, event: Dict) -> Any:
         """Return the first matching model for the event. See `self.get_models`."""
         return self.get_models(event)[0]
 

--- a/src/ralph/models/xapi/base/agents.py
+++ b/src/ralph/models/xapi/base/agents.py
@@ -1,12 +1,8 @@
 """Base xAPI `Agent` definitions."""
 
+import sys
 from abc import ABC
 from typing import Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import StrictStr
 
@@ -18,6 +14,11 @@ from .ifi import (
     BaseXapiMboxSha1SumIFI,
     BaseXapiOpenIdIFI,
 )
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseXapiAgentAccount(BaseModelWithConfig):

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -1,6 +1,6 @@
 """Common for xAPI base definitions."""
 
-from typing import Dict
+from typing import Dict, Generator, Type
 
 from langcodes import tag_is_valid
 from pydantic import StrictStr, validate_email
@@ -11,8 +11,8 @@ class IRI(str):
     """Pydantic custom data type validating RFC 3987 IRIs."""
 
     @classmethod
-    def __get_validators__(cls):  # noqa: D105
-        def validate(iri: str):
+    def __get_validators__(cls) -> Generator:  # noqa: D105
+        def validate(iri: str) -> Type["IRI"]:
             """Check whether the provided IRI is a valid RFC 3987 IRI."""
             parse(iri, rule="IRI")
             return cls(iri)
@@ -24,8 +24,8 @@ class LanguageTag(str):
     """Pydantic custom data type validating RFC 5646 Language tags."""
 
     @classmethod
-    def __get_validators__(cls):  # noqa: D105
-        def validate(tag: str):
+    def __get_validators__(cls) -> Generator:  # noqa: D105
+        def validate(tag: str) -> Type["LanguageTag"]:
             """Check whether the provided tag is a valid RFC 5646 Language tag."""
             if not tag_is_valid(tag):
                 raise TypeError("Invalid RFC 5646 Language tag")
@@ -41,8 +41,8 @@ class MailtoEmail(str):
     """Pydantic custom data type validating `mailto:email` format."""
 
     @classmethod
-    def __get_validators__(cls):  # noqa: D105
-        def validate(mailto: str):
+    def __get_validators__(cls) -> Generator:  # noqa: D105
+        def validate(mailto: str) -> Type["MailtoEmail"]:
             """Check whether the provided value follows the `mailto:email` format."""
             if not mailto.startswith("mailto:"):
                 raise TypeError("Invalid `mailto:email` value")

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -1,12 +1,8 @@
 """Base xAPI `Group` definitions."""
 
+import sys
 from abc import ABC
 from typing import List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import StrictStr
 
@@ -18,6 +14,11 @@ from .ifi import (
     BaseXapiMboxSha1SumIFI,
     BaseXapiOpenIdIFI,
 )
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseXapiGroupCommonProperties(BaseModelWithConfig, ABC):

--- a/src/ralph/models/xapi/base/objects.py
+++ b/src/ralph/models/xapi/base/objects.py
@@ -3,13 +3,9 @@
 # Nota bene: we split object definitions into `objects.py` and `unnested_objects.py`
 # because of the circular dependency : objects -> context -> objects.
 
+import sys
 from datetime import datetime
 from typing import List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -19,6 +15,11 @@ from .groups import BaseXapiGroup
 from .results import BaseXapiResult
 from .unnested_objects import BaseXapiUnnestedObject
 from .verbs import BaseXapiVerb
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseXapiSubStatement(BaseModelWithConfig):

--- a/src/ralph/models/xapi/base/results.py
+++ b/src/ralph/models/xapi/base/results.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 from decimal import Decimal
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from pydantic import StrictBool, StrictStr, conint, root_validator
 
@@ -27,7 +27,7 @@ class BaseXapiResultScore(BaseModelWithConfig):
 
     @root_validator
     @classmethod
-    def check_raw_min_max_relation(cls, values):
+    def check_raw_min_max_relation(cls, values: Any) -> Any:
         """Check the relationship `min < raw < max`."""
         raw_value = values.get("raw", None)
         min_value = values.get("min", None)

--- a/src/ralph/models/xapi/base/statements.py
+++ b/src/ralph/models/xapi/base/statements.py
@@ -1,7 +1,7 @@
 """Base xAPI `Statement` definitions."""
 
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import UUID
 
 from pydantic import constr, root_validator
@@ -47,7 +47,7 @@ class BaseXapiStatement(BaseModelWithConfig):
 
     @root_validator(pre=True)
     @classmethod
-    def check_abscence_of_empty_and_invalid_values(cls, values):
+    def check_absence_of_empty_and_invalid_values(cls, values: Any) -> Any:
         """Check the model for empty and invalid values.
 
         Check that the `context` field contains `platform` and `revision` fields
@@ -57,7 +57,7 @@ class BaseXapiStatement(BaseModelWithConfig):
             if value in [None, "", {}]:
                 raise ValueError(f"{field}: invalid empty value")
             if isinstance(value, dict) and field != "extensions":
-                cls.check_abscence_of_empty_and_invalid_values(value)
+                cls.check_absence_of_empty_and_invalid_values(value)
 
         context = dict(values.get("context", {}))
         if context:

--- a/src/ralph/models/xapi/base/unnested_objects.py
+++ b/src/ralph/models/xapi/base/unnested_objects.py
@@ -1,18 +1,18 @@
 """Base xAPI `Object` definitions (1)."""
 
-from typing import Dict, List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
+import sys
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import AnyUrl, StrictStr, constr, validator
 
 from ..config import BaseModelWithConfig
 from .common import IRI, LanguageMap
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class BaseXapiActivityDefinition(BaseModelWithConfig):
@@ -81,7 +81,7 @@ class BaseXapiActivityInteractionDefinition(BaseXapiActivityDefinition):
 
     @validator("choices", "scale", "source", "target", "steps")
     @classmethod
-    def check_unique_ids(cls, value):
+    def check_unique_ids(cls, value: Any) -> None:
         """Check the uniqueness of interaction components IDs."""
         if len(value) != len({x.id for x in value}):
             raise ValueError("Duplicate InteractionComponents are not valid")

--- a/src/ralph/models/xapi/concepts/activity_types/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/activity_types/acrossx_profile.py
@@ -1,15 +1,18 @@
 """`AcrossX Profile` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Message
+
+
 class MessageActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for message `Activity` type `definition` property.
 

--- a/src/ralph/models/xapi/concepts/activity_types/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/activity_types/activity_streams_vocabulary.py
@@ -1,14 +1,18 @@
 """`Activity streams vocabulary` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Page
+
+
 class PageActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for page `Activity` type `definition` property.
 
@@ -32,6 +36,8 @@ class PageActivity(BaseXapiActivity):
 
 
 # File
+
+
 class FileActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for file `Activity` type `definition` property.
 

--- a/src/ralph/models/xapi/concepts/activity_types/audio.py
+++ b/src/ralph/models/xapi/concepts/activity_types/audio.py
@@ -1,11 +1,14 @@
 """`Audio` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Audio
 

--- a/src/ralph/models/xapi/concepts/activity_types/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/activity_types/scorm_profile.py
@@ -1,14 +1,18 @@
 """`Scorm Profile` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # CMI Interaction
+
+
 class CMIInteractionActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for CMI Interaction `Activity` type `definition` property.
 
@@ -33,6 +37,8 @@ class CMIInteractionActivity(BaseXapiActivity):
 
 
 # Profile
+
+
 class ProfileActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for profile `Activity` type `definition` property.
 
@@ -57,6 +63,8 @@ class ProfileActivity(BaseXapiActivity):
 
 
 # Course
+
+
 class CourseActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for course `Activity` type `definition` property.
 
@@ -81,6 +89,8 @@ class CourseActivity(BaseXapiActivity):
 
 
 # Module
+
+
 class ModuleActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for module `Activity` type `definition` property.
 

--- a/src/ralph/models/xapi/concepts/activity_types/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/activity_types/tincan_vocabulary.py
@@ -1,14 +1,18 @@
 """`Scorm Profile` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Document
+
+
 class DocumentActivityDefinition(BaseXapiActivityDefinition):
     """Pydantic model for document `Activity` type `definition` property.
 

--- a/src/ralph/models/xapi/concepts/activity_types/video.py
+++ b/src/ralph/models/xapi/concepts/activity_types/video.py
@@ -1,11 +1,14 @@
 """`Video` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Video
 

--- a/src/ralph/models/xapi/concepts/activity_types/virtual_classroom.py
+++ b/src/ralph/models/xapi/concepts/activity_types/virtual_classroom.py
@@ -1,12 +1,14 @@
 """`Virtual classroom` activity types definitions."""
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
+import sys
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Virtual classroom
 

--- a/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
@@ -1,14 +1,15 @@
 """`AcrossX Profile` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class PostedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
@@ -1,14 +1,15 @@
 """`Activity streams vocabulary` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class JoinVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
@@ -1,14 +1,15 @@
 """`ADL Vocabulary` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class AskedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/navy_common_reference_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/navy_common_reference_profile.py
@@ -1,14 +1,15 @@
 """`Navy Common Reference Profile` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class AccessedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
@@ -1,14 +1,15 @@
 """`Scorm Profile` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class CompletedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
@@ -1,15 +1,15 @@
 """`TinCan Vocabulary` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class ViewedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/video.py
+++ b/src/ralph/models/xapi/concepts/verbs/video.py
@@ -1,14 +1,15 @@
 """`Video` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class PlayedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
+++ b/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
@@ -1,15 +1,15 @@
 """`Virtual classroom` verbs definitions."""
 
+import sys
 from typing import Dict, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class MutedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/lms/contexts.py
+++ b/src/ralph/models/xapi/lms/contexts.py
@@ -1,13 +1,9 @@
 """LMS xAPI events context fields definitions."""
 
+import sys
 from datetime import datetime
 from typing import List, Optional, Union
 from uuid import UUID
-
-try:
-    from typing import Literal  # pylint: disable = ungrouped-imports
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Field, NonNegativeFloat, PositiveInt, condecimal, validator
 
@@ -25,6 +21,11 @@ from ..concepts.constants.video import (
     CONTEXT_EXTENSION_QUALITY,
 )
 from ..config import BaseExtensionModelWithConfig
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class LMSProfileActivity(ProfileActivity):
@@ -55,7 +56,7 @@ class LMSContextContextActivities(BaseXapiContextContextActivities):
         value: Union[
             LMSProfileActivity, List[Union[LMSProfileActivity, BaseXapiActivity]]
         ],
-    ):
+    ) -> Union[LMSProfileActivity, List[Union[LMSProfileActivity, BaseXapiActivity]]]:
         """Check that the category list contains a `LMSProfileActivity`."""
         if isinstance(value, LMSProfileActivity):
             return value

--- a/src/ralph/models/xapi/lms/objects.py
+++ b/src/ralph/models/xapi/lms/objects.py
@@ -1,11 +1,7 @@
 """LMS xAPI events object fields definitions."""
 
+import sys
 from typing import Optional
-
-try:
-    from typing import Literal  # pylint: disable = ungrouped-imports
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Field
 
@@ -20,8 +16,15 @@ from ..concepts.activity_types.activity_streams_vocabulary import (
 from ..concepts.constants.acrossx_profile import ACTIVITY_EXTENSIONS_TYPE
 from ..config import BaseExtensionModelWithConfig
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 # Page
+
+
 class LMSPageObjectDefinitionExtensions(BaseExtensionModelWithConfig):
     """Pydantic model for LMS page `object`.`definition`.`extensions` property.
 
@@ -56,6 +59,8 @@ class LMSPageObject(WebpageActivity):
 
 
 # File
+
+
 class LMSFileObjectDefinitionExtensions(BaseExtensionModelWithConfig):
     """Pydantic model for LMS file `object`.`definition`.`extensions` property.
 

--- a/src/ralph/models/xapi/video/contexts.py
+++ b/src/ralph/models/xapi/video/contexts.py
@@ -1,12 +1,7 @@
 """Video xAPI events context fields definitions."""
 
+import sys
 from typing import List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat, validator
@@ -28,6 +23,11 @@ from ..concepts.constants.video import (
     CONTEXT_EXTENSION_VOLUME,
 )
 from ..config import BaseExtensionModelWithConfig
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class VideoProfileActivity(ProfileActivity):
@@ -58,7 +58,9 @@ class VideoContextContextActivities(BaseXapiContextContextActivities):
         value: Union[
             VideoProfileActivity, List[Union[VideoProfileActivity, BaseXapiActivity]]
         ],
-    ):
+    ) -> Union[
+        VideoProfileActivity, List[Union[VideoProfileActivity, BaseXapiActivity]]
+    ]:
         """Check that the category list contains a `VideoProfileActivity`."""
         if isinstance(value, VideoProfileActivity):
             return value

--- a/src/ralph/models/xapi/video/results.py
+++ b/src/ralph/models/xapi/video/results.py
@@ -1,12 +1,8 @@
 """Video xAPI events result fields definitions."""
 
+import sys
 from datetime import timedelta
 from typing import Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import Field, NonNegativeFloat
 
@@ -20,6 +16,11 @@ from ..concepts.constants.video import (
     RESULT_EXTENSION_TIME_TO,
 )
 from ..config import BaseExtensionModelWithConfig
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class VideoResultExtensions(BaseExtensionModelWithConfig):

--- a/src/ralph/models/xapi/virtual_classroom/contexts.py
+++ b/src/ralph/models/xapi/virtual_classroom/contexts.py
@@ -1,13 +1,8 @@
 """Virtual classroom xAPI events context fields definitions."""
 
+import sys
 from datetime import datetime
 from typing import List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from uuid import UUID
 
 from pydantic import Field, validator
@@ -19,6 +14,11 @@ from ..concepts.activity_types.virtual_classroom import VirtualClassroomActivity
 from ..concepts.constants.cmi5_profile import CONTEXT_EXTENSION_SESSION_ID
 from ..concepts.constants.tincan_vocabulary import CONTEXT_EXTENSION_PLANNED_DURATION
 from ..config import BaseExtensionModelWithConfig
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class VirtualClassroomProfileActivity(ProfileActivity):
@@ -53,7 +53,10 @@ class VirtualClassroomContextContextActivities(BaseXapiContextContextActivities)
             VirtualClassroomProfileActivity,
             List[Union[VirtualClassroomProfileActivity, BaseXapiActivity]],
         ],
-    ):
+    ) -> Union[
+        VirtualClassroomProfileActivity,
+        List[Union[VirtualClassroomProfileActivity, BaseXapiActivity]],
+    ]:
         """Check that the category list contains a `VirtualClassroomProfileActivity`."""
         if isinstance(value, VirtualClassroomProfileActivity):
             return value

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from abc import ABC, abstractmethod
+from typing import BinaryIO, Generator, TextIO, Union
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ class BaseParser(ABC):
     name = "base"
 
     @abstractmethod
-    def parse(self, input_file):
+    def parse(self, input_file: Union[TextIO, BinaryIO]) -> Generator:
         """Parse GELF formatted logs (one JSON string event per row).
 
         Args:
@@ -33,8 +34,8 @@ class GELFParser(BaseParser):
 
     name = "gelf"
 
-    def parse(self, input_file):
-        """Parse GELF formatted logs (one JSON string event per row).
+    def parse(self, input_file: Union[TextIO, BinaryIO]) -> Generator:
+        """Parses GELF formatted logs (one JSON string event per row).
 
         Args:
             input_file (file-like): The log file to parse.
@@ -65,8 +66,8 @@ class ElasticSearchParser(BaseParser):
 
     name = "es"
 
-    def parse(self, input_file):
-        """Parse Elasticsearch JSON documents.
+    def parse(self, input_file: Union[TextIO, BinaryIO]) -> Generator:
+        """Parses Elasticsearch JSON documents.
 
         Args:
             input_file (file-like): The file containing Elasticsearch JSON documents.

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -8,14 +8,15 @@ import operator
 from functools import reduce
 from importlib import import_module
 from inspect import getmembers, isclass, iscoroutine
-from typing import Any, Dict, Iterable, Iterator, List, Union
+from logging import Logger, getLogger
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Union
 
 from pydantic import BaseModel
 
 from ralph.exceptions import BackendException
 
 
-def import_subclass(dotted_path, parent_class):
+def import_subclass(dotted_path: str, parent_class: Any) -> Any:
     """Import a dotted module path.
 
     Return the class that is a subclass of `parent_class` inside this module.
@@ -34,7 +35,7 @@ def import_subclass(dotted_path, parent_class):
 
 # Taken from Django utilities
 # https://docs.djangoproject.com/en/3.1/_modules/django/utils/module_loading/#import_string
-def import_string(dotted_path):
+def import_string(dotted_path: str) -> Any:
     """Import a dotted module path.
 
     Return the attribute/class designated by the last name in the path.
@@ -55,7 +56,9 @@ def import_string(dotted_path):
         ) from err
 
 
-def get_backend_type(backend_types: List[BaseModel], backend_name: str):
+def get_backend_type(
+    backend_types: List[BaseModel], backend_name: str
+) -> Union[BaseModel, None]:
     """Return the backend type from a backend name."""
     backend_name = backend_name.upper()
     for backend_type in backend_types:
@@ -64,7 +67,7 @@ def get_backend_type(backend_types: List[BaseModel], backend_name: str):
     return None
 
 
-def get_backend_class(backend_type: BaseModel, backend_name: str):
+def get_backend_class(backend_type: BaseModel, backend_name: str) -> Any:
     """Return the backend class given the backend type and backend name."""
     # Get type name from backend_type class name
     backend_type_name = backend_type.__class__.__name__[
@@ -93,8 +96,8 @@ def get_backend_class(backend_type: BaseModel, backend_name: str):
 def get_backend_instance(
     backend_type: BaseModel,
     backend_name: str,
-    options: Union[dict, None] = None,
-):
+    options: Optional[Dict] = None,
+) -> Any:
     """Return the instantiated backend given the backend type, name and options."""
     backend_class = get_backend_class(backend_type, backend_name)
     backend_settings = getattr(backend_type, backend_name.upper())
@@ -111,20 +114,20 @@ def get_backend_instance(
     return backend_class(backend_settings.__class__(**options))
 
 
-def get_root_logger():
+def get_root_logger() -> Logger:
     """Get main Ralph logger."""
-    ralph_logger = logging.getLogger("ralph")
+    ralph_logger = getLogger("ralph")
     ralph_logger.propagate = True
 
     return ralph_logger
 
 
-def now():
+def now() -> str:
     """Return the current UTC time in ISO format."""
     return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
 
-def get_dict_value_from_path(dict_: dict, path: List[str]):
+def get_dict_value_from_path(dict_: Dict, path: Sequence[str]) -> Union[Dict, None]:
     """Get a nested dictionary value.
 
     Args:
@@ -140,7 +143,7 @@ def get_dict_value_from_path(dict_: dict, path: List[str]):
         return None
 
 
-def set_dict_value_from_path(dict_: dict, path: List[str], value: any):
+def set_dict_value_from_path(dict_: Dict, path: List[str], value: Any) -> None:
     """Set a nested dictionary value.
 
     Args:
@@ -153,7 +156,7 @@ def set_dict_value_from_path(dict_: dict, path: List[str], value: any):
     dict_[path[-1]] = value
 
 
-async def gather_with_limited_concurrency(num_tasks: Union[None, int], *tasks):
+async def gather_with_limited_concurrency(num_tasks: Optional[int], *tasks: Any) -> Any:
     """Gather no more than `num_tasks` tasks at time.
 
     Args:
@@ -164,7 +167,7 @@ async def gather_with_limited_concurrency(num_tasks: Union[None, int], *tasks):
     if num_tasks is not None:
         semaphore = asyncio.Semaphore(num_tasks)
 
-        async def sem_task(task):
+        async def sem_task(task: Any) -> Any:
             async with semaphore:
                 return await task
 
@@ -180,7 +183,7 @@ async def gather_with_limited_concurrency(num_tasks: Union[None, int], *tasks):
         raise exception
 
 
-def statements_are_equivalent(statement_1: dict, statement_2: dict):
+def statements_are_equivalent(statement_1: dict, statement_2: dict) -> bool:
     """Check if statements are equivalent.
 
     To be equivalent, they must be identical on all fields not modified on input by the


### PR DESCRIPTION
## Purpose

It has been decided that we use type checking in ralph project.
[`mypy`](https://mypy.readthedocs.io/en/stable/index.html) is the best candidate for ralph.

## Proposal

- [x] Add local tooling for development
- [x] Add CI tooling
- [x] Fix `mypy` warning

## Notes

All linter warnings are not solved in this issue.

### Models
- Unsolve valid-type for constrained type from Pydantic V1
- Unsolve assignment types for Pydantic model inheritences

### Backends
- Methods signatures in backends need redefinition considering types unions that are not compatible with mypy (particularly for query methods).

### API
 - Fix remaining issues for router statements and authentication

## Tips

Help for recurring problems:

- https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module
- https://mypy.readthedocs.io/en/stable/kinds_of_types.html#tuple-types
- https://github.com/pydantic/pydantic/blob/50bc0039185c1522174c471bf967fd29a61fce74/pydantic/v1/dataclasses.py#L77
- https://github.com/hauntsaninja/no_implicit_optional
- Variable redefinition: https://mypy.readthedocs.io/en/stable/error_code_list.html#check-that-each-name-is-defined-once-no-redef 
- Missing imports (rfc3987 for e.g.): https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports