### PR TITLE
♻️(backends) change how duplicate statement ids are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to
 ## [Unreleased]
 
 ### Changed
-- Change how duplicate xAPI statements are handled by backends
 
+- Change how duplicate xAPI statements are handled by backends
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## [Unreleased]
 
 ### Changed
+- Change how duplicate xAPI statements are handled by backends
+
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/src/ralph/backends/database/mongo.py
+++ b/src/ralph/backends/database/mongo.py
@@ -254,8 +254,11 @@ class MongoDatabase(BaseDatabase):
         )
 
     def query_statements_by_ids(self, ids: List[str]) -> List:
-        """Returns the list of matching statement IDs from the database."""
-        return self._find(filter={"_source.id": {"$in": ids}})
+        """Returns the list of matching statements from the database."""
+        return [
+            {"_id": statement["_source"]["id"], "_source": statement["_source"]}
+            for statement in self._find(filter={"_source.id": {"$in": ids}})
+        ]
 
     def _find(self, **kwargs):
         """Wraps the MongoClient.collection.find method.

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -224,7 +224,9 @@ def test_api_statements_put_statement_duplicate_of_existing_statement(
     )
 
     assert response.status_code == 409
-    assert response.json() == {"detail": "Statement already exists with the same ID"}
+    assert response.json() == {
+        "detail": "A different statement already exists with the same ID"
+    }
 
     response = client.get(
         f"/xAPI/statements/?statementId={statement['id']}",

--- a/tests/backends/database/test_mongo.py
+++ b/tests/backends/database/test_mongo.py
@@ -470,16 +470,20 @@ def test_backends_database_mongo_query_statements_by_ids_with_multiple_collectio
 
     # Insert documents
     timestamp = {"timestamp": "2022-06-27T15:36:50"}
-    collection_1_document = list(MongoDatabase.to_documents([{"id": "1", **timestamp}]))
-    collection_2_document = list(MongoDatabase.to_documents([{"id": "2", **timestamp}]))
+    statement_1 = {"id": "1", **timestamp}
+    statement_1_expected = [{"_id": "1", "_source": statement_1}]
+    statement_2 = {"id": "2", **timestamp}
+    statement_2_expected = [{"_id": "2", "_source": statement_2}]
+    collection_1_document = list(MongoDatabase.to_documents([statement_1]))
+    collection_2_document = list(MongoDatabase.to_documents([statement_2]))
     backend_1.bulk_import(collection_1_document)
     backend_2.bulk_import(collection_2_document)
 
     # Check the expected search query results
-    assert backend_1.query_statements_by_ids(["1"]) == collection_1_document
-    assert backend_1.query_statements_by_ids(["2"]) == []
+    assert backend_1.query_statements_by_ids(["1"]) == statement_1_expected
     assert backend_2.query_statements_by_ids(["1"]) == []
-    assert backend_2.query_statements_by_ids(["2"]) == collection_2_document
+    assert backend_2.query_statements_by_ids(["2"]) == statement_2_expected
+    assert backend_1.query_statements_by_ids(["2"]) == []
 
 
 def test_backends_database_mongo_status(mongo):


### PR DESCRIPTION
## Purpose

Allow duplicate statements ids to pass without throwing errors if the statements are identical.

## Proposal

As discussed in #345 I've implemented changes to only throw 429 errors when the statements differ. This should allow bulk backfill of data or catching up statements lost due to operational errors to succeed in most cases.

A side effect of this refactor is that all backends should now have the same return structure from `query_statements_by_ids`. Previously they all differed slightly.