### PR TITLE
💥(cli) Add mandatory "agent" field to credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 - Upgrade `httpx` to `0.24.1`
 - Force a valid (JSON-formatted) IFI to be passed for the `/statements` 
 GET query `agent` filtering
+- User credentials must now include an "agent" field which can be created 
+using the cli
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ RALPH_IMAGE_BUILD_TARGET ?= development
 RALPH_LRS_AUTH_USER_NAME  = ralph
 RALPH_LRS_AUTH_USER_PWD   = secret
 RALPH_LRS_AUTH_USER_SCOPE = ralph_scope
+RALPH_LRS_AUTH_USER_AGENT_MBOX = mailto:ralph@example.com
 
 # -- K3D
 K3D_CLUSTER_NAME              ?= ralph
@@ -65,6 +66,7 @@ bin/init-cluster:
 		-u $(RALPH_LRS_AUTH_USER_NAME) \
 		-p $(RALPH_LRS_AUTH_USER_PWD) \
 		-s $(RALPH_LRS_AUTH_USER_SCOPE) \
+		-M $(RALPH_LRS_AUTH_USER_AGENT_MBOX)
 		-w
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,20 +27,31 @@ documentation for
 details](https://click.palletsprojects.com/en/8.1.x/api/#click.get_app_dir)).
 
 The expected format is a list of entries (JSON objects) each containing the
-username, the user's `bcrypt` hashed+salted password and scopes they can
-access:
+username, the user's `bcrypt` hashed+salted password, scopes they can
+access, and an `agent` object used to represent the user in the LRS. The 
+`agent` is constrained by [LRS specifications](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#description-2), and must use one of four valid 
+[Inverse Functional Identifiers](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#inversefunctional).
 
 ```json
 [
   {
     "username": "john.doe@example.com",
     "hash": "$2b$12$yBXrzIuRIk6yaft5KUgVFOIPv0PskCCh9PXmF2t7pno.qUZ5LK0D2",
-    "scopes": ["example_scope"]
+    "scopes": ["example_scope"],
+    "agent": {
+      "mbox": "mailto:john.doe@example.com"
+    }
   },
   {
     "username": "simon.says@example.com",
     "hash": "$2b$12$yBXrzIuRIk6yaft5KUgVFOIPv0PskCCh9PXmF2t7pno.qUZ5LK0D2",
-    "scopes": ["second_scope", "third_scope"]
+    "scopes": ["second_scope", "third_scope"],
+    "agent": {
+      "account": {
+        "name": "simonsAccountName",
+        "homePage": "http://www.exampleHomePage.com"
+      }
+    }
   }
 ]
 ```
@@ -52,6 +63,11 @@ $ ralph auth \
     --username janedoe \
     --password supersecret \
     --scope janedoe_scope \
+    --agent-mbox mailto:janedoe@example.com \
+    # or --agent-mbox-sha1sum ebd31e95054c018b10727ccffd2ef2ec3a016ee9\
+    # or --agent-openid "http://jane.openid.example.org/" \
+    # or --agent-account-name exampleAccountname \
+    #    --agent-account-homePage http://www.exampleHomePage.com \
     -w
 ```
 
@@ -78,7 +94,7 @@ Send your username and password to the API server through HTTP Basic Auth:
 ```bash
 $ curl --user john.doe@example.com:PASSWORD http://localhost:8100/whoami
 < HTTP/1.1 200 OK
-< {"username":"john.doe@example.com","scopes":["authenticated","example_scope"]}
+< {"scopes":["example_scope"], "agent": {"mbox": "mailto:john.doe@example.com"}}
 ```
 
 ### Forwarding statements

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -46,4 +46,4 @@ app.include_router(health.router)
 @app.get("/whoami")
 async def whoami(user: AuthenticatedUser = Depends(authenticated_user)):
     """Return the current user's username along with their scopes."""
-    return {"username": user.username, "scopes": user.scopes}
+    return {"agent": user.agent, "scopes": user.scopes}

--- a/src/ralph/api/auth.py
+++ b/src/ralph/api/auth.py
@@ -3,7 +3,7 @@
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import bcrypt
 from fastapi import Depends, HTTPException, status
@@ -29,11 +29,11 @@ class AuthenticatedUser(BaseModel):
     """Pydantic model for user authentication.
 
     Attributes:
-        username (str): Consists of the username of the current user.
+        agent (dict): The agent representing the current user.
         scopes (List): Consists of the scopes the user has access to.
     """
 
-    username: str
+    agent: Dict
     scopes: List[str]
 
 
@@ -41,12 +41,12 @@ class UserCredentials(AuthenticatedUser):
     """Pydantic model for user credentials as stored in the credentials file.
 
     Attributes:
-        username (str): Consists of the username for a declared user.
         hash (str): Consists of the hashed password for a declared user.
-        scopes (List): Consists of the scopes a declared has access to.
+        username (str): Consists of the username for a declared user.
     """
 
     hash: str
+    username: str
 
 
 class ServerUsersCredentials(BaseModel):
@@ -165,4 +165,4 @@ def authenticated_user(credentials: HTTPBasicCredentials = Depends(security)):
             headers={"WWW-Authenticate": "Basic"},
         )
 
-    return AuthenticatedUser(username=credentials.username, scopes=user.scopes)
+    return AuthenticatedUser(scopes=user.scopes, agent=user.agent)

--- a/src/ralph/backends/database/clickhouse.py
+++ b/src/ralph/backends/database/clickhouse.py
@@ -269,48 +269,94 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
             logger.error("%s. %s", msg, error)
             raise BackendException(msg, *error.args) from error
 
+    @staticmethod
+    def _add_agent_filters(
+        clickhouse_params, where_clauses, agent_params, target_field
+    ):
+        """Add filters relative to agents to `clickhouse_params` and `where_clauses`.
+
+        Args:
+            clickhouse_params: values to be used in `where_clauses`
+            where_clauses: filters to be passed to clickhouse
+            agent_params: query parameters that represent the agent to search for
+            target_field: the field in the database in which to perform the search
+        """
+        if agent_params.mbox:
+            clickhouse_params[f"{target_field}__mbox"] = agent_params.mbox
+            where_clauses.append(
+                f"event.{target_field}.mbox = {{{target_field}__mbox:String}}"
+            )
+
+        if agent_params.mbox_sha1sum:
+            clickhouse_params[
+                f"{target_field}__mbox_sha1sum"
+            ] = agent_params.mbox_sha1sum
+            where_clauses.append(
+                f"event.{target_field}.mbox_sha1sum = {{{target_field}__mbox_sha1sum:String}}"  # noqa: E501 # pylint: disable=line-too-long
+            )
+
+        if agent_params.openid:
+            clickhouse_params[f"{target_field}__openid"] = agent_params.openid
+            where_clauses.append(
+                f"event.{target_field}.openid = {{{target_field}__openid:String}}"
+            )
+
+        if agent_params.account__name:
+            clickhouse_params[
+                f"{target_field}__account__name"
+            ] = agent_params.account__name
+            clickhouse_params[
+                f"{target_field}__account__home_page"
+            ] = agent_params.account__home_page
+            where_clauses.append(
+                f"event.{target_field}.account.name = {{{target_field}__account__name:String}}"  # noqa: E501 # pylint: disable=line-too-long
+            )
+            where_clauses.append(
+                f"event.{target_field}.account.homePage = {{{target_field}__account__home_page:String}}"  # noqa: E501 # pylint: disable=line-too-long
+            )
+
     def query_statements(self, params: StatementParameters) -> StatementQueryResult:
         """Returns the results of a statements query using xAPI parameters."""
-        params = asdict(params)
+        # pylint: disable=too-many-branches
+        # pylint: disable=invalid-name
+
+        clickhouse_params = asdict(params)
         where_clauses = []
 
-        if params["statementId"]:
+        if params.statementId:
             where_clauses.append("event_id = {statementId:UUID}")
 
-        if params["agent__mbox"]:
-            where_clauses.append("event.actor.mbox = {agent__mbox:String}")
+        self._add_agent_filters(
+            clickhouse_params,
+            where_clauses,
+            params.__dict__["agent"],
+            target_field="actor",
+        )
+        clickhouse_params.pop("agent")
 
-        if params["agent__mbox_sha1sum"]:
-            where_clauses.append(
-                "event.actor.mbox_sha1sum = {agent__mbox_sha1sum:String}"
-            )
+        self._add_agent_filters(
+            clickhouse_params,
+            where_clauses,
+            params.__dict__["authority"],
+            target_field="authority",
+        )
+        clickhouse_params.pop("authority")
 
-        if params["agent__openid"]:
-            where_clauses.append("event.actor.openid = {agent__openid:String}")
-
-        if params["agent__account__name"]:
-            where_clauses.append(
-                "event.actor.account.name = {agent__account__name:String}"
-            )
-            where_clauses.append(
-                "event.actor.account.homePage = {agent__account__home_page:String}"
-            )
-
-        if params["verb"]:
+        if params.verb:
             where_clauses.append("event.verb.id = {verb:String}")
 
-        if params["activity"]:
+        if params.activity:
             where_clauses.append("event.object.objectType = 'Activity'")
             where_clauses.append("event.object.id = {activity:String}")
 
-        if params["since"]:
+        if params.since:
             where_clauses.append("emission_time > {since:DateTime64(6)}")
 
-        if params["until"]:
+        if params.until:
             where_clauses.append("emission_time <= {until:DateTime64(6)}")
 
-        if params["search_after"]:
-            search_order = ">" if params["ascending"] else "<"
+        if params.search_after:
+            search_order = ">" if params.ascending else "<"
 
             where_clauses.append(
                 f"(emission_time {search_order} "
@@ -323,11 +369,14 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
                 "))"
             )
 
-        sort_order = "ASCENDING" if params["ascending"] else "DESCENDING"
+        sort_order = "ASCENDING" if params.ascending else "DESCENDING"
         order_by = f"emission_time {sort_order}, event_id {sort_order}"
 
         response = self._find(
-            where=where_clauses, parameters=params, limit=params["limit"], sort=order_by
+            where=where_clauses,
+            parameters=clickhouse_params,
+            limit=params.limit,
+            sort=order_by,
         )
         response = list(response)
 

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -238,28 +238,130 @@ def backends_options(name=None, backend_types: List[BaseModel] = None):
     help="The user scope(s). This option can be provided multiple times.",
 )
 @click.option(
+    "-M",
+    "--agent-ifi-mbox",
+    type=str,
+    required=False,
+    help="The mbox Inverse Functional Identifier of the associated agent.",
+)
+@click.option(
+    "-S",
+    "--agent-ifi-mbox-sha1sum",
+    type=str,
+    required=False,
+    help="The mbox-sha1sum Inverse Functional Identifier of the associated agent.",
+)
+@click.option(
+    "-O",
+    "--agent-ifi-openid",
+    type=str,
+    required=False,
+    help="The openid Inverse Functional Identifier of the associated agent.",
+)
+@click.option(
+    "-A",
+    "--agent-ifi-account",
+    type=str,
+    nargs=2,
+    required=False,
+    help=(
+        'Input "{name} {homePage}". The account Inverse Functional Identifier of the '
+        "associated agent."
+    ),
+)
+@click.option(
+    "-N",
+    "--agent-name",
+    type=str,
+    required=False,
+    help="The name of the associated agent.",
+)
+@click.option(
     "-w",
     "--write",
     is_flag=True,
     default=False,
     help="Write new credentials to the LRS authentication file.",
 )
-def auth(username, password, scope, write):
+# pylint: disable=too-many-arguments, too-many-locals
+def auth(
+    username,
+    password,
+    scope,
+    write,
+    agent_ifi_mbox,
+    agent_ifi_mbox_sha1sum,
+    agent_ifi_openid,
+    agent_ifi_account,
+    agent_name,
+):
     """Generate credentials for LRS HTTP basic authentification."""
     logger.info("Will generate credentials for user: %s", username)
+
+    # Verify that exactly one agent representation has been provided
+    if (
+        sum(
+            opt is not None
+            for opt in [
+                agent_ifi_mbox,
+                agent_ifi_mbox_sha1sum,
+                agent_ifi_openid,
+                agent_ifi_account,
+            ]
+        )
+        != 1
+    ):
+        raise click.UsageError(
+            "Exactly one (1) of the ifi options is required. These options are:\n"
+            "-M --agent-ifi-mbox : mbox Agent IFI\n"
+            "-S --agent-ifi-mboxsha1sum : mbox-sha1sum Agent IFIr\n"
+            "-O --agent-ifi-openid : openid Agent IFI\n"
+            "-A --agent-ifi-account : account Agent IFI"
+        )
 
     # Import required Pydantic models dynamically so that we don't create a
     # direct dependency between the CLI and the LRS
     # pylint: disable=invalid-name
     ServerUsersCredentials = import_string("ralph.api.auth.ServerUsersCredentials")
-    UserCredentials = import_string("ralph.api.auth.UserCredentials")
+    UserCredentialsBasicAuth = import_string("ralph.api.auth.UserCredentials")
 
-    credentials = UserCredentials(
+    # NB: renaming classes below for clarity
+    Account = import_string("ralph.models.xapi.base.ifi.BaseXapiAccount")
+    AgentMbox = import_string("ralph.models.xapi.base.agents.BaseXapiAgentWithMbox")
+    AgentMboxSha1sum = import_string(
+        "ralph.models.xapi.base.agents.BaseXapiAgentWithMboxSha1Sum"
+    )
+    AgentOpenid = import_string("ralph.models.xapi.base.agents.BaseXapiAgentWithOpenId")
+    AgentAccount = import_string(
+        "ralph.models.xapi.base.agents.BaseXapiAgentWithAccount"
+    )
+
+    if agent_ifi_mbox:
+        if agent_ifi_mbox[:7] != "mailto:":
+            raise click.UsageError(
+                'Mbox field must start with "mailto:" (e.g.: "mailto:foo@bar.com")'
+            )
+        agent = AgentMbox(mbox=agent_ifi_mbox, name=agent_name, objectType="Agent")
+    if agent_ifi_mbox_sha1sum:
+        agent = AgentMboxSha1sum(
+            mbox_sha1sum=agent_ifi_mbox_sha1sum, name=agent_name, objectType="Agent"
+        )
+    if agent_ifi_openid:
+        agent = AgentOpenid(
+            openid=agent_ifi_openid, name=agent_name, objectType="Agent"
+        )
+    if agent_ifi_account:
+        # Parse account details
+        account = Account(homePage=agent_ifi_account[1], name=agent_ifi_account[0])
+        agent = AgentAccount(account=account, name=agent_name, objectType="Agent")
+
+    credentials = UserCredentialsBasicAuth(
         username=username,
         hash=bcrypt.hashpw(
             bytes(password, encoding=settings.LOCALE_ENCODING), bcrypt.gensalt()
         ).decode("ascii"),
         scopes=scope,
+        agent=agent,
     )
 
     if write:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -11,15 +11,26 @@ def test_api_auth_model_serveruserscredentials():
     users = ServerUsersCredentials(
         __root__=[
             UserCredentials(
-                username="johndoe", hash="notrealhash", scopes=["johndoe_scope"]
+                username="johndoe",
+                hash="notrealhash",
+                scopes=["johndoe_scope"],
+                agent={"mbox": "mailto:johndoe@example.com"},
             ),
-            UserCredentials(username="foo", hash="notsorealhash", scopes=["foo_scope"]),
+            UserCredentials(
+                username="foo",
+                hash="notsorealhash",
+                scopes=["foo_scope"],
+                agent={"mbox": "mailto:foo@example.com"},
+            ),
         ]
     )
     other_users = ServerUsersCredentials.parse_obj(
         [
             UserCredentials(
-                username="janedoe", hash="notreallyrealhash", scopes=["janedoe_scope"]
+                username="janedoe",
+                hash="notreallyrealhash",
+                scopes=["janedoe_scope"],
+                agent={"mbox": "mailto:janedoe@example.com"},
             ),
         ]
     )
@@ -48,7 +59,10 @@ def test_api_auth_model_serveruserscredentials():
         users += ServerUsersCredentials.parse_obj(
             [
                 UserCredentials(
-                    username="foo", hash="notsorealhash", scopes=["foo_scope"]
+                    username="foo",
+                    hash="notsorealhash",
+                    scopes=["foo_scope"],
+                    agent={"mbox": "mailto:foo2@example.com"},
                 ),
             ]
         )

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -253,11 +253,13 @@ def test_api_statements_get_statements_by_agent(
             "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
             "timestamp": datetime.now().isoformat(),
             "actor": agent_1,
+            "authority": agent_1,
         },
         {
             "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
             "timestamp": datetime.now().isoformat(),
             "actor": agent_2,
+            "authority": agent_1,
         },
     ]
     insert_statements_and_monkeypatch_backend(statements)

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -5,33 +5,68 @@ import json
 import bcrypt
 import pytest
 
+from ralph.api.auth import get_stored_credentials
 from ralph.conf import settings
 
 
-# pylint: disable=invalid-name
-@pytest.fixture
-def auth_credentials(fs):
-    """Sets up the credentials file for request authentication.
+def create_user(fs_, user: str, pwd: str, scopes: list, agent: dict):
+    """Create a user using Basic Auth in the (fake) file system.
 
-    Returns:
-        credentials (str): auth parameters that need to be passed
-            through headers to authenticate the request.
+    Args:
+        fs_: fixture provided by pyfakefs
+        user: username used for auth
+        pwd: password used for auth
+        scopes (List[str]): list of scopes available to the user
+        agent (dict): an agent that represents the user and may be used as authority
     """
-    credential_bytes = base64.b64encode("ralph:admin".encode("utf-8"))
+    credential_bytes = base64.b64encode(f"{user}:{pwd}".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
+    auth_file_path = settings.AUTH_FILE  # settings.APP_DIR / "auth.json"
 
-    auth_file_path = settings.APP_DIR / "auth.json"
-    fs.create_file(
+    # Clear lru_cache to allow for auth testing within same function
+    get_stored_credentials.cache_clear()
+
+    fs_.create_file(
         auth_file_path,
         contents=json.dumps(
             [
                 {
-                    "username": "ralph",
-                    "hash": bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode("UTF-8"),
-                    "scopes": ["ralph_test_scope"],
+                    "username": user,
+                    "hash": bcrypt.hashpw(
+                        bytes(pwd.encode("utf-8")), bcrypt.gensalt()
+                    ).decode("UTF-8"),
+                    "scopes": scopes,
+                    "agent": agent,
                 }
             ]
         ),
     )
+    return credentials
+
+
+# pylint: disable=invalid-name
+@pytest.fixture
+def auth_credentials(fs, user_scopes=None, agent=None):
+    """Sets up the credentials file for request authentication.
+
+    Args:
+        fs: fixture provided by pyfakefs (not called in the code)
+        user_scopes (List[str]): list of scopes to associate to the user
+
+    Returns:
+        credentials (str): auth parameters that need to be passed
+            through headers to authenticate the request.
+        user_scopes (List[str]): list of scopes for the created user
+        agent (dict): valid Agent (per xAPI specification) representing the user
+    """
+
+    user = "ralph"
+    pwd = "admin"
+    if user_scopes is None:
+        user_scopes = ["all"]
+    if agent is None:
+        agent = {"mbox": "mailto:test_ralph@example.com"}
+
+    credentials = create_user(fs, user, pwd, user_scopes, agent)
 
     return credentials

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -18,6 +18,7 @@ STORED_CREDENTIALS = json.dumps(
             "username": "ralph",
             "hash": bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode("UTF-8"),
             "scopes": ["ralph_test_scope"],
+            "agent": {"mbox": "mailto:ralph@example.com"},
         }
     ]
 )
@@ -95,6 +96,6 @@ def test_get_whoami_correct_credentials(fs):
 
     assert response.status_code == 200
     assert response.json() == {
-        "username": "ralph",
+        "agent": {"mbox": "mailto:ralph@example.com"},
         "scopes": ["ralph_test_scope"],
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from pathlib import Path
+from typing import Union
 
 import pytest
 from click.exceptions import BadParameter
@@ -160,88 +161,250 @@ def test_cli_help_option():
     ) in result.output
 
 
-def test_cli_auth_command_without_writing_auth_file():
-    """Test ralph auth command when credentials are displayed in the tty."""
-    runner = CliRunner()
-    result = runner.invoke(cli, ["auth", "-u", "foo", "-p", "bar", "-s", "foo_scope"])
+# pylint: disable=too-many-arguments
+def _gen_cli_auth_args(
+    username: str,
+    password: str,
+    scopes: list,
+    ifi_command: str,
+    ifi_value: Union[str, dict],
+    agent_name: str = None,
+    write: bool = False,
+):
+    """Generate arguments for cli to create user."""
+    cli_args = ["auth", "-u", username, "-p", password]
+    for scope in scopes:
+        cli_args.extend(["-s", scope])
+    cli_args.append(ifi_command)
+    cli_args.extend(ifi_value.split())
+    if agent_name:
+        cli_args.extend(["-N", agent_name])
+    if write:
+        cli_args.append("-w")
+    return cli_args
 
-    assert result.exit_code == 0
 
-    credentials = json.loads("".join(result.output.split("\n")[-8:-1]))
-    assert credentials["username"] == "foo"
+# pylint: disable=too-many-arguments
+def _assert_matching_basic_auth_credentials(
+    credentials: dict,
+    username: str,
+    scopes: list,
+    ifi_type: str,
+    ifi_value: Union[str, dict],
+    agent_name: str = None,
+    hash_: str = None,
+):
+    """Assert that credentials match other arguments.
+
+    args:
+        credentials: credentials to match against
+        username: username that should match credentials
+        scopes: scopes that should match credentials
+        ifi_type: type of ifi used in credentials. One of "mbox",
+            "mbox_sha1sum", "openid", or "account"
+        ifi_value: value of ifi
+        agent_name: name to assign to agent. If None, no matching is performed
+        hash: hash value of the password. If None, no matching is performed
+    """
+    assert credentials["username"] == username
     assert "hash" in credentials
-    assert len(credentials["scopes"]) == 1
-    assert credentials["scopes"][0] == "foo_scope"
+    if hash_:
+        assert credentials["hash"] == hash_
+    assert credentials["scopes"] == scopes
+    assert "agent" in credentials
 
-    # Test multiple scopes
-    result = runner.invoke(
-        cli, ["auth", "-u", "foo", "-p", "bar", "-s", "foo_scope", "-s", "admin_scope"]
+    if agent_name is not None:
+        assert credentials["agent"]["name"] == agent_name
+
+    if "objectType" in credentials["agent"]:
+        assert credentials["agent"]["objectType"] == "Agent"
+
+    if ifi_type in ["mbox", "mbox_sha1sum", "openid"]:
+        assert ifi_type in credentials["agent"]
+        assert credentials["agent"][ifi_type] == ifi_value
+    elif ifi_type == "account":
+        assert "account" in credentials["agent"]
+        assert "name" in credentials["agent"]["account"]
+        assert "homePage" in credentials["agent"]["account"]
+        assert credentials["agent"]["account"] == ifi_value
+    else:
+        raise ValueError(
+            'ifi_type should be one of: "mbox", "mbox_sha1sum", "openid", "account"'
+        )
+
+
+def _ifi_type_from_command(ifi_command):
+    """Return the ifi_type associated to the command being passed to cli"""
+    if ifi_command not in ["-M", "-S", "-O", "-A"]:
+        raise ValueError('The ifi_command must be one of: "-M", "-S", "-O", "-A"')
+
+    return {"-M": "mbox", "-S": "mbox_sha1sum", "-O": "openid", "-A": "account"}[
+        ifi_command
+    ]
+
+
+def _ifi_value_from_command(ifi_value, ifi_type):
+    """Parse ifi_value returned by cli to generate dict when `ifi_type` is `account`"""
+    if ifi_type == "account":
+        # Parse arguments from cli
+        return {"name": ifi_value.split()[0], "homePage": ifi_value.split()[1]}
+    return ifi_value
+
+
+@pytest.mark.parametrize(
+    "scopes,ifi_command,ifi_value",
+    [
+        (["foo_scope"], "-M", "mailto:foo@bar.com"),  # mbox ifi
+        (["foo_scope", "admin_scope"], "-M", "mailto:foo@bar.com"),
+        (
+            ["foo_scope"],
+            "-S",
+            "ebd31e95054c018b10727ccffd2ef2ec3a016ee9",
+        ),  # mbox_sha1sum ifi
+        (["foo_scope"], "-O", "http://foo.openid.example.org/"),  # mbox_openid ifi
+        (["foo_scope"], "-A", "foo_name http://www.bar.xyz"),  # account ifi
+    ],
+)
+def test_cli_auth_command_without_writing_auth_file(scopes, ifi_command, ifi_value):
+    """Test ralph auth command when credentials are displayed in the tty."""
+
+    username = "foo"
+    password = "bar"
+    agent_name = "foobarname"  # optional name
+
+    cli_args = _gen_cli_auth_args(
+        username,
+        password,
+        scopes,
+        ifi_command,
+        ifi_value,
+        agent_name=agent_name,
+        write=False,
     )
 
+    runner = CliRunner()
+    result = runner.invoke(cli, cli_args)
+
     assert result.exit_code == 0
 
-    credentials = json.loads("".join(result.output.split("\n")[-9:-1]))
-    assert credentials["username"] == "foo"
-    assert "hash" in credentials
-    assert len(credentials["scopes"]) == 2
-    assert credentials["scopes"][0] == "foo_scope"
-    assert credentials["scopes"][1] == "admin_scope"
+    credentials = json.loads(result.output.split(".json", 1)[1].strip())
+
+    ifi_type = _ifi_type_from_command(ifi_command=ifi_command)
+    ifi_value = _ifi_value_from_command(ifi_value, ifi_type)
+
+    _assert_matching_basic_auth_credentials(
+        credentials=credentials,
+        username=username,
+        scopes=scopes,
+        ifi_type=ifi_type,
+        ifi_value=ifi_value,
+        agent_name=agent_name,
+    )
 
 
 # pylint: disable=invalid-name,unused-argument
-def test_cli_auth_command_when_writing_auth_file(fs):
+@pytest.mark.parametrize(
+    "ifi_command_1, ifi_value_1, ifi_command_2, ifi_value_2",
+    [
+        (
+            "-M",
+            "mailto:foo@bar.com",
+            "-S",
+            "ebd31e95054c018b10727ccffd2ef2ec3a016ee9",
+        ),  # mbox ifi
+        (
+            "-S",
+            "ebd31e95054c018b10727ccffd2ef2ec3a016ee9",
+            "-O",
+            "http://foo.openid.example.org/",
+        ),  # mbox_sha1sum ifi
+        (
+            "-O",
+            "http://foo.openid.example.org/",
+            "-A",
+            "foo_name http://www.bar.xyz",
+        ),  # mbox_openid ifi
+        (
+            "-A",
+            "foo_name http://www.bar.xyz",
+            "-M",
+            "mailto:foo@bar.com",
+        ),  # account ifi
+    ],
+)
+# pylint: disable=too-many-locals
+def test_cli_auth_command_when_writing_auth_file(
+    fs, ifi_command_1, ifi_value_1, ifi_command_2, ifi_value_2
+):
     """Test ralph auth command when credentials are written in the authentication
     file.
     """
     runner = CliRunner()
 
+    username_1 = "foo"
+    password_1 = "bar"
+    scopes_1 = ["tele_scope"]
+
     # The authentication file does not exist
-    assert Path(settings.AUTH_FILE).exists() is False
-    result = runner.invoke(
-        cli, ["auth", "-u", "foo", "-p", "bar", "-s", "foo_scope", "-w"]
+
+    # Add a first user
+    cli_args = _gen_cli_auth_args(
+        username_1, password_1, scopes_1, ifi_command_1, ifi_value_1, write=True
     )
+
+    assert Path(settings.AUTH_FILE).exists() is False
+    result = runner.invoke(cli, cli_args)
     assert result.exit_code == 0
     assert Path(settings.AUTH_FILE).exists() is True
     with Path(settings.AUTH_FILE).open(encoding="utf-8") as auth_file:
         all_credentials = json.loads("\n".join(auth_file.readlines()))
     assert len(all_credentials) == 1
-    credentials = all_credentials[0]
-    assert credentials["username"] == "foo"
-    assert "hash" in credentials
-    assert len(credentials["scopes"]) == 1
-    assert credentials["scopes"][0] == "foo_scope"
 
-    # Add a new user
-    result = runner.invoke(
-        cli,
-        [
-            "auth",
-            "-u",
-            "lol",
-            "-p",
-            "baz",
-            "-s",
-            "lol_scope",
-            "-s",
-            "admin_scope",
-            "-w",
-        ],
+    # Check that the first user matches
+    ifi_type_1 = _ifi_type_from_command(ifi_command=ifi_command_1)
+    ifi_value_1 = _ifi_value_from_command(ifi_value_1, ifi_type_1)
+    _assert_matching_basic_auth_credentials(
+        credentials=all_credentials[0],
+        username=username_1,
+        scopes=scopes_1,
+        ifi_type=ifi_type_1,
+        ifi_value=ifi_value_1,
     )
+
+    # Add a second user
+    username_2 = "lol"
+    password_2 = "baz"
+    scopes_2 = ["steto_scope", "peri_scope"]
+
+    cli_args = _gen_cli_auth_args(
+        username_2, password_2, scopes_2, ifi_command_2, ifi_value_2, write=True
+    )
+    result = runner.invoke(cli, cli_args)
+
     assert result.exit_code == 0
     with Path(settings.AUTH_FILE).open(encoding="utf-8") as auth_file:
         all_credentials = json.loads("\n".join(auth_file.readlines()))
     assert len(all_credentials) == 2
-    credentials = all_credentials[0]
-    assert credentials["username"] == "foo"
-    assert "hash" in credentials
-    assert len(credentials["scopes"]) == 1
-    assert credentials["scopes"][0] == "foo_scope"
-    credentials = all_credentials[1]
-    assert credentials["username"] == "lol"
-    assert "hash" in credentials
-    assert len(credentials["scopes"]) == 2
-    assert credentials["scopes"][0] == "lol_scope"
-    assert credentials["scopes"][1] == "admin_scope"
+
+    # Check that the first user still matches
+    _assert_matching_basic_auth_credentials(
+        credentials=all_credentials[0],
+        username=username_1,
+        scopes=scopes_1,
+        ifi_type=ifi_type_1,
+        ifi_value=ifi_value_1,
+    )
+
+    # Check that the second user matches
+    ifi_type_2 = _ifi_type_from_command(ifi_command=ifi_command_2)
+    ifi_value_2 = _ifi_value_from_command(ifi_value_2, ifi_type_2)
+    _assert_matching_basic_auth_credentials(
+        credentials=all_credentials[1],
+        username=username_2,
+        scopes=scopes_2,
+        ifi_type=ifi_type_2,
+        ifi_value=ifi_value_2,
+    )
 
 
 # pylint: disable=invalid-name

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -14,18 +14,21 @@ def test_cli_auth_command_usage():
     result = runner.invoke(cli, ["auth", "--help"])
 
     assert result.exit_code == 0
-    assert (
-        "Options:\n"
-        "  -u, --username TEXT  The user for which we generate credentials.  "
-        "[required]\n"
-        "  -p, --password TEXT  The password to encrypt for this user. Will be "
-        "prompted\n"
-        "                       if missing.  [required]\n"
-        "  -s, --scope TEXT     The user scope(s). This option can be provided "
-        "multiple\n"
-        "                       times.  [required]\n"
-        "  -w, --write          Write new credentials to the LRS authentication file.\n"
-    ) in result.output
+    assert all(
+        text in result.output
+        for text in [
+            "Options:",
+            "-u, --username TEXT",
+            "-p, --password TEXT",
+            "-s, --scope TEXT",
+            "-M, --agent-ifi-mbox TEXT",
+            "-S, --agent-ifi-mbox-sha1sum TEXT",
+            "-O, --agent-ifi-openid TEXT",
+            "-A, --agent-ifi-account TEXT",
+            "-N, --agent-name TEXT",
+            "-w, --write",
+        ]
+    )
 
     result = runner.invoke(cli, ["auth"])
     assert result.exit_code > 0


### PR DESCRIPTION
## Purpose

In link with #288 , we need a mechanism to assign an "Agent" ([in the sense of the xAPI specification](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#2421-when-the-actor-objecttype-is-agent)) to a user (to later be able to infer the "Authority" field when writing a statement). 

It was proposed  to add the "agent" representation as a field in the user credentials, which is what this PR implements. There is no contraint as to which of the 4 valid [IFI's](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#2423-inverse-functional-identifier) must be used.

## Proposal

Add "agent" to user credentials.

- [x] update make file with default agent (using "mbox" IFI)
- [x] update cli to create "agent" field when creating a new user
- [x] write tests 
- [x] update documentation

