### PR TITLE
(auth) Integration of "agent" field and "mine" query param with OpenIDConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 - Upgrade `uvicorn` to `0.23.0`
 - Enforce valid IRI for `activity` parameter in `GET /statements`
 - Change how duplicate xAPI statements are handled for `clickhouse` backend
+- User credentials must now include an "agent" field which can be created 
+using the cli
+
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to
 - Change how duplicate xAPI statements are handled for `clickhouse` backend
 - User credentials must now include an "agent" field which can be created 
 using the cli
-
+- `GET /statements` now has "mine" option which matches statements that
+have an authority field matching that of the user
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ RALPH_IMAGE_BUILD_TARGET ?= development
 RALPH_LRS_AUTH_USER_NAME  = ralph
 RALPH_LRS_AUTH_USER_PWD   = secret
 RALPH_LRS_AUTH_USER_SCOPE = ralph_scope
+RALPH_LRS_AUTH_USER_AGENT_MBOX = mailto:ralph@example.com
 
 # -- K3D
 K3D_CLUSTER_NAME              ?= ralph
@@ -65,6 +66,7 @@ bin/init-cluster:
 		-u $(RALPH_LRS_AUTH_USER_NAME) \
 		-p $(RALPH_LRS_AUTH_USER_PWD) \
 		-s $(RALPH_LRS_AUTH_USER_SCOPE) \
+		-M $(RALPH_LRS_AUTH_USER_AGENT_MBOX)
 		-w
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,20 +36,31 @@ documentation for
 details](https://click.palletsprojects.com/en/8.1.x/api/#click.get_app_dir)).
 
 The expected format is a list of entries (JSON objects) each containing the
-username, the user's `bcrypt` hashed+salted password and scopes they can
-access:
+username, the user's `bcrypt` hashed+salted password, scopes they can
+access, and an `agent` object used to represent the user in the LRS. The 
+`agent` is constrained by [LRS specifications](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#description-2), and must use one of four valid 
+[Inverse Functional Identifiers](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#inversefunctional).
 
 ```json
 [
   {
     "username": "john.doe@example.com",
     "hash": "$2b$12$yBXrzIuRIk6yaft5KUgVFOIPv0PskCCh9PXmF2t7pno.qUZ5LK0D2",
-    "scopes": ["example_scope"]
+    "scopes": ["example_scope"],
+    "agent": {
+      "mbox": "mailto:john.doe@example.com"
+    }
   },
   {
     "username": "simon.says@example.com",
     "hash": "$2b$12$yBXrzIuRIk6yaft5KUgVFOIPv0PskCCh9PXmF2t7pno.qUZ5LK0D2",
-    "scopes": ["second_scope", "third_scope"]
+    "scopes": ["second_scope", "third_scope"],
+    "agent": {
+      "account": {
+        "name": "simonsAccountName",
+        "homePage": "http://www.exampleHomePage.com"
+      }
+    }
   }
 ]
 ```
@@ -61,6 +72,11 @@ $ ralph auth \
     --username janedoe \
     --password supersecret \
     --scope janedoe_scope \
+    --agent-mbox mailto:janedoe@example.com \
+    # or --agent-mbox-sha1sum ebd31e95054c018b10727ccffd2ef2ec3a016ee9\
+    # or --agent-openid "http://jane.openid.example.org/" \
+    # or --agent-account-name exampleAccountname \
+    #    --agent-account-homePage http://www.exampleHomePage.com \
     -w
 ```
 
@@ -91,7 +107,7 @@ Send your username and password to the API server through HTTP Basic Auth:
 ```bash
 $ curl --user john.doe@example.com:PASSWORD http://localhost:8100/whoami
 < HTTP/1.1 200 OK
-< {"username":"john.doe@example.com","scopes":["authenticated","example_scope"]}
+< {"scopes":["example_scope"], "agent": {"mbox": "mailto:john.doe@example.com"}}
 ```
 
 ### OpenID Connect authentication

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -49,4 +49,4 @@ async def whoami(
     user: AuthenticatedUser = Depends(get_authenticated_user),
 ):
     """Return the current user's username along with their scopes."""
-    return {"username": user.username, "scopes": user.scopes}
+    return {"agent": user.agent, "scopes": user.scopes}

--- a/src/ralph/api/auth/basic.py
+++ b/src/ralph/api/auth/basic.py
@@ -32,12 +32,12 @@ class UserCredentials(AuthenticatedUser):
     """Pydantic model for user credentials as stored in the credentials file.
 
     Attributes:
-        username (str): Consists of the username for a declared user.
         hash (str): Consists of the hashed password for a declared user.
-        scopes (List): Consists of the scopes a declared has access to.
+        username (str): Consists of the username for a declared user.
     """
 
     hash: str
+    username: str
 
 
 class ServerUsersCredentials(BaseModel):
@@ -182,4 +182,4 @@ def get_authenticated_user(
             headers={"WWW-Authenticate": "Basic"},
         )
 
-    return AuthenticatedUser(username=credentials.username, scopes=user.scopes)
+    return AuthenticatedUser(scopes=user.scopes, agent=user.agent)

--- a/src/ralph/api/auth/user.py
+++ b/src/ralph/api/auth/user.py
@@ -1,6 +1,6 @@
 """Authenticated user for the Ralph API."""
 
-from typing import List, Optional
+from typing import Dict, List
 
 from pydantic import BaseModel
 
@@ -9,9 +9,9 @@ class AuthenticatedUser(BaseModel):
     """Pydantic model for user authentication.
 
     Attributes:
-        username (str): Consists of the username of the current user.
-        scopes (list): Consists of the scopes the user has access to.
+        agent (dict): The agent representing the current user.
+        scopes (list): The scopes the user has access to.
     """
 
-    username: str
-    scopes: Optional[List[str]]
+    agent: Dict
+    scopes: List[str]

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -1,5 +1,6 @@
 """API routes related to statements."""
 
+import json
 import logging
 from datetime import datetime
 from typing import List, Literal, Optional, Union
@@ -16,10 +17,12 @@ from fastapi import (
     Response,
     status,
 )
-from pydantic import parse_raw_as
+from pydantic import parse_obj_as
 from pydantic.types import Json
+from typing_extensions import Annotated
 
 from ralph.api.auth import get_authenticated_user
+from ralph.api.auth.user import AuthenticatedUser
 from ralph.api.forwarding import forward_xapi_statements, get_active_xapi_forwardings
 from ralph.backends.database.base import (
     AgentParameters,
@@ -63,11 +66,32 @@ POST_PUT_RESPONSES = {
 }
 
 
+def _parse_agent_parameters(agent_obj: dict):
+    """Parse a dict and return an AgentParameters object to use in queries."""
+    # Transform agent to `dict` as FastAPI cannot parse JSON (seen as string)
+    agent = parse_obj_as(BaseXapiAgent, agent_obj)
+
+    agent_query_params = {}
+    if isinstance(agent, BaseXapiAgentWithMbox):
+        agent_query_params["mbox"] = agent.mbox
+    elif isinstance(agent, BaseXapiAgentWithMboxSha1Sum):
+        agent_query_params["mbox_sha1sum"] = agent.mbox_sha1sum
+    elif isinstance(agent, BaseXapiAgentWithOpenId):
+        agent_query_params["openid"] = agent.openid
+    elif isinstance(agent, BaseXapiAgentWithAccount):
+        agent_query_params["account__name"] = agent.account.name
+        agent_query_params["account__home_page"] = agent.account.homePage
+
+    # Overwrite `agent` field
+    return AgentParameters(**agent_query_params)
+
+
 @router.get("")
 @router.get("/")
 # pylint: disable=too-many-arguments, too-many-locals
 async def get(
     request: Request,
+    current_user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
     ###
     # Query string parameters defined by the LRS specification
     ###
@@ -179,6 +203,13 @@ async def get(
     ascending: Optional[bool] = Query(
         False, description='If "true", return results in ascending order of stored time'
     ),
+    mine: Optional[bool] = Query(
+        False,
+        description=(
+            'If "true", return only the results for which the authority matches the '
+            '"agent" associated to the user that is making the query.'
+        ),
+    ),
     ###
     # Private use query string parameters
     ###
@@ -242,26 +273,20 @@ async def get(
             ),
         )
 
-    # Parse the agent parameter (JSON) into multiple string parameters
     query_params = dict(request.query_params)
 
+    # Parse the "agent" parameter (JSON) into multiple string parameters
     if query_params.get("agent") is not None:
-        # Transform agent to `dict` as FastAPI cannot parse JSON (seen as string)
+        # Overwrite `agent` field
+        query_params["agent"] = _parse_agent_parameters(
+            json.loads(query_params["agent"])
+        )
 
-        agent = parse_raw_as(BaseXapiAgent, query_params["agent"])
+    if mine:
+        query_params["authority"] = _parse_agent_parameters(current_user.agent)
 
-        agent_query_params = {}
-        if isinstance(agent, BaseXapiAgentWithMbox):
-            agent_query_params["mbox"] = agent.mbox
-        elif isinstance(agent, BaseXapiAgentWithMboxSha1Sum):
-            agent_query_params["mbox_sha1sum"] = agent.mbox_sha1sum
-        elif isinstance(agent, BaseXapiAgentWithOpenId):
-            agent_query_params["openid"] = agent.openid
-        elif isinstance(agent, BaseXapiAgentWithAccount):
-            agent_query_params["account__name"] = agent.account.name
-            agent_query_params["account__home_page"] = agent.account.homePage
-
-        query_params["agent"] = AgentParameters(**agent_query_params)
+    if "mine" in query_params:
+        query_params.pop("mine")
 
     # Query Database
     try:

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -21,7 +21,11 @@ from pydantic.types import Json
 
 from ralph.api.auth import get_authenticated_user
 from ralph.api.forwarding import forward_xapi_statements, get_active_xapi_forwardings
-from ralph.backends.database.base import BaseDatabase, StatementParameters
+from ralph.backends.database.base import (
+    AgentParameters,
+    BaseDatabase,
+    StatementParameters,
+)
 from ralph.conf import settings
 from ralph.exceptions import BackendException, BadFormatException
 from ralph.models.xapi.base.agents import (
@@ -240,21 +244,24 @@ async def get(
 
     # Parse the agent parameter (JSON) into multiple string parameters
     query_params = dict(request.query_params)
+
     if query_params.get("agent") is not None:
         # Transform agent to `dict` as FastAPI cannot parse JSON (seen as string)
+
         agent = parse_raw_as(BaseXapiAgent, query_params["agent"])
 
-        query_params.pop("agent")
-
+        agent_query_params = {}
         if isinstance(agent, BaseXapiAgentWithMbox):
-            query_params["agent__mbox"] = agent.mbox
+            agent_query_params["mbox"] = agent.mbox
         elif isinstance(agent, BaseXapiAgentWithMboxSha1Sum):
-            query_params["agent__mbox_sha1sum"] = agent.mbox_sha1sum
+            agent_query_params["mbox_sha1sum"] = agent.mbox_sha1sum
         elif isinstance(agent, BaseXapiAgentWithOpenId):
-            query_params["agent__openid"] = agent.openid
+            agent_query_params["openid"] = agent.openid
         elif isinstance(agent, BaseXapiAgentWithAccount):
-            query_params["agent__account__name"] = agent.account.name
-            query_params["agent__account__home_page"] = agent.account.homePage
+            agent_query_params["account__name"] = agent.account.name
+            agent_query_params["account__home_page"] = agent.account.homePage
+
+        query_params["agent"] = AgentParameters(**agent_query_params)
 
     # Query Database
     try:

--- a/src/ralph/backends/database/mongo.py
+++ b/src/ralph/backends/database/mongo.py
@@ -15,6 +15,7 @@ from ralph.conf import MongoClientOptions, settings
 from ralph.exceptions import BackendException, BadFormatException
 
 from .base import (
+    AgentParameters,
     BaseDatabase,
     BaseQuery,
     DatabaseStatus,
@@ -185,31 +186,56 @@ class MongoDatabase(BaseDatabase):
 
         return success
 
+    @staticmethod
+    def _add_agent_filters(
+        mongo_query_filters: dict, agent_params: AgentParameters, target_field: str
+    ):
+        """Add filters relative to agents to mongo_query_filters.
+
+        Args:
+            mongo_query_filters: filters to be passed to mongo
+            agent_params: query parameters that represent the agent to search for
+            target_field: the field in the database in which to perform the search
+        """
+        if agent_params.mbox:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.mbox": agent_params.mbox}
+            )
+
+        if agent_params.mbox_sha1sum:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.mbox_sha1sum": agent_params.mbox_sha1sum}
+            )
+
+        if agent_params.openid:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.openid": agent_params.openid}
+            )
+
+        if agent_params.account__name:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.account.name": agent_params.account__name}
+            )
+            mongo_query_filters.update(
+                {
+                    f"_source.{target_field}.account.homePage": agent_params.account__home_page  # noqa: E501 # pylint: disable=line-too-long
+                }
+            )
+
     def query_statements(self, params: StatementParameters) -> StatementQueryResult:
-        """Returns the results of a statements query using xAPI parameters."""
+        """Return the results of a statements query using xAPI parameters."""
+        # pylint: disable=too-many-branches
         mongo_query_filters = {}
 
         if params.statementId:
             mongo_query_filters.update({"_source.id": params.statementId})
 
-        if params.agent__mbox:
-            mongo_query_filters.update({"_source.actor.mbox": params.agent__mbox})
-
-        if params.agent__mbox_sha1sum:
-            mongo_query_filters.update(
-                {"_source.actor.mbox_sha1sum": params.agent__mbox_sha1sum}
-            )
-
-        if params.agent__openid:
-            mongo_query_filters.update({"_source.actor.openid": params.agent__openid})
-
-        if params.agent__account__name:
-            mongo_query_filters.update(
-                {"_source.actor.account.name": params.agent__account__name}
-            )
-            mongo_query_filters.update(
-                {"_source.actor.account.homePage": params.agent__account__home_page}
-            )
+        self._add_agent_filters(
+            mongo_query_filters, params.__dict__["agent"], target_field="actor"
+        )
+        self._add_agent_filters(
+            mongo_query_filters, params.__dict__["authority"], target_field="authority"
+        )
 
         if params.verb:
             mongo_query_filters.update({"_source.verb.id": params.verb})

--- a/tests/api/auth/test_basic.py
+++ b/tests/api/auth/test_basic.py
@@ -97,6 +97,7 @@ def test_api_auth_basic_caching_credentials(fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     credentials = HTTPBasicCredentials(username="ralph", password="admin")
 
@@ -117,6 +118,7 @@ def test_api_auth_basic_with_wrong_password(fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     credentials = HTTPBasicCredentials(username="ralph", password="wrong_password")
 
@@ -171,6 +173,7 @@ def test_get_whoami_username_not_found(basic_auth_test_client, fs):
     """Whoami route returns a 401 error when the username cannot be found."""
     credential_bytes = base64.b64encode("john:admin".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
+    get_authenticated_user.cache_clear()
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
@@ -192,6 +195,7 @@ def test_get_whoami_wrong_password(basic_auth_test_client, fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     response = basic_auth_test_client.get(
         "/whoami", headers={"Authorization": f"Basic {credentials}"}
@@ -213,6 +217,7 @@ def test_get_whoami_correct_credentials(basic_auth_test_client, fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     response = basic_auth_test_client.get(
         "/whoami", headers={"Authorization": f"Basic {credentials}"}

--- a/tests/api/auth/test_basic.py
+++ b/tests/api/auth/test_basic.py
@@ -23,6 +23,7 @@ STORED_CREDENTIALS = json.dumps(
             "username": "ralph",
             "hash": bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode("UTF-8"),
             "scopes": ["ralph_test_scope"],
+            "agent": {"mbox": "mailto:ralph@example.com"},
         }
     ]
 )
@@ -34,15 +35,26 @@ def test_api_auth_basic_model_serveruserscredentials():
     users = ServerUsersCredentials(
         __root__=[
             UserCredentials(
-                username="johndoe", hash="notrealhash", scopes=["johndoe_scope"]
+                username="johndoe",
+                hash="notrealhash",
+                scopes=["johndoe_scope"],
+                agent={"mbox": "mailto:johndoe@example.com"},
             ),
-            UserCredentials(username="foo", hash="notsorealhash", scopes=["foo_scope"]),
+            UserCredentials(
+                username="foo",
+                hash="notsorealhash",
+                scopes=["foo_scope"],
+                agent={"mbox": "mailto:foo@example.com"},
+            ),
         ]
     )
     other_users = ServerUsersCredentials.parse_obj(
         [
             UserCredentials(
-                username="janedoe", hash="notreallyrealhash", scopes=["janedoe_scope"]
+                username="janedoe",
+                hash="notreallyrealhash",
+                scopes=["janedoe_scope"],
+                agent={"mbox": "mailto:janedoe@example.com"},
             ),
         ]
     )
@@ -71,7 +83,10 @@ def test_api_auth_basic_model_serveruserscredentials():
         users += ServerUsersCredentials.parse_obj(
             [
                 UserCredentials(
-                    username="foo", hash="notsorealhash", scopes=["foo_scope"]
+                    username="foo",
+                    hash="notsorealhash",
+                    scopes=["foo_scope"],
+                    agent={"mbox": "mailto:foo2@example.com"},
                 ),
             ]
         )
@@ -90,7 +105,10 @@ def test_api_auth_basic_caching_credentials(fs):
 
     assert get_authenticated_user.cache.popitem() == (
         ("ralph", "admin"),
-        AuthenticatedUser(username="ralph", scopes=["ralph_test_scope"]),
+        AuthenticatedUser(
+            agent={"mbox": "mailto:ralph@example.com"},
+            scopes=["ralph_test_scope"],
+        ),
     )
 
 
@@ -202,6 +220,6 @@ def test_get_whoami_correct_credentials(basic_auth_test_client, fs):
 
     assert response.status_code == 200
     assert response.json() == {
-        "username": "ralph",
+        "agent": {"mbox": "mailto:ralph@example.com"},
         "scopes": ["ralph_test_scope"],
     }

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -40,7 +40,7 @@ def test_api_auth_oidc_valid(
     assert response.status_code == 200
     assert response.json() == {
         "scopes": ["all", "statements/read"],
-        "agent": {"homePage": "https://iss.example.com", "name": "123|oidc"},
+        "agent": {"openid": "123|oidc"},
     }
 
 

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -38,7 +38,10 @@ def test_api_auth_oidc_valid(
         headers={"Authorization": f"Bearer {encoded_token}"},
     )
     assert response.status_code == 200
-    assert response.json() == {"scopes": None, "username": "some-issuer/123|oidc"}
+    assert response.json() == {
+        "scopes": ["all", "statements/read"],
+        "agent": {"homePage": "https://iss.example.com", "name": "123|oidc"},
+    }
 
 
 @responses.activate

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -266,11 +266,13 @@ def test_api_statements_get_statements_by_agent(
             "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
             "timestamp": datetime.now().isoformat(),
             "actor": agent_1,
+            "authority": agent_1,
         },
         {
             "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
             "timestamp": datetime.now().isoformat(),
             "actor": agent_2,
+            "authority": agent_1,
         },
     ]
     insert_statements_and_monkeypatch_backend(statements)

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -14,18 +14,21 @@ def test_cli_auth_command_usage():
     result = runner.invoke(cli, ["auth", "--help"])
 
     assert result.exit_code == 0
-    assert (
-        "Options:\n"
-        "  -u, --username TEXT  The user for which we generate credentials.  "
-        "[required]\n"
-        "  -p, --password TEXT  The password to encrypt for this user. Will be "
-        "prompted\n"
-        "                       if missing.  [required]\n"
-        "  -s, --scope TEXT     The user scope(s). This option can be provided "
-        "multiple\n"
-        "                       times.  [required]\n"
-        "  -w, --write          Write new credentials to the LRS authentication file.\n"
-    ) in result.output
+    assert all(
+        text in result.output
+        for text in [
+            "Options:",
+            "-u, --username TEXT",
+            "-p, --password TEXT",
+            "-s, --scope TEXT",
+            "-M, --agent-ifi-mbox TEXT",
+            "-S, --agent-ifi-mbox-sha1sum TEXT",
+            "-O, --agent-ifi-openid TEXT",
+            "-A, --agent-ifi-account TEXT",
+            "-N, --agent-name TEXT",
+            "-w, --write",
+        ]
+    )
 
     result = runner.invoke(cli, ["auth"])
     assert result.exit_code > 0


### PR DESCRIPTION
## Purpose

Rebasing and integrating the works on authentication:
- On one side was added:
	- PR #342 💥(cli) add mandatory "agent" field to credentials
	- PR #343 ✨(api) add "mine" option to fetch statements with matching authority
- On the other side was added the OpenIdConnect authentication method:
	- PR #262 ✨(authentication) add OpenId Connect authentication


