### PR TITLE
🔖(minor) bump release to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+
+## [3.6.0] - 2023-05-17
+
+### Added
+
+- Allow to ignore health check routes for Sentry transactions
+
 ### Changed
 
 - Upgrade `sentry_sdk` to `1.22.2`
@@ -16,7 +23,6 @@ and this project adheres to
 as per the xAPI specification
 - Use batch/v1 api in cronjob_pipeline manifest
 - Use autoscaling/v2 in HorizontalPodAutoscaler manifest
-- Add the ability to ignore health check routes for Sentry transactions
 
 ### Fixed
 
@@ -289,7 +295,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.5.1...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.6.0...master
+[3.6.0]: https://github.com/openfun/ralph/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/openfun/ralph/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/openfun/ralph/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/openfun/ralph/compare/v3.3.0...v3.4.0

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,5 +1,5 @@
 metadata:
   name: ralph
-  version: 3.5.1
+  version: 3.6.0
 source:
   path: src/tray

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.5.1
+version = 3.6.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5.1"
+appVersion: "3.6.0"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.5.1"
+__version__ = "3.6.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.5.1
+  version: 3.6.0


### PR DESCRIPTION
## Added

- Add the ability to ignore health check routes for Sentry transactions

## Changed

- Upgrade `sentry_sdk` to `1.22.2`
- Upgrade `uvicorn` to `0.22.0`
- LRS `/statements` `GET` method returns a code 400 with certain parameters
as per the xAPI specification
- Use batch/v1 api in cronjob_pipeline manifest
- Use autoscaling/v2 in HorizontalPodAutoscaler manifest

## Fixed

- Fix the `more` IRL building in LRS `/statements` GET requests

