### PR TITLE
✅(tests) use requests_mock fixture in LDPDataBackend tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,7 @@ dev =
     pytest-asyncio==0.21.1
     pytest-cov==4.1.0
     pytest-httpx==0.22.0
+    requests-mock==1.11.0
     responses==0.23.1
 ci =
     twine==4.0.2


### PR DESCRIPTION
## Purpose

We want to simplify our tests that are mocking the `request` package.

## Proposal

- [x] use the `request_mock` library to mock the request.

