### PR TITLE
📝(api) improve API statements documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ General improvement for the Helm Chart:
 - remove prefix label from ingress object name
 - add missing namespace label
 - make object name consistent
+- add statement API documentation
 
 ## [3.8.0] - 2023-06-21
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,7 +90,7 @@ This command updates your credentials file with the new `janedoe` user.
 
 (Work In Progress)
 
-#### Making a GET request
+#### Validating Authentication
 
 The first request that can be answered by the ralph API server is a `whoami` request, which checks if the user is authenticated and returns their username and permission scopes.
 
@@ -137,7 +137,7 @@ The [Learning analytics playground](https://github.com/openfun/learning-analytic
 
 (Work In Progress)
 
-#### Making a GET request
+#### Validating Authentication
 
 The first request that can be answered by the ralph API server is a `whoami` request, which checks if the user is authenticated and returns their username and permission scopes.
 
@@ -181,6 +181,14 @@ $ curl http://localhost:8100/whoami --header "Authorization: Bearer eyJhbGciOiJS
 < HTTP/1.1 200 OK
 < {"username":"ralph_admin","scopes":["all"]}
 ```
+
+## The statement API
+
+Ralph's statements API can be used to POST, PUT, GET and DELETE xApi statements.
+
+To use the statements API on a running server, connect to `http://localhost:8100/xAPI/statements`. You will have to be authenticated to make a call.
+
+
 
 ## Forwarding statements
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -182,9 +182,9 @@ $ curl http://localhost:8100/whoami --header "Authorization: Bearer eyJhbGciOiJS
 < {"username":"ralph_admin","scopes":["all"]}
 ```
 
-## The statement API
+## The Statement Resource API
 
-Ralph's statements API can be used to POST, PUT, GET and DELETE xApi statements.
+Ralph's statements API can be used to POST, PUT, GET and DELETE xAPI statements.
 
 To use the statements API on a running server, connect to `http://localhost:8100/xAPI/statements`. You will have to be authenticated to make a call.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 Ralph comes with an API server that aims to implement the Learning Record Store
 (LRS) specification (still a work in progress).
 
-## Getting started
+## Authenticating via API
 
 The API server supports the following authentication methods:
 


### PR DESCRIPTION
## Purpose

Add a clear guide to the API documentation about how the statements API works 

## Proposal

The current getting started header will be changed to a header for authenticating. A new section will be added with an in depth explanation about calling the statements endpoints.

- [x] Update document structure
- [x] Add statements section

