### PR TITLE
🔖(minor) bump release to 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.8.0] - 2023-06-21
+
 ### Added
 
 - Implement edX open response assessment events pydantic models
 - Implement edx peer instruction events pydantic models
 - Implement xAPI VideoDownloaded pydantic model
-(using xAPI TinCan `downloaded` verb)
+  (using xAPI TinCan `downloaded` verb)
 
 ### Changed
 
@@ -331,7 +333,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.7.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.8.0...master
+[3.8.0]: https://github.com/openfun/ralph/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/openfun/ralph/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/openfun/ralph/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/openfun/ralph/compare/v3.5.0...v3.5.1

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,5 +1,5 @@
 metadata:
   name: ralph
-  version: 3.7.0
+  version: 3.8.0
 source:
   path: src/tray

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.7.0
+version = 3.8.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.7.0"
+appVersion: "3.8.0"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.7.0
+  version: 3.8.0


### PR DESCRIPTION
## [3.8.0] - 2023-06-21

### Added

- Implement edX open response assessment events pydantic models
- Implement edx peer instruction events pydantic models
- Implement xAPI VideoDownloaded pydantic model
  (using xAPI TinCan `downloaded` verb)

### Changed

- Allow to use a query for HTTP backends in the CLI

