### PR TITLE
💚(circle) display test coverage in ci

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -133,7 +133,7 @@ skip_glob=venv
 profile=black
 
 [tool:pytest]
-addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=src/ralph
+addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=ralph
 python_files =
     test_*.py
     tests.py


### PR DESCRIPTION
## Purpose

Coverage was displaying correctly locally, but not on the CI test runs.

## Proposal

`src/ralph` path for pytest-cov works locally when Ralph is installed in editable mode, but does not work on the CI test runs where Ralph is installed in non editable mode (when the source files are under `site-packages/ralph`). A `ralph` path now covers both cases.
