### PR TITLE
⚡️(cli) allow to use a query for HTTP backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Allow to use a query for HTTP backends in the CLI
+
 ## [3.7.0] - 2023-06-13
 
 ### Added
@@ -15,7 +19,7 @@ and this project adheres to
 - Implement synchronous `lrs` backend
 - Implement xAPI virtual classroom pydantic models
 - Allow to insert custom endpoint url for S3 service
-- Cache the HTTP Basic auth credentials to improve API response time   
+- Cache the HTTP Basic auth credentials to improve API response time
 - Support OpenID Connect authentication method
 
 ### Changed
@@ -25,7 +29,7 @@ and this project adheres to
 - Upgrade `sentry_sdk` to `1.25.1`
 - Set Clickhouse `client_options` to a dedicated Pydantic model
 - Upgrade `httpx` to `0.24.1`
-- Force a valid (JSON-formatted) IFI to be passed for the `/statements` 
+- Force a valid (JSON-formatted) IFI to be passed for the `/statements`
 GET query `agent` filtering
 - Upgrade `cachetools` to `5.3.1`
 

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -466,7 +466,7 @@ def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs)
     "--query",
     type=JSONStringParamType(),
     default=None,
-    help="Query object as a JSON string (database backends ONLY)",
+    help="Query object as a JSON string (database and HTTP backends ONLY)",
 )
 def fetch(backend, archive, chunk_size, target, query, **options):
     """Fetch an archive or records from a configured backend."""
@@ -502,7 +502,11 @@ def fetch(backend, archive, chunk_size, target, query, **options):
     elif backend_type == settings.BACKENDS.STREAM:
         backend.stream(sys.stdout.buffer)
     elif backend_type == settings.BACKENDS.HTTP:
-        for statement in backend.read(target=target, chunk_size=chunk_size):
+        if query is not None:
+            query = backend.query(query=query)
+        for statement in backend.read(
+            target=target, query=query, chunk_size=chunk_size
+        ):
             click.echo(
                 bytes(
                     json.dumps(statement) if isinstance(statement, dict) else statement,

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -165,8 +165,9 @@ def test_cli_fetch_command_usage():
         "  -t, --target TEXT               Endpoint from which to fetch events (e.g.\n"
         "                                  `/statements`)\n"
         '  -q, --query \'{"KEY": "VALUE", "KEY": "VALUE"}\'\n'
-        "                                  Query object as a JSON string (database\n"
-        "                                  backends ONLY)\n"
+        "                                  Query object as a JSON string (database "
+        "and\n"
+        "                                  HTTP backends ONLY)\n"
     ) in result.output
     logging.warning(result.output)
     result = runner.invoke(cli, ["fetch"])


### PR DESCRIPTION
## Purpose

When using the LRS backend to fetch statements with the CLI, it seems mandatory to be able to filter statements using a standard LRS query (`since`, `until`, `verb`, etc...).

## Proposal

- [x] activate the `query` parameter for HTTP backends
