### PR TITLE
🏗️(backends) unify data backends swift

### DIFF
--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -1,0 +1,384 @@
+"""Base data backend for Ralph."""
+
+import json
+import logging
+from functools import cached_property
+from io import IOBase
+from typing import Iterable, Iterator, Union
+from uuid import uuid4
+
+from swiftclient.service import ClientException, Connection
+
+from ralph.backends.data.base import (
+    BaseDataBackend,
+    BaseDataBackendSettings,
+    BaseOperationType,
+    BaseQuery,
+    DataBackendStatus,
+    enforce_query_checks,
+)
+from ralph.backends.mixins import HistoryMixin
+from ralph.conf import BaseSettingsConfig
+from ralph.exceptions import BackendException, BackendParameterException
+from ralph.utils import now
+
+logger = logging.getLogger(__name__)
+
+
+class SwiftDataBackendSettings(BaseDataBackendSettings):
+    """Represent the SWIFT data backend default configuration.
+
+    Attributes:
+        AUTH_URL (str): The authentication URL.
+        USERNAME (str): The name of the openstack swift user.
+        PASSWORD (str): The password of the openstack swift user.
+        IDENTITY_API_VERSION (str): The keystone API version to authenticate to.
+        TENANT_ID (str): The identifier of the tenant of the container.
+        TENANT_NAME (str): The name of the tenant of the container.
+        PROJECT_DOMAIN_NAME (str): The project domain name.
+        REGION_NAME (str): The region where the container is.
+        OBJECT_STORAGE_URL (str): The default storage URL.
+        USER_DOMAIN_NAME (str): The user domain name.
+        DEFAULT_CONTAINER (str): The default target container.
+        LOCALE_ENCODING (str): The encoding used for reading/writing documents.
+    """
+
+    class Config(BaseSettingsConfig):
+        """Pydantic Configuration."""
+
+        env_prefix = "RALPH_BACKENDS__DATA__SWIFT__"
+
+    AUTH_URL: str = "https://auth.cloud.ovh.net/"
+    USERNAME: str = None
+    PASSWORD: str = None
+    IDENTITY_API_VERSION: str = "3"
+    TENANT_ID: str = None
+    TENANT_NAME: str = None
+    PROJECT_DOMAIN_NAME: str = "Default"
+    REGION_NAME: str = None
+    OBJECT_STORAGE_URL: str = None
+    USER_DOMAIN_NAME: str = "Default"
+    DEFAULT_CONTAINER: str = None
+    LOCALE_ENCODING: str = "utf8"
+
+
+class SwiftDataBackend(HistoryMixin, BaseDataBackend):
+    """SWIFT data backend."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    name = "swift"
+    default_operation_type = BaseOperationType.CREATE
+    settings_class = SwiftDataBackendSettings
+
+    def __init__(self, settings: settings_class = None):
+        """Prepares the options for the SwiftService."""
+        self.settings = settings if settings else self.settings_class()
+
+        self.default_container = self.settings.DEFAULT_CONTAINER
+        self.locale_encoding = self.settings.LOCALE_ENCODING
+        self._connection = None
+
+    @cached_property
+    def options(self) -> dict:
+        """Return the required options for the Swift Connection."""
+        return {
+            "tenant_id": self.settings.TENANT_ID,
+            "tenant_name": self.settings.TENANT_NAME,
+            "project_domain_name": self.settings.PROJECT_DOMAIN_NAME,
+            "region_name": self.settings.REGION_NAME,
+            "object_storage_url": self.settings.OBJECT_STORAGE_URL,
+            "user_domain_name": self.settings.USER_DOMAIN_NAME,
+        }
+
+    @property
+    def connection(self):
+        """Create a Swift Connection if it doesn't exist."""
+        if not self._connection:
+            self._connection = Connection(
+                authurl=self.settings.AUTH_URL,
+                user=self.settings.USERNAME,
+                key=self.settings.PASSWORD,
+                os_options=self.options,
+                auth_version=self.settings.IDENTITY_API_VERSION,
+            )
+        return self._connection
+
+    def status(self) -> DataBackendStatus:
+        """Implement data backend checks (e.g. connection, cluster status).
+
+        Returns:
+            DataBackendStatus: The status of the data backend.
+        """
+        try:
+            self.connection.head_account()
+        except ClientException as err:
+            msg = "Unable to connect to the Swift account: %s"
+            logger.error(msg, err.msg)
+            return DataBackendStatus.ERROR
+
+        return DataBackendStatus.OK
+
+    def list(
+        self, target: str = None, details: bool = False, new: bool = False
+    ) -> Iterator[Union[str, dict]]:
+        """List files for the target container.
+
+        Args:
+            target (str or None): The target container to list from.
+                If `target` is `None`, the `default_container` will be used.
+            details (bool): Get detailed object information instead of just names.
+            new (bool): Given the history, list only not already read objects.
+
+        Yields:
+            str: The next object path. (If details is False)
+            dict: The next object details. (If `details` is True.)
+
+        Raises:
+            BackendException: If a failure occurs.
+        """
+        if target is None:
+            target = self.default_container
+
+        archives_to_skip = set()
+        if new:
+            archives_to_skip = set(self.get_command_history(self.name, "read"))
+
+        try:
+            _, objects = self.connection.get_container(
+                container=target, full_listing=True
+            )
+        except ClientException as err:
+            msg = "Failed to list container %s: %s"
+            logger.error(msg, target, err.msg)
+            raise BackendException(msg % (target, err.msg)) from err
+
+        for obj in objects:
+            if new and obj in archives_to_skip:
+                continue
+            yield self._details(target, obj) if details else obj
+
+    @enforce_query_checks
+    def read(
+        self,
+        *,
+        query: Union[str, BaseQuery] = None,
+        target: str = None,
+        chunk_size: Union[None, int] = 500,
+        raw_output: bool = False,
+        ignore_errors: bool = False,
+    ) -> Iterator[Union[bytes, dict]]:
+        """Read objects matching the `query` in the `target` container and yields them.
+
+        Args:
+            query: (str or BaseQuery): The query to select objects to read.
+            target (str or None): The target container name.
+                If `target` is `None`, a default value is used instead.
+            chunk_size (int or None): The number of records or bytes to read in one
+                batch, depending on whether the records are dictionaries or bytes.
+            raw_output (bool): Controls whether to yield bytes or dictionaries.
+                If the objects are dictionaries and `raw_output` is set to `True`, they
+                are encoded as JSON.
+                If the objects are bytes and `raw_output` is set to `False`, they are
+                decoded as JSON by line.
+            ignore_errors (bool): If `True`, errors during the read operation
+                are be ignored and logged. If `False` (default), a `BackendException`
+                is raised if an error occurs.
+
+        Yields:
+            dict: If `raw_output` is False.
+            bytes: If `raw_output` is True.
+
+        Raises:
+            BackendException: If a failure during the read operation occurs and
+                `ignore_errors` is set to `False`.
+            BackendParameterException: If a backend argument value is not valid.
+        """
+        if query.query_string is None:
+            msg = "Invalid query. The query should be a valid archive name."
+            logger.error(msg)
+            if not ignore_errors:
+                raise BackendParameterException(msg)
+
+        target = target if target else self.default_container
+
+        logger.info(
+            "Getting object from container: %s (query_string: %s)",
+            target,
+            query.query_string,
+        )
+
+        try:
+            resp_headers, content = self.connection.get_object(
+                container=target,
+                obj=query.query_string,
+                resp_chunk_size=chunk_size,
+            )
+        except ClientException as err:
+            msg = "Failed to read %s: %s"
+            error = err.msg
+            logger.error(msg, query.query_string, error)
+            if not ignore_errors:
+                raise BackendException(msg % (query.query_string, error)) from err
+
+        reader = self._read_raw if raw_output else self._read_dict
+
+        for chunk in reader(content, chunk_size, ignore_errors):
+            yield chunk
+
+        # Archive read, add a new entry to the history
+        self.append_to_history(
+            {
+                "backend": self.name,
+                "action": "read",
+                "id": f"{target}/{query.query_string}",
+                "size": resp_headers["Content-Length"],
+                "timestamp": now(),
+            }
+        )
+
+    def write(  # pylint: disable=too-many-arguments, disable=too-many-branches
+        self,
+        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
+        target: Union[None, str] = None,
+        chunk_size: Union[None, int] = None,
+        ignore_errors: bool = False,
+        operation_type: Union[None, BaseOperationType] = None,
+    ) -> int:
+        """Write `data` records to the `target` container and returns their count.
+
+        Args:
+            data: (Iterable or IOBase): The data to write.
+            target (str or None): The target container name.
+                If `target` is `None`, a default value is used instead.
+            chunk_size (int or None): Ignored.
+            ignore_errors (bool): If `True`, errors during the write operation
+                are ignored and logged. If `False` (default), a `BackendException`
+                is raised if an error occurs.
+            operation_type (BaseOperationType or None): The mode of the write operation.
+                If `operation_type` is `None`, the `default_operation_type` is used
+                instead. See `BaseOperationType`.
+
+        Returns:
+            int: The number of written records.
+
+        Raises:
+            BackendException: If a failure during the write operation occurs and
+                `ignore_errors` is set to `False`.
+            BackendParameterException: If a backend argument value is not valid.
+        """
+        try:
+            first_record = next(iter(data))
+        except StopIteration:
+            logger.info("Data Iterator is empty; skipping write to target.")
+            return 0
+        if not operation_type:
+            operation_type = self.default_operation_type
+
+        if not target:
+            target = f"{self.default_container}/{now()}-{uuid4()}"
+            logger.info(
+                (
+                    "Target not specified; using default container "
+                    "with random object name: %s"
+                ),
+                target,
+            )
+        elif "/" not in target:
+            target = f"{self.default_container}/{target}"
+            logger.info(
+                "Container not specified; using default container: %s",
+                self.default_container,
+            )
+
+        target_container, target_object = target.split("/", 1)
+
+        if operation_type in [
+            BaseOperationType.APPEND,
+            BaseOperationType.DELETE,
+            BaseOperationType.UPDATE,
+        ]:
+            msg = "%s operation_type is not allowed."
+            logger.error(msg, operation_type.name)
+            if not ignore_errors:
+                raise BackendParameterException(msg % operation_type.name)
+
+        if operation_type in [BaseOperationType.CREATE, BaseOperationType.INDEX]:
+            if target_object in list(self.list(target=target_container)):
+                msg = "%s already exists and overwrite is not allowed for operation %s"
+                logger.error(msg, target_object, operation_type)
+                if not ignore_errors:
+                    raise BackendException(msg % (target_object, operation_type))
+
+            if isinstance(first_record, dict):
+                data = [
+                    json.dumps(statement).encode(self.locale_encoding)
+                    for statement in data
+                ]
+
+            try:
+                self.connection.put_object(
+                    container=target_container, obj=target_object, contents=data
+                )
+                resp = self.connection.head_object(
+                    container=target_container, obj=target_object
+                )
+            except ClientException as err:
+                msg = "Failed to write to object %s: %s"
+                error = err.msg
+                logger.error(msg, target_object, error)
+                if not ignore_errors:
+                    raise BackendException(msg % (target_object, error)) from err
+
+        count = sum(1 for _ in data)
+        logging.info("Successfully written %s statements to %s", count, target)
+
+        # Archive written, add a new entry to the history
+        self.append_to_history(
+            {
+                "backend": self.name,
+                "action": "write",
+                "operation_type": operation_type.value,
+                "id": target,
+                "size": resp["Content-Length"],
+                "timestamp": now(),
+            }
+        )
+        return count
+
+    def _details(self, container: str, name: str):
+        """Return `name` object details from `container`."""
+        try:
+            resp = self.connection.head_object(container=container, obj=name)
+        except ClientException as err:
+            msg = "Unable to retrieve details for object %s: %s"
+            logger.error(msg, name, err.msg)
+            raise BackendException(msg % (name, err.msg)) from err
+
+        return {
+            "name": name,
+            "lastModified": resp["Last-Modified"],
+            "size": resp["Content-Length"],
+        }
+
+    @staticmethod
+    def _read_dict(
+        obj: Iterable, _chunk_size: int, ignore_errors: bool
+    ) -> Iterator[dict]:
+        """Read the `object` by line and yield JSON parsed dictionaries."""
+        for i, line in enumerate(obj):
+            try:
+                yield json.loads(line)
+            except (TypeError, json.JSONDecodeError) as err:
+                msg = "Raised error: %s, at line %s"
+                logger.error(msg, err, i)
+                if not ignore_errors:
+                    raise BackendException(msg % (err, i)) from err
+
+    @staticmethod
+    def _read_raw(
+        obj: Iterable, chunk_size: int, _ignore_errors: bool
+    ) -> Iterator[bytes]:
+        """Read the `object` by line and yield bytes."""
+        while chunk := obj.read(chunk_size):
+            yield chunk

--- a/tests/backends/data/test_swift.py
+++ b/tests/backends/data/test_swift.py
@@ -1,0 +1,640 @@
+"""Tests for Ralph swift data backend."""
+
+import json
+import logging
+from io import BytesIO
+from operator import itemgetter
+from typing import Iterable
+from uuid import uuid4
+
+import pytest
+from swiftclient.service import ClientException
+
+from ralph.backends.data.base import BaseOperationType, BaseQuery, DataBackendStatus
+from ralph.backends.data.swift import SwiftDataBackend, SwiftDataBackendSettings
+from ralph.conf import settings
+from ralph.exceptions import BackendException, BackendParameterException
+from ralph.utils import now
+
+
+def test_backends_data_swift_data_backend_default_instantiation(monkeypatch, fs):
+    """Test the `SwiftDataBackend` default instantiation."""
+    # pylint: disable=invalid-name
+    fs.create_file(".env")
+    backend_settings_names = [
+        "AUTH_URL",
+        "USERNAME",
+        "PASSWORD",
+        "IDENTITY_API_VERSION",
+        "TENANT_ID",
+        "TENANT_NAME",
+        "PROJECT_DOMAIN_NAME",
+        "REGION_NAME",
+        "OBJECT_STORAGE_URL",
+        "USER_DOMAIN_NAME",
+        "DEFAULT_CONTAINER",
+        "LOCALE_ENCODING",
+    ]
+    for name in backend_settings_names:
+        monkeypatch.delenv(f"RALPH_BACKENDS__DATA__SWIFT__{name}", raising=False)
+
+    assert SwiftDataBackend.name == "swift"
+    assert SwiftDataBackend.query_model == BaseQuery
+    assert SwiftDataBackend.default_operation_type == BaseOperationType.CREATE
+    assert SwiftDataBackend.settings_class == SwiftDataBackendSettings
+    backend = SwiftDataBackend()
+    assert backend.options["tenant_id"] is None
+    assert backend.options["tenant_name"] is None
+    assert backend.options["project_domain_name"] == "Default"
+    assert backend.options["region_name"] is None
+    assert backend.options["object_storage_url"] is None
+    assert backend.options["user_domain_name"] == "Default"
+    assert backend.default_container is None
+    assert backend.locale_encoding == "utf8"
+
+
+def test_backends_data_swift_data_backend_instantiation_with_settings(fs):
+    """Test the `SwiftDataBackend` instantiation with settings."""
+    # pylint: disable=invalid-name
+    fs.create_file(".env")
+    settings_ = SwiftDataBackend.settings_class(
+        AUTH_URL="https://toto.net/",
+        USERNAME="username",
+        PASSWORD="password",
+        IDENTITY_API_VERSION="2",
+        TENANT_ID="tenant_id",
+        TENANT_NAME="tenant_name",
+        PROJECT_DOMAIN_NAME="project_domain_name",
+        REGION_NAME="region_name",
+        OBJECT_STORAGE_URL="object_storage_url",
+        USER_DOMAIN_NAME="user_domain_name",
+        DEFAULT_CONTAINER="default_container",
+        LOCALE_ENCODING="utf-16",
+    )
+    backend = SwiftDataBackend(settings_)
+    assert backend.options["tenant_id"] == "tenant_id"
+    assert backend.options["tenant_name"] == "tenant_name"
+    assert backend.options["project_domain_name"] == "project_domain_name"
+    assert backend.options["region_name"] == "region_name"
+    assert backend.options["object_storage_url"] == "object_storage_url"
+    assert backend.options["user_domain_name"] == "user_domain_name"
+    assert backend.default_container == "default_container"
+    assert backend.locale_encoding == "utf-16"
+
+    try:
+        SwiftDataBackend(settings_)
+    except Exception as err:  # pylint:disable=broad-except
+        pytest.fail(f"SwiftDataBackend should not raise exceptions: {err}")
+
+
+def test_backends_data_swift_data_backend_status_method_with_error_status(
+    monkeypatch, swift_backend, caplog
+):
+    """Test the `SwiftDataBackend.status` method, given a failed connection,
+    should return `DataBackendStatus.ERROR`."""
+    error = (
+        "Unauthorized. Check username/id, password, tenant name/id and"
+        " user/tenant domain name/id."
+    )
+
+    def mock_failed_head_account(*args, **kwargs):
+        # pylint:disable=unused-argument
+        raise ClientException(error)
+
+    swift = swift_backend()
+    monkeypatch.setattr(swift.connection, "head_account", mock_failed_head_account)
+
+    with caplog.at_level(logging.ERROR):
+        assert swift.status() == DataBackendStatus.ERROR
+
+    assert (
+        "ralph.backends.data.swift",
+        logging.ERROR,
+        f"Unable to connect to the Swift account: {error}",
+    ) in caplog.record_tuples
+
+
+def test_backends_data_swift_data_backend_status_method_with_ok_status(
+    monkeypatch, swift_backend, caplog
+):
+    """Test the `SwiftDataBackend.status` method, given a directory with wrong
+    permissions, should return `DataBackendStatus.OK`.
+    """
+
+    def mock_successful_head_account(*args, **kwargs):  # pylint:disable=unused-argument
+        return 1
+
+    swift = swift_backend()
+    monkeypatch.setattr(swift.connection, "head_account", mock_successful_head_account)
+
+    with caplog.at_level(logging.ERROR):
+        assert swift.status() == DataBackendStatus.OK
+
+    assert caplog.record_tuples == []
+
+
+def test_backends_data_swift_data_backend_list_method(
+    swift_backend, monkeypatch, fs, settings_fs
+):  # pylint:disable=invalid-name,unused-argument
+    """Test that the `SwiftDataBackend.list` method argument should list
+    the default container.
+    """
+    frozen_now = now()
+    listing = [
+        {
+            "name": "2020-04-29.gz",
+            "lastModified": frozen_now,
+            "size": 12,
+        },
+        {
+            "name": "2020-04-30.gz",
+            "lastModified": frozen_now,
+            "size": 25,
+        },
+        {
+            "name": "2020-05-01.gz",
+            "lastModified": frozen_now,
+            "size": 42,
+        },
+    ]
+    history = [
+        {
+            "backend": "swift",
+            "action": "read",
+            "id": "2020-04-29.gz",
+        },
+        {
+            "backend": "swift",
+            "action": "read",
+            "id": "2020-04-30.gz",
+        },
+    ]
+
+    def mock_get_container(*args, **kwargs):  # pylint:disable=unused-argument
+        return (None, [x["name"] for x in listing])
+
+    def mock_head_object(container, obj):  # pylint:disable=unused-argument
+        resp = next((x for x in listing if x["name"] == obj), None)
+        return {
+            "Last-Modified": resp["lastModified"],
+            "Content-Length": resp["size"],
+        }
+
+    backend = swift_backend()
+    monkeypatch.setattr(backend.connection, "get_container", mock_get_container)
+    monkeypatch.setattr(backend.connection, "head_object", mock_head_object)
+    fs.create_file(settings.HISTORY_FILE, contents=json.dumps(history))
+
+    assert list(backend.list()) == [x["name"] for x in listing]
+    assert list(backend.list(new=True)) == ["2020-05-01.gz"]
+    assert list(backend.list(details=True)) == listing
+
+
+def test_backends_data_swift_data_backend_list_with_failed_details(
+    swift_backend, monkeypatch, fs, caplog, settings_fs
+):  # pylint:disable=invalid-name,unused-argument,too-many-arguments
+    """Test that the `SwiftDataBackend.list` method with a failed connection
+    when retrieving details, should log the error and raise a BackendException.
+    """
+    error = "Test client exception"
+
+    frozen_now = now()
+    listing = [
+        {
+            "name": "2020-04-29.gz",
+            "lastModified": frozen_now,
+            "size": 12,
+        },
+    ]
+
+    def mock_get_container(*args, **kwargs):  # pylint:disable=unused-argument
+        return (None, [x["name"] for x in listing])
+
+    def mock_head_object(*args, **kwargs):  # pylint:disable=unused-argument
+        raise ClientException(error)
+
+    backend = swift_backend()
+    monkeypatch.setattr(backend.connection, "get_container", mock_get_container)
+    monkeypatch.setattr(backend.connection, "head_object", mock_head_object)
+    fs.create_file(settings.HISTORY_FILE, contents=json.dumps([]))
+
+    error = "Test client exception"
+    msg = f"Unable to retrieve details for object {listing[0]['name']}: {error}"
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(BackendException, match=msg):
+            next(backend.list(details=True))
+
+    assert ("ralph.backends.data.swift", logging.ERROR, msg) in caplog.record_tuples
+
+
+def test_backends_data_swift_data_backend_list_with_failed_connection(
+    swift_backend, monkeypatch, fs, caplog, settings_fs
+):  # pylint:disable=invalid-name,unused-argument,too-many-arguments
+    """Test that the `SwiftDataBackend.list` method with a failed connection
+    should log the error and raise a BackendException.
+    """
+    error = "Container not found"
+
+    def mock_get_container(*args, **kwargs):  # pylint:disable=unused-argument
+        raise ClientException(error)
+
+    backend = swift_backend()
+    monkeypatch.setattr(backend.connection, "get_container", mock_get_container)
+    fs.create_file(settings.HISTORY_FILE, contents=json.dumps([]))
+
+    msg = "Failed to list container container_name: Container not found"
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(BackendException, match=msg):
+            next(backend.list())
+        with pytest.raises(BackendException, match=msg):
+            next(backend.list(new=True))
+        with pytest.raises(BackendException, match=msg):
+            next(backend.list(details=True))
+
+    assert ("ralph.backends.data.swift", logging.ERROR, msg) in caplog.record_tuples
+
+
+def test_backends_data_swift_data_backend_read_method_with_raw_output(
+    swift_backend, monkeypatch, fs, settings_fs
+):  # pylint:disable=invalid-name, unused-argument
+    """Test the `SwiftDataBackend.read` method with `raw_output` set to `True`."""
+
+    # Object contents.
+    content = b'{"foo": "bar"}'
+
+    # Freeze the ralph.utils.now() value.
+    frozen_now = now()
+
+    backend = swift_backend()
+
+    def mock_get_object(*args, **kwargs):  # pylint:disable=unused-argument
+        resp_headers = {"Content-Length": 14}
+        return (resp_headers, BytesIO(content))
+
+    monkeypatch.setattr(backend.connection, "get_object", mock_get_object)
+    monkeypatch.setattr("ralph.backends.data.swift.now", lambda: frozen_now)
+    fs.create_file(settings.HISTORY_FILE, contents=json.dumps([]))
+
+    # The `read` method should read the object and yield bytes.
+    result = backend.read(raw_output=True, query="2020-04-29.gz")
+    assert isinstance(result, Iterable)
+    assert list(result) == [content]
+
+    assert backend.history == [
+        {
+            "backend": "swift",
+            "action": "read",
+            "id": "container_name/2020-04-29.gz",
+            "size": 14,
+            "timestamp": frozen_now,
+        }
+    ]
+
+    # Given a `chunk_size`,` the `read` method should write the output bytes
+    # in chunks of the specified `chunk_size`.
+    result = backend.read(raw_output=True, query="2020-05-30.gz", chunk_size=2)
+    assert isinstance(result, Iterable)
+    assert list(result) == [b'{"', b"fo", b'o"', b": ", b'"b', b"ar", b'"}']
+
+    assert backend.history == [
+        {
+            "backend": "swift",
+            "action": "read",
+            "id": "container_name/2020-04-29.gz",
+            "size": 14,
+            "timestamp": frozen_now,
+        },
+        {
+            "backend": "swift",
+            "action": "read",
+            "id": "container_name/2020-05-30.gz",
+            "size": 14,
+            "timestamp": frozen_now,
+        },
+    ]
+
+
+def test_backends_data_swift_data_backend_read_method_without_raw_output(
+    swift_backend, monkeypatch, fs, settings_fs
+):  # pylint:disable=invalid-name, unused-argument
+    """Test the `SwiftDataBackend.read` method with `raw_output` set to `False`."""
+
+    # Object contents.
+    content_dict = {"foo": "bar"}
+    content_bytes = b'{"foo": "bar"}'
+
+    # Freeze the ralph.utils.now() value.
+    frozen_now = now()
+
+    backend = swift_backend()
+
+    def mock_get_object(*args, **kwargs):  # pylint:disable=unused-argument
+        resp_headers = {"Content-Length": 14}
+        return (resp_headers, BytesIO(content_bytes))
+
+    monkeypatch.setattr(backend.connection, "get_object", mock_get_object)
+    monkeypatch.setattr("ralph.backends.data.swift.now", lambda: frozen_now)
+    fs.create_file(settings.HISTORY_FILE, contents=json.dumps([]))
+
+    # The `read` method should read the object and yield bytes.
+    result = backend.read(raw_output=False, query="2020-04-29.gz")
+    assert isinstance(result, Iterable)
+    assert list(result) == [content_dict]
+
+    assert backend.history == [
+        {
+            "backend": "swift",
+            "action": "read",
+            "id": "container_name/2020-04-29.gz",
+            "size": 14,
+            "timestamp": frozen_now,
+        }
+    ]
+
+
+def test_backends_data_swift_data_backend_read_method_with_invalid_query(swift_backend):
+    """Test the `SwiftDataBackend.read` method given an invalid `query` argument should
+    raise a `BackendParameterException`.
+    """
+    backend = swift_backend()
+    # Given no `query`, the `read` method should raise a `BackendParameterException`.
+    error = "Invalid query. The query should be a valid archive name"
+    with pytest.raises(BackendParameterException, match=error):
+        list(backend.read())
+
+
+def test_backends_data_swift_data_backend_read_method_with_ignore_errors(
+    monkeypatch, swift_backend, fs, settings_fs
+):
+    """Test the `SwiftDataBackend.read` method with `ignore_errors` set to `True`,
+    given an archive containing invalid JSON lines, should skip the invalid lines.
+    """
+    # pylint: disable=invalid-name, unused-argument
+
+    # File contents.
+    valid_dictionary = {"foo": "bar"}
+    valid_json = json.dumps(valid_dictionary)
+    invalid_json = "baz"
+    valid_invalid_json = bytes(
+        f"{valid_json}\n{invalid_json}\n{valid_json}",
+        encoding="utf8",
+    )
+    invalid_valid_json = bytes(
+        f"{invalid_json}\n{valid_json}\n{invalid_json}",
+        encoding="utf8",
+    )
+
+    backend = swift_backend()
+
+    def mock_get_object_1(*args, **kwargs):  # pylint:disable=unused-argument
+        resp_headers = {"Content-Length": 14}
+        return (resp_headers, BytesIO(valid_invalid_json))
+
+    monkeypatch.setattr(backend.connection, "get_object", mock_get_object_1)
+
+    # The `read` method should read all valid statements and yield dictionaries
+    result = backend.read(ignore_errors=True, query="2020-06-02.gz")
+    assert isinstance(result, Iterable)
+    assert list(result) == [valid_dictionary, valid_dictionary]
+
+    def mock_get_object_2(*args, **kwargs):  # pylint:disable=unused-argument
+        resp_headers = {"Content-Length": 14}
+        return (resp_headers, BytesIO(invalid_valid_json))
+
+    monkeypatch.setattr(backend.connection, "get_object", mock_get_object_2)
+
+    # The `read` method should read all valid statements and yield bytes
+    result = backend.read(ignore_errors=True, query="2020-06-02.gz")
+    assert isinstance(result, Iterable)
+    assert list(result) == [valid_dictionary]
+
+
+def test_backends_data_swift_data_backend_read_method_without_ignore_errors(
+    monkeypatch, swift_backend, fs, settings_fs
+):
+    """Test the `SwiftDataBackend.read` method with `ignore_errors` set to `False`,
+    given a file containing invalid JSON lines, should raise a `BackendException`.
+    """
+    # pylint: disable=invalid-name, unused-argument
+
+    # File contents.
+    valid_dictionary = {"foo": "bar"}
+    valid_json = json.dumps(valid_dictionary)
+    invalid_json = "baz"
+    valid_invalid_json = bytes(
+        f"{valid_json}\n{invalid_json}\n{valid_json}",
+        encoding="utf8",
+    )
+    invalid_valid_json = bytes(
+        f"{invalid_json}\n{valid_json}\n{invalid_json}",
+        encoding="utf8",
+    )
+
+    backend = swift_backend()
+
+    def mock_get_object_1(*args, **kwargs):  # pylint:disable=unused-argument
+        resp_headers = {"Content-Length": 14}
+        return (resp_headers, BytesIO(valid_invalid_json))
+
+    monkeypatch.setattr(backend.connection, "get_object", mock_get_object_1)
+
+    # Given one object with an invalid json at the second line, the `read`
+    # method should yield the first valid line and raise a `BackendException`
+    # at the second line.
+    result = backend.read(ignore_errors=False, query="2020-06-02.gz")
+    assert isinstance(result, Iterable)
+    assert next(result) == valid_dictionary
+    with pytest.raises(BackendException, match="Raised error:"):
+        next(result)
+
+    # When the `read` method fails to read a file entirely, then no entry should be
+    # added to the history.
+    assert not backend.history
+
+    def mock_get_object_2(*args, **kwargs):  # pylint:disable=unused-argument
+        resp_headers = {"Content-Length": 14}
+        return (resp_headers, BytesIO(invalid_valid_json))
+
+    monkeypatch.setattr(backend.connection, "get_object", mock_get_object_2)
+
+    # Given one object with an invalid json at the first and third lines, the `read`
+    # method should raise a `BackendException` at the second line.
+    result = backend.read(ignore_errors=False, query="2020-06-03.gz")
+    assert isinstance(result, Iterable)
+    with pytest.raises(BackendException, match="Raised error:"):
+        next(result)
+
+
+def test_backends_data_swift_data_backend_read_method_with_failed_connection(
+    caplog, monkeypatch, swift_backend
+):
+    """Test the `SwiftDataBackend.read` method, given a `ClientException` raised by
+    method `get_object`, should raise a  `BackendException`."""
+
+    error = "Failed to get object."
+
+    def mock_failed_get_object(*args, **kwargs):  # pylint:disable=unused-argument
+        raise ClientException(error)
+
+    backend = swift_backend()
+    monkeypatch.setattr(backend.connection, "get_object", mock_failed_get_object)
+
+    msg = f"Failed to read object.gz: {error}"
+    with caplog.at_level(logging.ERROR):
+        result = backend.read(query="object.gz")
+        with pytest.raises(BackendException, match=msg):
+            next(result)
+
+    assert ("ralph.backends.data.swift", logging.ERROR, msg) in caplog.record_tuples
+
+
+@pytest.mark.parametrize(
+    "operation_type", [None, BaseOperationType.CREATE, BaseOperationType.INDEX]
+)
+def test_backends_data_swift_data_backend_write_method_with_file_exists_error(
+    operation_type, swift_backend, monkeypatch, fs, settings_fs
+):
+    """Test the `SwiftDataBackend.write` method, given a target matching an
+    existing file and a `CREATE` or `INDEX` `operation_type`, should raise a
+    `BackendException`.
+    """
+    # pylint: disable=invalid-name, unused-argument
+    listing = [{"name": "2020-04-29.gz"}, {"name": "object.gz"}]
+
+    def mock_get_container(*args, **kwargs):  # pylint:disable=unused-argument
+        return (None, [x["name"] for x in listing])
+
+    backend = swift_backend()
+    monkeypatch.setattr(backend.connection, "get_container", mock_get_container)
+
+    msg = (
+        f"object.gz already exists and overwrite is not allowed for operation"
+        f" {operation_type if operation_type is not None else BaseOperationType.CREATE}"
+    )
+
+    with pytest.raises(BackendException, match=msg):
+        backend.write(
+            target="object.gz", data=[b"foo", b"test"], operation_type=operation_type
+        )
+
+    # When the `write` method fails, then no entry should be added to the history.
+    assert not sorted(backend.history, key=itemgetter("id"))
+
+
+def test_backends_data_swift_data_backend_write_method_with_failed_connection(
+    monkeypatch, swift_backend, fs, settings_fs
+):
+    """Test the `SwiftDataBackend.write` method, given a failed connection, should
+    raise a `BackendException`."""
+    # pylint: disable=invalid-name, unused-argument
+
+    backend = swift_backend()
+
+    error = "Client Exception error."
+    msg = f"Failed to write to object object.gz: {error}"
+
+    def mock_get_container(*args, **kwargs):  # pylint:disable=unused-argument
+        return (None, [])
+
+    def mock_put_object(*args, **kwargs):  # pylint:disable=unused-argument
+        return 1
+
+    def mock_head_object(*args, **kwargs):  # pylint:disable=unused-argument
+        raise ClientException(error)
+
+    monkeypatch.setattr(backend.connection, "get_container", mock_get_container)
+    monkeypatch.setattr(backend.connection, "put_object", mock_put_object)
+    monkeypatch.setattr(backend.connection, "head_object", mock_head_object)
+
+    with pytest.raises(BackendException, match=msg):
+        backend.write(target="object.gz", data=[b"foo"])
+
+    # When the `write` method fails, then no entry should be added to the history.
+    assert not sorted(backend.history, key=itemgetter("id"))
+
+
+@pytest.mark.parametrize(
+    "operation_type",
+    [
+        BaseOperationType.APPEND,
+        BaseOperationType.DELETE,
+        BaseOperationType.UPDATE,
+    ],
+)
+def test_backends_data_swift_data_backend_write_method_with_invalid_operation(
+    # pylint: disable=line-too-long
+    operation_type,
+    swift_backend,
+    fs,
+    settings_fs,
+):
+    """Test the `SwiftDataBackend.write` method, given an unsupported `operation_type`,
+    should raise a `BackendParameterException`."""
+    # pylint: disable=invalid-name, unused-argument
+
+    backend = swift_backend()
+
+    msg = f"{operation_type.name} operation_type is not allowed."
+    with pytest.raises(BackendParameterException, match=msg):
+        backend.write(data=[b"foo"], operation_type=operation_type)
+
+    # When the `write` method fails, then no entry should be added to the history.
+    assert not sorted(backend.history, key=itemgetter("id"))
+
+
+def test_backends_data_swift_data_backend_write_method_without_target(
+    swift_backend, monkeypatch, fs, settings_fs
+):
+    """Test the `SwiftDataBackend.write` method, given no target, should write
+    to the default container to a random object with the provided data.
+    """
+    # pylint: disable=invalid-name, unused-argument
+
+    # Freeze the ralph.utils.now() value.
+    frozen_now = now()
+    monkeypatch.setattr("ralph.backends.data.swift.now", lambda: frozen_now)
+
+    # Freeze the uuid4() value.
+    frozen_uuid4 = uuid4()
+    monkeypatch.setattr("ralph.backends.data.swift.uuid4", lambda: frozen_uuid4)
+
+    backend = swift_backend()
+
+    # With empty data, `write` method is skipped
+    count = backend.write(data=())
+
+    assert backend.history == []
+    assert count == 0
+
+    listing = [{"name": "2020-04-29.gz"}, {"name": "object.gz"}]
+
+    def mock_get_container(*args, **kwargs):  # pylint:disable=unused-argument
+        return (None, [x["name"] for x in listing])
+
+    def mock_put_object(*args, **kwargs):  # pylint:disable=unused-argument
+        return 1
+
+    def mock_head_object(*args, **kwargs):  # pylint:disable=unused-argument
+        return {"Content-Length": 3}
+
+    expected_filename = f"{frozen_now}-{frozen_uuid4}"
+    monkeypatch.setattr(backend.connection, "get_container", mock_get_container)
+    monkeypatch.setattr(backend.connection, "put_object", mock_put_object)
+    monkeypatch.setattr(backend.connection, "head_object", mock_head_object)
+    monkeypatch.setattr("ralph.backends.data.swift.now", lambda: frozen_now)
+
+    count = backend.write(data=[{"foo": "bar"}, {"test": "toto"}])
+
+    assert count == 2
+    assert backend.history == [
+        {
+            "backend": "swift",
+            "action": "write",
+            "operation_type": BaseOperationType.CREATE.value,
+            "id": f"container_name/{expected_filename}",
+            "size": mock_head_object()["Content-Length"],
+            "timestamp": frozen_now,
+        }
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from .fixtures.backends import (  # noqa: F401
     s3,
     settings_fs,
     swift,
+    swift_backend,
     ws,
 )
 from .fixtures.logs import gelf_logger  # noqa: F401

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -23,6 +23,7 @@ from pymongo import MongoClient
 from pymongo.errors import CollectionInvalid
 
 from ralph.backends.data.fs import FSDataBackend, FSDataBackendSettings
+from ralph.backends.data.swift import SwiftDataBackend, SwiftDataBackendSettings
 from ralph.backends.database.clickhouse import ClickHouseDatabase
 from ralph.backends.database.es import ESDatabase
 from ralph.backends.database.mongo import MongoDatabase
@@ -351,6 +352,31 @@ def swift():
         )
 
     return get_swift_storage
+
+
+@pytest.fixture
+def swift_backend():
+    """Returns get_swift_data_backend function."""
+
+    def get_swift_data_backend():
+        """Returns an instance of SwiftDataBackend."""
+        settings = SwiftDataBackendSettings(
+            AUTH_URL="https://auth.cloud.ovh.net/",
+            USERNAME="os_username",
+            PASSWORD="os_password",
+            IDENTITY_API_VERSION="3",
+            TENANT_ID="os_tenant_id",
+            TENANT_NAME="os_tenant_name",
+            PROJECT_DOMAIN_NAME="Default",
+            REGION_NAME="os_region_name",
+            OBJECT_STORAGE_URL="os_storage_url/ralph_logs_container",
+            USER_DOMAIN_NAME="Default",
+            DEFAULT_CONTAINER="container_name",
+            LOCALE_ENCODING="utf8",
+        )
+        return SwiftDataBackend(settings)
+
+    return get_swift_data_backend
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Purpose

Storage and Database backends had similar interfaces and usage, a new Data backend interface has been created.
With the `data` parameter changed to an Iterable, we cannot use high level SwiftService API to upload files anymore (it needs a file object source, not an iterable).
Changing to Connection lower-level API, which is more flexible.


## Proposal

- [x] Add SwiftDataBackend
- [x] Add tests

