### PR TITLE
🔖(minor) bump release to 3.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,6 +483,45 @@ jobs:
             git config --global user.name "FUN MOOC Bot"
             ~/.local/bin/mkdocs gh-deploy
 
+  # Make a new github release
+  release:
+    docker:
+      - image: cimg/base:current
+        auth:
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASSWORD
+    working_directory: ~/fun
+    steps:
+      - checkout
+      - *docker-login
+      - attach_workspace:
+          at: ~/fun
+      - run:
+          name: Install gh CLI
+          command: |
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+              sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+              sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
+            sudo apt install gh
+      - run:
+          name: Define release reference
+          command: |
+            echo 'RELEASE=$(echo "${CIRCLE_TAG}")' >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Get release changes
+          command: |
+            tag="${RELEASE/v/}" ;
+            sed -E -n "/^## \[${tag}\]/,/^##\ /{/^## \[${tag}\]/d ;/^##\ /d; p}" CHANGELOG.md > release.md
+      - run:
+          name: Create release on GitHub
+          command: |
+            gh config set prompt disabled
+            if ! gh release list | grep "${RELEASE}"; then
+              gh release create -F release.md -t "${RELEASE/v/}" "${RELEASE}";
+            fi
 workflows:
   version: 2
 
@@ -623,3 +662,14 @@ workflows:
               only: master
             tags:
               only: /.*/
+
+      # Release
+      - release:
+          requires:
+            - tray
+            - package
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.7.0] - 2023-06-13
+
 ### Added
 
 - Implement synchronous `lrs` backend
@@ -30,6 +32,7 @@ GET query `agent` filtering
 ### Removed
 
 - `verb`.`display` field no longer mandatory in xAPI models and for converter
+
 ## [3.6.0] - 2023-05-17
 
 ### Added
@@ -316,7 +319,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.6.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.7.0...master
+[3.7.0]: https://github.com/openfun/ralph/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/openfun/ralph/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/openfun/ralph/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/openfun/ralph/compare/v3.4.0...v3.5.0

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,5 +1,5 @@
 metadata:
   name: ralph
-  version: 3.6.0
+  version: 3.7.0
 source:
   path: src/tray

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.6.0
+version = 3.7.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.6.0"
+appVersion: "3.7.0"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.6.0
+  version: 3.7.0


### PR DESCRIPTION
### Added

- Implement synchronous `lrs` backend
- Implement xAPI virtual classroom pydantic models
- Allow to insert custom endpoint url for S3 service
- Cache the HTTP Basic auth credentials to improve API response time
- Support OpenID Connect authentication method

### Changed

- Clean xAPI pydantic models naming convention
- Upgrade `fastapi` to `0.97.0`
- Upgrade `sentry_sdk` to `1.25.1`
- Set Clickhouse `client_options` to a dedicated Pydantic model
- Upgrade `httpx` to `0.24.1`
- Force a valid (JSON-formatted) IFI to be passed for the `/statements`
GET query `agent` filtering
- Upgrade `cachetools` to `5.3.1`

### Removed

- `verb`.`display` field no longer mandatory in xAPI models and for converter

