### PR TITLE
🦺(models) make ProfileActivity presence mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ have an authority field matching that of the user
 - Upgrade `uvicorn` to `0.23.2`
 - API: Invalid parameters now return 400 status code
 - API: Forwarding PUT now uses PUT (instead of POST)
+- Models: The xAPI `context.contextActivities.category` field is now mandatory
+  in the video and virtual classroom profiles. [BC]
 
 ## [3.9.0] - 2023-07-21
 

--- a/src/ralph/models/edx/converters/xapi/video.py
+++ b/src/ralph/models/edx/converters/xapi/video.py
@@ -52,6 +52,11 @@ class VideoBaseXapiConverter(BaseXapiConverter):
                     + event["event"]["id"],
                 ),
                 ConversionItem(
+                    "context__contextActivities__category",
+                    None,
+                    lambda _: [{"id": "https://w3id.org/xapi/video"}],
+                ),
+                ConversionItem(
                     "context__extensions__" + CONTEXT_EXTENSION_SESSION_ID,
                     "session",
                 ),

--- a/src/ralph/models/xapi/video/statements.py
+++ b/src/ralph/models/xapi/video/statements.py
@@ -1,7 +1,5 @@
 """Video xAPI event definitions."""
 
-from typing import Optional
-
 from ...selector import selector
 from ..base.statements import BaseXapiStatement
 from ..concepts.activity_types.video import VideoActivity
@@ -84,7 +82,7 @@ class VideoPlayed(BaseVideoStatement):
 
     verb: PlayedVerb = PlayedVerb()
     result: VideoPlayedResult
-    context: Optional[VideoPlayedContext]
+    context: VideoPlayedContext
 
 
 class VideoPaused(BaseVideoStatement):
@@ -127,7 +125,7 @@ class VideoSeeked(BaseVideoStatement):
 
     verb: SeekedVerb = SeekedVerb()
     result: VideoSeekedResult
-    context: Optional[VideoSeekedContext]
+    context: VideoSeekedContext
 
 
 class VideoCompleted(BaseVideoStatement):

--- a/tests/models/edx/converters/xapi/test_video.py
+++ b/tests/models/edx/converters/xapi/test_video.py
@@ -35,6 +35,8 @@ def test_ui_load_video_to_video_initialized(uuid_namespace, event, platform_url)
     event.context.course_id = ""
     event.context.org_id = ""
     event.context.user_id = "1"
+    event.session = "af45a0e650c4a4fdb0bcde75a1e4b694"
+    session_uuid = "af45a0e6-50c4-a4fd-b0bc-de75a1e4b694"
     event_str = event.json()
     event = json.loads(event_str)
     xapi_event = convert_dict_event(
@@ -47,13 +49,21 @@ def test_ui_load_video_to_video_initialized(uuid_namespace, event, platform_url)
         "actor": {"account": {"homePage": platform_url, "name": "1"}},
         "verb": {"id": "http://adlnet.gov/expapi/verbs/initialized"},
         "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/video",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
             "extensions": {
                 "https://w3id.org/xapi/video/extensions/length": 0.0,
-                "https://w3id.org/xapi/video/extensions/session-id": str(
-                    UUID(event["session"])
-                ),
+                "https://w3id.org/xapi/video/extensions/session-id": session_uuid,
                 "https://w3id.org/xapi/video/extensions/user-agent": event["agent"],
-            }
+            },
         },
         "object": {
             "id": platform_url
@@ -81,6 +91,8 @@ def test_ui_play_video_to_video_played(uuid_namespace, event, platform_url):
     event.context.course_id = ""
     event.context.org_id = ""
     event.context.user_id = "1"
+    event.session = "af45a0e650c4a4fdb0bcde75a1e4b694"
+    session_uuid = "af45a0e6-50c4-a4fd-b0bc-de75a1e4b694"
     event_str = event.json()
     event = json.loads(event_str)
     xapi_event = convert_dict_event(
@@ -110,10 +122,18 @@ def test_ui_play_video_to_video_played(uuid_namespace, event, platform_url):
             }
         },
         "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/video",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
             "extensions": {
-                "https://w3id.org/xapi/video/extensions/session-id": str(
-                    UUID(event["session"])
-                ),
+                "https://w3id.org/xapi/video/extensions/session-id": session_uuid,
             },
         },
         "timestamp": event["time"],
@@ -131,6 +151,8 @@ def test_ui_pause_video_to_video_paused(uuid_namespace, event, platform_url):
     event.context.course_id = ""
     event.context.org_id = ""
     event.context.user_id = "1"
+    event.session = "af45a0e650c4a4fdb0bcde75a1e4b694"
+    session_uuid = "af45a0e6-50c4-a4fd-b0bc-de75a1e4b694"
     event_str = event.json()
     event = json.loads(event_str)
     xapi_event = convert_dict_event(
@@ -153,12 +175,20 @@ def test_ui_pause_video_to_video_paused(uuid_namespace, event, platform_url):
             },
         },
         "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/video",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
             "extensions": {
                 "https://w3id.org/xapi/video/extensions/length": 0.0,
-                "https://w3id.org/xapi/video/extensions/session-id": str(
-                    UUID(event["session"])
-                ),
-            }
+                "https://w3id.org/xapi/video/extensions/session-id": session_uuid,
+            },
         },
         "result": {
             "extensions": {
@@ -182,6 +212,8 @@ def test_ui_stop_video_to_video_terminated(uuid_namespace, event, platform_url):
     event.context.course_id = ""
     event.context.org_id = ""
     event.context.user_id = "1"
+    event.session = "af45a0e650c4a4fdb0bcde75a1e4b694"
+    session_uuid = "af45a0e6-50c4-a4fd-b0bc-de75a1e4b694"
     event_str = event.json()
     event = json.loads(event_str)
     xapi_event = convert_dict_event(
@@ -204,12 +236,20 @@ def test_ui_stop_video_to_video_terminated(uuid_namespace, event, platform_url):
             },
         },
         "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/video",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
             "extensions": {
                 "https://w3id.org/xapi/video/extensions/length": 0.0,
-                "https://w3id.org/xapi/video/extensions/session-id": str(
-                    UUID(event["session"])
-                ),
-            }
+                "https://w3id.org/xapi/video/extensions/session-id": session_uuid,
+            },
         },
         "result": {
             "extensions": {
@@ -234,6 +274,8 @@ def test_ui_seek_video_to_video_seeked(uuid_namespace, event, platform_url):
     event.context.course_id = ""
     event.context.org_id = ""
     event.context.user_id = "1"
+    event.session = "af45a0e650c4a4fdb0bcde75a1e4b694"
+    session_uuid = "af45a0e6-50c4-a4fd-b0bc-de75a1e4b694"
     event_str = event.json()
     event = json.loads(event_str)
     xapi_event = convert_dict_event(
@@ -266,10 +308,18 @@ def test_ui_seek_video_to_video_seeked(uuid_namespace, event, platform_url):
             }
         },
         "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/video",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
             "extensions": {
-                "https://w3id.org/xapi/video/extensions/session-id": str(
-                    UUID(event["session"])
-                ),
+                "https://w3id.org/xapi/video/extensions/session-id": session_uuid,
             },
         },
         "timestamp": event["time"],


### PR DESCRIPTION
## Purpose

The latest version of the xapi video profile (1.0.3) seems to enforce the presence of a video profile activity in the
`context.contextActivities.category` field, which was previously validated to optionally contain the profile activity value.

## Proposal

- [x] make the presence of a ProfileActivity mandatory in video and virtual classroom profile statements

