### PR TITLE
Add all Inverse Functional Identifier support for filtering by `agent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Force a valid (JSON-formatted) IFI to be passed for the `/statements` 
+GET query `agent` filtering
 
 ## [3.6.0] - 2023-05-17
 

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -51,7 +51,11 @@ class StatementParameters:
 
     statementId: Optional[str] = None  # pylint: disable=invalid-name
     voidedStatementId: Optional[str] = None  # pylint: disable=invalid-name
-    agent: Optional[str] = None
+    agent__mbox: Optional[str] = None
+    agent__mbox_sha1sum: Optional[str] = None
+    agent__openid: Optional[str] = None
+    agent__account__name: Optional[str] = None
+    agent__account__home_page: Optional[str] = None
     verb: Optional[str] = None
     activity: Optional[str] = None
     registration: Optional[UUID] = None
@@ -65,6 +69,33 @@ class StatementParameters:
     ascending: Optional[bool] = False
     search_after: Optional[str] = None
     pit_id: Optional[str] = None
+
+    def __post_init__(self):
+        """Perform additional conformity verifications on parameters."""
+        # Check that both `homePage` and `name` are provided if `account` is being used
+        if (self.agent__account__name is not None) != (
+            self.agent__account__home_page is not None
+        ):
+            raise BackendParameterException(
+                "Invalid agent parameters: home_page and name are both required"
+            )
+
+        # Check that no more than one Inverse Functional Identifier is provided
+        if (
+            sum(
+                x is not None
+                for x in [
+                    self.agent__mbox,
+                    self.agent__mbox_sha1sum,
+                    self.agent__openid,
+                    self.agent__account__name,
+                ]
+            )
+            > 1
+        ):
+            raise BackendParameterException(
+                "Invalid agent parameters: Only one identifier can be used"
+            )
 
 
 def enforce_query_checks(method):

--- a/src/ralph/backends/database/clickhouse.py
+++ b/src/ralph/backends/database/clickhouse.py
@@ -277,8 +277,24 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
         if params["statementId"]:
             where_clauses.append("event_id = {statementId:UUID}")
 
-        if params["agent"]:
-            where_clauses.append("event.actor.account.name = {agent:String}")
+        if params["agent__mbox"]:
+            where_clauses.append("event.actor.mbox = {agent__mbox:String}")
+
+        if params["agent__mbox_sha1sum"]:
+            where_clauses.append(
+                "event.actor.mbox_sha1sum = {agent__mbox_sha1sum:String}"
+            )
+
+        if params["agent__openid"]:
+            where_clauses.append("event.actor.openid = {agent__openid:String}")
+
+        if params["agent__account__name"]:
+            where_clauses.append(
+                "event.actor.account.name = {agent__account__name:String}"
+            )
+            where_clauses.append(
+                "event.actor.account.homePage = {agent__account__home_page:String}"
+            )
 
         if params["verb"]:
             where_clauses.append("event.verb.id = {verb:String}")

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -148,13 +148,35 @@ class ESDatabase(BaseDatabase):
 
     def query_statements(self, params: StatementParameters) -> StatementQueryResult:
         """Returns the results of a statements query using xAPI parameters."""
+        # pylint: disable=too-many-branches
+
         es_query_filters = []
 
         if params.statementId:
             es_query_filters += [{"term": {"_id": params.statementId}}]
 
-        if params.agent:
-            es_query_filters += [{"term": {"actor.account.name.keyword": params.agent}}]
+        if params.agent__mbox:
+            es_query_filters += [{"term": {"actor.mbox.keyword": params.agent__mbox}}]
+
+        if params.agent__mbox_sha1sum:
+            es_query_filters += [
+                {"term": {"actor.mbox_sha1sum.keyword": params.agent__mbox_sha1sum}}
+            ]
+
+        if params.agent__openid:
+            es_query_filters += [
+                {"term": {"actor.openid.keyword": params.agent__openid}}
+            ]
+
+        if params.agent__account__name:
+            es_query_filters += [
+                {"term": {"actor.account.name.keyword": params.agent__account__name}},
+                {
+                    "term": {
+                        "actor.account.homePage.keyword": params.agent__account__home_page  # pylint: disable=line-too-long # noqa: E501
+                    }
+                },
+            ]
 
         if params.verb:
             es_query_filters += [{"term": {"verb.id.keyword": params.verb}}]

--- a/src/ralph/backends/database/mongo.py
+++ b/src/ralph/backends/database/mongo.py
@@ -192,8 +192,24 @@ class MongoDatabase(BaseDatabase):
         if params.statementId:
             mongo_query_filters.update({"_source.id": params.statementId})
 
-        if params.agent:
-            mongo_query_filters.update({"_source.actor.account.name": params.agent})
+        if params.agent__mbox:
+            mongo_query_filters.update({"_source.actor.mbox": params.agent__mbox})
+
+        if params.agent__mbox_sha1sum:
+            mongo_query_filters.update(
+                {"_source.actor.mbox_sha1sum": params.agent__mbox_sha1sum}
+            )
+
+        if params.agent__openid:
+            mongo_query_filters.update({"_source.actor.openid": params.agent__openid})
+
+        if params.agent__account__name:
+            mongo_query_filters.update(
+                {"_source.actor.account.name": params.agent__account__name}
+            )
+            mongo_query_filters.update(
+                {"_source.actor.account.homePage": params.agent__account__home_page}
+            )
 
         if params.verb:
             mongo_query_filters.update({"_source.verb.id": params.verb})


### PR DESCRIPTION
## Purpose

The xAPI specification proposes identifying Agents using 4 methods (called [Inverse Functional Identifier](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#2423-inverse-functional-identifier)). Currently the API and backend only handle the `account` method (using `name` and `homePage`). 

Additionally, [the xAPI specification](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#213-get-statements) requires for the `GET /statements?agent=` endpoint to accept JSON (Agent or group of Agents) as a value for query parameter `agent`. Currently, this parameter accepts string and only filters on  `agent.account.name`.

## Proposal

The proposed change aims to allow querying for Agents (**groups of agents is still NOT handled**) following the specification.

- [x] Change `GET /statements?agent=` to accept JSON and parse JSON as Agent object
- [x] Update databases to query all 4 types of Inverse Functional Identifier
- [x] Test filtering by `agent` using all 4 Inverse Functional Identifier methods  
- [x] Update CHANGELOG 

