### PR TITLE
(cli) Rename cli fetch & push to read & write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- CLI: change `push` to `write` and `fetch` to `read` [BC]
+
 ## [3.9.0] - 2023-07-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ $ ralph COMMAND --help
 > You should substitute `COMMAND` by the target command, _e.g._ `list`, to see
 > its usage.
 
+## Migrating
+
+Some major version changes require updating persistence layers. Check out the [migration guide](https://github.com/openfun/ralph/blob/master/UPGRADE.md) for more information.
+
 ## Documentation
 
 We try our best to maintain an up-to-date reference documentation for this

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -103,18 +103,18 @@ it's time to play with them:
 ```bash
 # Store a JSON file in the Swift backend
 $ echo '{"id": 1, "foo": "bar"}' | \
-    ./bin/ralph push -b swift -f foo.json
+    ./bin/ralph write -b swift -f foo.json
 
 # Check that we have created a new JSON file in the Swift backend
 $ bin/ralph list -b swift
 foo.json
 
-# Fetch the content of the JSON file and index it in Elasticsearch
-$ bin/ralph fetch -b swift foo.json | \
-    bin/ralph push -b es
+# Read the content of the JSON file and index it in Elasticsearch
+$ bin/ralph read -b swift foo.json | \
+    bin/ralph write -b es
 
 # Check that we have properly indexed the JSON file in Elasticsearch
-$ bin/ralph fetch -b es
+$ bin/ralph read -b es
 {"id": 1, "foo": "bar"}
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Ralph is a toolbox for your learning analytics, it can be used as a:
 
-- **library**, to fetch learning events from various backends, (de)serialize or
+- **library**, to read learning events from various backends, (de)serialize or
   convert them from various standard formats such as
   [xAPI](https://adlnet.gov/projects/xapi/),
 - **command-line interface** (CLI), to build data pipelines the UNIX-way™️,
@@ -38,15 +38,15 @@ base commands and UNIX standard streams (`stdin`, `stdout`) to connect them in
 a pipeline. A base example pipeline may be:
 
 ```sh
-$ ralph fetch --backend swift my_archive.gzip | \
+$ ralph read --backend swift my_archive.gzip | \
     gunzip | \
-    ralph push --backend es
+    ralph write --backend es
 ```
 
 In this small pipeline, we stream `my_archive.gzip` content from a Swift
-container to the standard output (using the `fetch` command), uncompress the
+container to the standard output (using the `read` command), uncompress the
 content (using the `gunzip` command), and bulk insert logs in an ElasticSearch
-index (using the `push` command).
+index (using the `write` command).
 
 As UNIX is beautiful, Ralph offers many powerful possibilities by combining its
 commands with other standard commands or command line tools.

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,7 @@ universal = 1
 max-line-length = 88
 extend-ignore = E203
 exclude =
-    .conda
+    .conda,
     .git,
     .venv,
     build,

--- a/src/helm/ralph/values.yaml
+++ b/src/helm/ralph/values.yaml
@@ -129,9 +129,9 @@ ralph_cronjobs:
     command:
       - ralph list --backend ldp --new |
         xargs -I {} -n 1 bash -c "
-        ralph fetch --backend ldp {} |
+        ralph read --backend ldp {} |
         gunzip |
         ralph extract -p gelf |
-        ralph push \
+        ralph write \
         --backend es \
         --es-client-options ca_certs=/usr/local/share/ca-certificates/es-cluster.pem"

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -229,7 +229,7 @@ async def get(
         ),
     ),
 ):
-    """Fetches a single xAPI Statement or multiple xAPI Statements.
+    """Read a single xAPI Statement or multiple xAPI Statements.
 
     LRS Specification:
     https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md#213-get-statements

--- a/src/ralph/backends/storage/fs.py
+++ b/src/ralph/backends/storage/fs.py
@@ -62,7 +62,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         logger.debug("Found %d archives", len(archives))
 
         if new:
-            archives = set(archives) - set(self.get_command_history(self.name, "fetch"))
+            archives = set(archives) - set(self.get_command_history(self.name, "read"))
             logger.debug("New archives: %d", len(archives))
 
         for archive in archives:
@@ -86,7 +86,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "filename": details.get("filename"),
                 "size": details.get("size"),
@@ -114,7 +114,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "push",
+                "command": "write",
                 "id": name,
                 "filename": details.get("filename"),
                 "size": details.get("size"),

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -104,7 +104,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         logger.debug("Found %d archives", len(archives))
 
         if new:
-            archives = set(archives) - set(self.get_command_history(self.name, "fetch"))
+            archives = set(archives) - set(self.get_command_history(self.name, "read"))
             logger.debug("New archives: %d", len(archives))
 
         for archive in archives:
@@ -130,7 +130,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "filename": details.get("filename"),
                 "size": details.get("size"),

--- a/src/ralph/backends/storage/s3.py
+++ b/src/ralph/backends/storage/s3.py
@@ -64,7 +64,7 @@ class S3Storage(
         """Lists archives in the storage backend."""
         archives_to_skip = set()
         if new:
-            archives_to_skip = set(self.get_command_history(self.name, "fetch"))
+            archives_to_skip = set(self.get_command_history(self.name, "read"))
 
         try:
             paginator = self.client.get_paginator("list_objects_v2")
@@ -114,7 +114,7 @@ class S3Storage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "size": size,
                 "fetched_at": now(),
@@ -141,7 +141,7 @@ class S3Storage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "push",
+                "command": "write",
                 "id": name,
                 "pushed_at": now(),
             }

--- a/src/ralph/backends/storage/swift.py
+++ b/src/ralph/backends/storage/swift.py
@@ -81,7 +81,7 @@ class SwiftStorage(
         """Lists files in the storage backend."""
         archives_to_skip = set()
         if new:
-            archives_to_skip = set(self.get_command_history(self.name, "fetch"))
+            archives_to_skip = set(self.get_command_history(self.name, "read"))
         with SwiftService(self.options) as swift:
             for page in swift.list(self.container):
                 if not page["success"]:
@@ -126,7 +126,7 @@ class SwiftStorage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "size": size,
                 "fetched_at": now(),
@@ -153,7 +153,7 @@ class SwiftStorage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "push",
+                "command": "write",
                 "id": name,
                 "pushed_at": now(),
             }

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -304,7 +304,7 @@ def backends_options(name=None, backend_types: List[BaseModel] = None):
 )
 @click.option(
     "-w",
-    "--write",
+    "--write-to-disk",
     is_flag=True,
     default=False,
     help="Write new credentials to the LRS authentication file.",
@@ -314,7 +314,7 @@ def auth(
     username,
     password,
     scope,
-    write,
+    write_to_disk,
     agent_ifi_mbox,
     agent_ifi_mbox_sha1sum,
     agent_ifi_openid,
@@ -392,7 +392,7 @@ def auth(
         agent=agent,
     )
 
-    if write:
+    if write_to_disk:
         logger.info("Will append new credentials to: %s", settings.AUTH_FILE)
 
         # Force Path object instantiation so that the file creation can be
@@ -561,7 +561,7 @@ def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs)
     "--target",
     type=str,
     default=None,
-    help="Endpoint from which to fetch events (e.g. `/statements`)",
+    help="Endpoint from which to read events (e.g. `/statements`)",
 )
 @click.option(
     "-q",
@@ -570,8 +570,8 @@ def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs)
     default=None,
     help="Query object as a JSON string (database and HTTP backends ONLY)",
 )
-def fetch(backend, archive, chunk_size, target, query, **options):
-    """Fetch an archive or records from a configured backend."""
+def read(backend, archive, chunk_size, target, query, **options):
+    """Read an archive or records from a configured backend."""
     logger.info(
         (
             "Fetching data from the configured %s backend "
@@ -673,9 +673,9 @@ def fetch(backend, archive, chunk_size, target, query, **options):
     "--target",
     type=str,
     default=None,
-    help="Endpoint in which to push events (e.g. `statements`)",
+    help="Endpoint in which to write events (e.g. `statements`)",
 )
-def push(
+def write(
     backend,
     archive,
     chunk_size,
@@ -686,8 +686,9 @@ def push(
     target,
     **options,
 ):
-    """Push an archive to a configured backend."""
-    logger.info("Pushing archive %s to the configured %s backend", archive, backend)
+    """Write an archive to a configured backend."""
+    logger.info("Writing archive %s to the configured %s backend", archive, backend)
+
     logger.debug("Backend parameters: %s", options)
 
     if max_num_simultaneous == 1:

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -21,10 +21,10 @@ ralph_mount_es_ca_secret: false
 #       - "-c"
 #       - ralph list --backend ldp --new |
 #           xargs -I {} -n 1 bash -c "
-#             ralph fetch --backend ldp {} |
+#             ralph read --backend ldp {} |
 #             gunzip |
 #             ralph extract -p gelf |
-#             ralph push \
+#             ralph write \
 #               --backend es \
 #               --es-client-options ca_certs=/usr/local/share/ca-certificates/es-cluster.pem"
 ralph_cronjobs: []

--- a/tests/backends/storage/test_ldp.py
+++ b/tests/backends/storage/test_ldp.py
@@ -229,14 +229,14 @@ def test_backends_storage_ldp_list_method_history_management(
     # Apply the monkeypatch for requests.post to mock_get
     monkeypatch.setattr(storage.client, "get", mock_list)
 
-    # Create a fetch history
+    # Create a read history
     fs.create_file(
         settings.HISTORY_FILE,
         contents=json.dumps(
             [
                 {
                     "backend": "ldp",
-                    "command": "fetch",
+                    "command": "read",
                     "id": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
                     "filename": "20201002.tgz",
                     "size": 23424233,
@@ -244,7 +244,7 @@ def test_backends_storage_ldp_list_method_history_management(
                 },
                 {
                     "backend": "ldp",
-                    "command": "fetch",
+                    "command": "read",
                     "id": "997db3eb-b9ca-485d-810f-b530a6cef7c6",
                     "filename": "20201002.tgz",
                     "size": 23424233,
@@ -252,7 +252,7 @@ def test_backends_storage_ldp_list_method_history_management(
                 },
                 {
                     "backend": "ldp",
-                    "command": "fetch",
+                    "command": "read",
                     "id": "08075b54-8d24-42ea-a509-9f10b0e3b416",
                     "filename": "20201002.tgz",
                     "size": 23424233,
@@ -430,7 +430,7 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs, settings_fs):
     assert storage.history == [
         {
             "backend": "ldp",
-            "command": "fetch",
+            "command": "read",
             "id": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
             "filename": "2020-06-16.gz",
             "size": 67906662,

--- a/tests/backends/storage/test_s3.py
+++ b/tests/backends/storage/test_s3.py
@@ -99,8 +99,8 @@ def test_backends_storage_s3_list_should_yield_archive_names(
     ]
 
     history = [
-        {"id": "2022-04-29.gz", "backend": "s3", "command": "fetch"},
-        {"id": "2022-04-30.gz", "backend": "s3", "command": "fetch"},
+        {"id": "2022-04-29.gz", "backend": "s3", "command": "read"},
+        {"id": "2022-04-30.gz", "backend": "s3", "command": "read"},
     ]
 
     s3 = s3()
@@ -224,7 +224,7 @@ def test_backends_storage_s3_read_with_valid_name_should_write_to_history(
     assert s3.history == [
         {
             "backend": "s3",
-            "command": "fetch",
+            "command": "read",
             "id": "2022-09-29.gz",
             "size": len(body),
             "fetched_at": freezed_now,
@@ -300,8 +300,8 @@ def test_backends_storage_s3_write_should_write_to_history_new_or_overwritten_ar
     )
 
     history = [
-        {"id": "2022-09-29.gz", "backend": "s3", "command": "fetch"},
-        {"id": "2022-09-30.gz", "backend": "s3", "command": "fetch"},
+        {"id": "2022-09-29.gz", "backend": "s3", "command": "read"},
+        {"id": "2022-09-30.gz", "backend": "s3", "command": "read"},
     ]
 
     freezed_now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
@@ -309,7 +309,7 @@ def test_backends_storage_s3_write_should_write_to_history_new_or_overwritten_ar
     new_history_entry = [
         {
             "backend": "s3",
-            "command": "push",
+            "command": "write",
             "id": archive_name,
             "pushed_at": freezed_now,
         }
@@ -359,8 +359,8 @@ def test_backends_storage_s3_write_should_log_the_error(
     )
 
     history = [
-        {"id": "2022-09-29.gz", "backend": "s3", "command": "fetch"},
-        {"id": "2022-09-30.gz", "backend": "s3", "command": "fetch"},
+        {"id": "2022-09-29.gz", "backend": "s3", "command": "read"},
+        {"id": "2022-09-30.gz", "backend": "s3", "command": "read"},
     ]
 
     fs.create_file(settings.HISTORY_FILE, contents=json.dumps(history))

--- a/tests/backends/storage/test_swift.py
+++ b/tests/backends/storage/test_swift.py
@@ -61,8 +61,8 @@ def test_backends_storage_swift_list_should_yield_archive_names(
         {"name": "2020-05-01.gz"},
     ]
     history = [
-        {"id": "2020-04-29.gz", "backend": "swift", "command": "fetch"},
-        {"id": "2020-04-30.gz", "backend": "swift", "command": "fetch"},
+        {"id": "2020-04-29.gz", "backend": "swift", "command": "read"},
+        {"id": "2020-04-30.gz", "backend": "swift", "command": "read"},
     ]
 
     def mock_list_with_pages(*args, **kwargs):  # pylint:disable=unused-argument
@@ -141,7 +141,7 @@ def test_backends_storage_swift_read_with_valid_name_should_write_to_history(
     assert swift.history == [
         {
             "backend": "swift",
-            "command": "fetch",
+            "command": "read",
             "id": "2020-04-29.gz",
             "size": 12,
             "fetched_at": freezed_now,
@@ -192,8 +192,8 @@ def test_backends_storage_swift_write_should_write_to_history_new_or_overwriten_
     should raise a FileExistsError.
     """
     history = [
-        {"id": "2020-04-29.gz", "backend": "swift", "command": "fetch"},
-        {"id": "2020-04-30.gz", "backend": "swift", "command": "fetch"},
+        {"id": "2020-04-29.gz", "backend": "swift", "command": "read"},
+        {"id": "2020-04-30.gz", "backend": "swift", "command": "read"},
     ]
     listing = [
         {"name": "2020-04-29.gz"},
@@ -205,7 +205,7 @@ def test_backends_storage_swift_write_should_write_to_history_new_or_overwriten_
     new_history_entry = [
         {
             "backend": "swift",
-            "command": "push",
+            "command": "write",
             "id": archive_name,
             "pushed_at": freezed_now,
         }
@@ -249,8 +249,8 @@ def test_backends_storage_swift_write_should_log_the_error(
     """
     error = "Unauthorized. Check username/id, password"
     history = [
-        {"id": "2020-04-29.gz", "backend": "swift", "command": "fetch"},
-        {"id": "2020-04-30.gz", "backend": "swift", "command": "fetch"},
+        {"id": "2020-04-29.gz", "backend": "swift", "command": "read"},
+        {"id": "2020-04-30.gz", "backend": "swift", "command": "read"},
     ]
     listing = [
         {"name": "2020-04-29.gz"},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ test_logger = logging.getLogger("ralph")
 
 
 def test_cli_comma_separated_key_value_param_type():
-    """Tests the CommaSeparatedKeyValueParamType custom parameter type."""
+    """Test the CommaSeparatedKeyValueParamType custom parameter type."""
     param_type = CommaSeparatedKeyValueParamType()
 
     # Bad options
@@ -114,14 +114,14 @@ def test_cli_comma_separated_key_value_param_type():
     ],
 )
 def test_cli_comma_separated_tuple_param_type_with_valid_input(value, expected):
-    """Tests the CommaSeparatedTupleParamType parameter type with valid input."""
+    """Test the CommaSeparatedTupleParamType parameter type with valid input."""
     param_type = CommaSeparatedTupleParamType()
     assert param_type.convert(value, None, None) == expected
 
 
 @pytest.mark.parametrize("value", [None, {}, ["foo"], 10, True])
 def test_cli_comma_separated_tuple_param_type_with_invalid_input(value):
-    """Tests the CommaSeparatedTupleParamType parameter type with invalid input."""
+    """Test the CommaSeparatedTupleParamType parameter type with invalid input."""
     param_type = CommaSeparatedTupleParamType()
     with pytest.raises(
         BadParameter,
@@ -132,14 +132,14 @@ def test_cli_comma_separated_tuple_param_type_with_invalid_input(value):
 
 @pytest.mark.parametrize("value,expected", [('{"foo": "bar"}', {"foo": "bar"})])
 def test_cli_json_string_param_type_with_valid_input(value, expected):
-    """Tests the JSONStringParamType custom parameter type with valid input."""
+    """Test the JSONStringParamType custom parameter type with valid input."""
     param_type = JSONStringParamType()
     assert param_type.convert(value, None, None) == expected
 
 
 @pytest.mark.parametrize("value", ["foo", None, {}])
 def test_cli_json_string_param_type_with_invalid_input(value):
-    """Tests the JSONStringParamType custom parameter type with invalid input."""
+    """Test the JSONStringParamType custom parameter type with invalid input."""
     param_type = JSONStringParamType()
     with pytest.raises(
         BadParameter,
@@ -149,7 +149,7 @@ def test_cli_json_string_param_type_with_invalid_input(value):
 
 
 def test_cli_help_option():
-    """Tests ralph --help command."""
+    """Test ralph --help command."""
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
 
@@ -435,7 +435,7 @@ def test_cli_auth_command_when_writing_auth_file_whith_incorrect_auth_file(fs):
 
 
 def test_cli_extract_command_with_gelf_parser(gelf_logger):
-    """Tests the extract command using the GELF parser."""
+    """Test the extract command using the GELF parser."""
     gelf_logger.info('{"username": "foo"}')
 
     runner = CliRunner()
@@ -448,7 +448,7 @@ def test_cli_extract_command_with_gelf_parser(gelf_logger):
 
 
 def test_cli_extract_command_with_es_parser():
-    """Tests the extract command using the ElasticSearchParser."""
+    """Test the extract command using the ElasticSearchParser."""
     es_output = (
         "\n".join(
             [
@@ -475,7 +475,7 @@ def test_cli_extract_command_with_es_parser():
 
 @custom_given(UIPageClose)
 def test_cli_validate_command_with_edx_format(event):
-    """Tests the validate command using the edx format."""
+    """Test the validate command using the edx format."""
     event_str = event.json()
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "-f", "edx"], input=event_str)
@@ -486,7 +486,7 @@ def test_cli_validate_command_with_edx_format(event):
 @custom_given(UIPageClose)
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 def test_cli_convert_command_from_edx_to_xapi_format(valid_uuid, event):
-    """Tests the convert command from edx to xapi format."""
+    """Test the convert command from edx to xapi format."""
     event_str = event.json()
     runner = CliRunner()
     command = f"-v ERROR convert -f edx -t xapi -u {valid_uuid} -p https://fun-mooc.fr"
@@ -500,7 +500,7 @@ def test_cli_convert_command_from_edx_to_xapi_format(valid_uuid, event):
 
 @pytest.mark.parametrize("invalid_uuid", ["", None, 1, {}])
 def test_cli_convert_command_with_invalid_uuid(invalid_uuid):
-    """Tests that the convert command raises an exception when the uuid namespace is
+    """Test that the convert command raises an exception when the uuid namespace is
     invalid.
     """
     runner = CliRunner()
@@ -523,14 +523,14 @@ def dummy_verbosity_check():
 
 @pytest.mark.parametrize("verbosity", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
 def test_cli_verbosity_option_should_impact_logging_behaviour(verbosity):
-    """Tests that the verbosity option impacts logging output."""
+    """Test that the verbosity option impacts logging output."""
     runner = CliRunner()
     result = runner.invoke(cli, ["-v", verbosity, "dummy-verbosity-check"])
     assert verbosity in result.output
 
 
-def test_cli_fetch_command_with_ldp_backend(monkeypatch):
-    """Tests the fetch command using the LDP backend."""
+def test_cli_read_command_with_ldp_backend(monkeypatch):
+    """Test the read command using the LDP backend."""
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size=500):
@@ -542,7 +542,7 @@ def test_cli_fetch_command_with_ldp_backend(monkeypatch):
     monkeypatch.setattr(LDPStorage, "read", mock_read)
 
     runner = CliRunner()
-    command = "fetch -b ldp --ldp-endpoint ovh-eu a547d9b3-6f2f-4913-a872-cf4efe699a66"
+    command = "read -b ldp --ldp-endpoint ovh-eu a547d9b3-6f2f-4913-a872-cf4efe699a66"
     result = runner.invoke(cli, command.split())
 
     assert result.exit_code == 0
@@ -551,8 +551,8 @@ def test_cli_fetch_command_with_ldp_backend(monkeypatch):
 
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-def test_cli_fetch_command_with_fs_backend(fs, monkeypatch):
-    """Tests the fetch command using the FS backend."""
+def test_cli_read_command_with_fs_backend(fs, monkeypatch):
+    """Test the read command using the FS backend."""
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size):
@@ -564,14 +564,14 @@ def test_cli_fetch_command_with_fs_backend(fs, monkeypatch):
     monkeypatch.setattr(FSStorage, "read", mock_read)
 
     runner = CliRunner()
-    result = runner.invoke(cli, "fetch -b fs foo".split())
+    result = runner.invoke(cli, "read -b fs foo".split())
 
     assert result.exit_code == 0
     assert '{"foo": "bar"}' in result.output
 
 
-def test_cli_fetch_command_with_es_backend(es):
-    """Tests ralph fetch command using the es backend."""
+def test_cli_read_command_with_es_backend(es):
+    """Test ralph read command using the es backend."""
     # pylint: disable=invalid-name
 
     # Insert documents
@@ -589,7 +589,7 @@ def test_cli_fetch_command_with_es_backend(es):
     runner = CliRunner()
     es_hosts = ",".join(ES_TEST_HOSTS)
     es_client_options = "verify_certs=True"
-    command = f"""-v ERROR fetch -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}
+    command = f"""-v ERROR read -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}
         --es-client-options {es_client_options}"""
     result = runner.invoke(cli, command.split())
     assert result.exit_code == 0
@@ -614,20 +614,20 @@ def test_cli_fetch_command_with_es_backend(es):
     assert expected == result.output
 
 
-def test_cli_fetch_command_client_options_with_es_backend(es):
-    """Tests ralph fetch command with multiple client options using the es backend."""
+def test_cli_read_command_client_options_with_es_backend(es):
+    """Test ralph read command with multiple client options using the es backend."""
     # pylint: disable=invalid-name
 
     runner = CliRunner()
     es_client_options = "ca_certs=/path/,verify_certs=True"
-    command = f"""-v ERROR fetch -b es --es-client-options {es_client_options}"""
+    command = f"""-v ERROR read -b es --es-client-options {es_client_options}"""
     result = runner.invoke(cli, command.split())
     assert result.exit_code == 1
     assert "TLS options require scheme to be 'https'" in str(result.exception)
 
 
-def test_cli_fetch_command_with_es_backend_query(es):
-    """Tests ralph fetch command using the es backend and a query."""
+def test_cli_read_command_with_es_backend_query(es):
+    """Test ralph read command using the es backend and a query."""
     # pylint: disable=invalid-name
 
     # Insert documents
@@ -653,7 +653,7 @@ def test_cli_fetch_command_with_es_backend_query(es):
 
     command = (
         "-v ERROR "
-        "fetch "
+        "read "
         "-b es "
         f"--es-hosts {es_hosts} "
         f"--es-index {ES_TEST_INDEX} "
@@ -682,18 +682,18 @@ def test_cli_fetch_command_with_es_backend_query(es):
     assert expected == result.output
 
 
-def test_cli_fetch_command_with_ws_backend(events, ws):
-    """Tests ralph fetch command using the ws backend."""
+def test_cli_read_command_with_ws_backend(events, ws):
+    """Test ralph read command using the ws backend."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["fetch", "-b", "ws", "--ws-uri", f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}"],
+        ["read", "-b", "ws", "--ws-uri", f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}"],
     )
     assert "\n".join([json.dumps(event) for event in events]) in result.output
 
 
 def test_cli_list_command_with_ldp_backend(monkeypatch):
-    """Tests the list command using the LDP backend."""
+    """Test the list command using the LDP backend."""
     archive_list = [
         "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
         "997db3eb-b9ca-485d-810f-b530a6cef7c6",
@@ -765,7 +765,7 @@ def test_cli_list_command_with_ldp_backend(monkeypatch):
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 def test_cli_list_command_with_fs_backend(fs, monkeypatch):
-    """Tests the list command using the LDP backend."""
+    """Test the list command using the LDP backend."""
     archive_list = [
         "file1",
         "file2",
@@ -825,8 +825,8 @@ def test_cli_list_command_with_fs_backend(fs, monkeypatch):
 
 
 # pylint: disable=invalid-name
-def test_cli_push_command_with_fs_backend(fs):
-    """Tests the push command using the FS backend."""
+def test_cli_write_command_with_fs_backend(fs):
+    """Test the write command using the FS backend."""
     fs.create_dir(str(settings.APP_DIR))
 
     filename = Path("file1")
@@ -834,7 +834,7 @@ def test_cli_push_command_with_fs_backend(fs):
 
     # Create a file
     runner = CliRunner()
-    result = runner.invoke(cli, "push -b fs file1".split(), input="test content")
+    result = runner.invoke(cli, "write -b fs file1".split(), input="test content")
 
     assert result.exit_code == 0
 
@@ -845,13 +845,13 @@ def test_cli_push_command_with_fs_backend(fs):
 
     # Trying to create the same file without -f should raise an error
     runner = CliRunner()
-    result = runner.invoke(cli, "push -b fs file1".split(), input="other content")
+    result = runner.invoke(cli, "write -b fs file1".split(), input="other content")
     assert result.exit_code == 1
     assert "file1 already exists and overwrite is not allowed" in result.output
 
     # Try to create the same file with -f
     runner = CliRunner()
-    result = runner.invoke(cli, "push -b fs -f file1".split(), input="other content")
+    result = runner.invoke(cli, "write -b fs -f file1".split(), input="other content")
 
     assert result.exit_code == 0
 
@@ -861,8 +861,8 @@ def test_cli_push_command_with_fs_backend(fs):
     assert "other content" in content
 
 
-def test_cli_push_command_with_es_backend(es):
-    """Tests ralph push command using the es backend."""
+def test_cli_write_command_with_es_backend(es):
+    """Test ralph write command using the es backend."""
     # pylint: disable=invalid-name
 
     # Documents
@@ -872,7 +872,7 @@ def test_cli_push_command_with_es_backend(es):
     es_hosts = ",".join(ES_TEST_HOSTS)
     result = runner.invoke(
         cli,
-        f"push -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}".split(),
+        f"write -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}".split(),
         input="\n".join(json.dumps(record) for record in records),
     )
     assert result.exit_code == 0
@@ -888,7 +888,7 @@ def test_cli_push_command_with_es_backend(es):
 
 @pytest.mark.parametrize("host_,port_", [("0.0.0.0", "8000"), ("127.0.0.1", "80")])
 def test_cli_runserver_command_with_host_and_port_arguments(host_, port_, monkeypatch):
-    """Tests the ralph runserver command should consider the host and port arguments."""
+    """Test the ralph runserver command should consider the host and port arguments."""
 
     def mock_uvicorn_run(_, host=None, port=None, **kwargs):
         """Mocks uvicorn.run asserting host and port values."""
@@ -904,7 +904,7 @@ def test_cli_runserver_command_with_host_and_port_arguments(host_, port_, monkey
 
 
 def test_cli_runserver_command_environment_file_generation(monkeypatch):
-    """Tests the ralph runserver command should create the expected environment file."""
+    """Test the ralph runserver command should create the expected environment file."""
 
     def mock_uvicorn_run(_, env_file=None, **kwargs):
         """Mocks uvicorn.run asserting environment file content."""

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -26,7 +26,7 @@ def test_cli_auth_command_usage():
             "-O, --agent-ifi-openid TEXT",
             "-A, --agent-ifi-account TEXT",
             "-N, --agent-name TEXT",
-            "-w, --write",
+            "-w, --write-to-disk",
         ]
     )
 
@@ -36,7 +36,7 @@ def test_cli_auth_command_usage():
 
 
 def test_cli_extract_command_usage():
-    """Tests ralph extract command usage."""
+    """Test ralph extract command usage."""
     runner = CliRunner()
     result = runner.invoke(cli, ["extract", "--help"])
 
@@ -55,7 +55,7 @@ def test_cli_extract_command_usage():
 
 
 def test_cli_validate_command_usage():
-    """Tests ralph validate command usage."""
+    """Test ralph validate command usage."""
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "--help"])
 
@@ -75,7 +75,7 @@ def test_cli_validate_command_usage():
 
 
 def test_cli_convert_command_usage():
-    """Tests ralph convert command usage."""
+    """Test ralph convert command usage."""
     runner = CliRunner()
     result = runner.invoke(cli, ["convert", "--help"])
 
@@ -101,10 +101,10 @@ def test_cli_convert_command_usage():
     assert "Error: Missing option '-p' / '--platform-url'" in result.output
 
 
-def test_cli_fetch_command_usage():
-    """Test ralph fetch command usage."""
+def test_cli_read_command_usage():
+    """Test ralph read command usage."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["fetch", "--help"])
+    result = runner.invoke(cli, ["read", "--help"])
 
     assert result.exit_code == 0
     assert (
@@ -166,7 +166,7 @@ def test_cli_fetch_command_usage():
         "    --es-index TEXT\n"
         "    --es-hosts VALUE1,VALUE2,VALUE3\n"
         "  -c, --chunk-size INTEGER        Get events by chunks of size #\n"
-        "  -t, --target TEXT               Endpoint from which to fetch events (e.g.\n"
+        "  -t, --target TEXT               Endpoint from which to read events (e.g.\n"
         "                                  `/statements`)\n"
         '  -q, --query \'{"KEY": "VALUE", "KEY": "VALUE"}\'\n'
         "                                  Query object as a JSON string (database "
@@ -174,7 +174,7 @@ def test_cli_fetch_command_usage():
         "                                  HTTP backends ONLY)\n"
     ) in result.output
     logging.warning(result.output)
-    result = runner.invoke(cli, ["fetch"])
+    result = runner.invoke(cli, ["read"])
     assert result.exit_code > 0
     assert (
         "Error: Missing option '-b' / '--backend'. "
@@ -232,17 +232,17 @@ def test_cli_list_command_usage():
     ) in result.output
 
 
-def test_cli_push_command_usage():
-    """Test ralph push command usage."""
+def test_cli_write_command_usage():
+    """Test ralph write command usage."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["push", "--help"])
+    result = runner.invoke(cli, ["write", "--help"])
 
     assert result.exit_code == 0
 
     expected_output = (
-        "Usage: ralph push [OPTIONS] [ARCHIVE]\n"
+        "Usage: ralph write [OPTIONS] [ARCHIVE]\n"
         "\n"
-        "  Push an archive to a configured backend.\n"
+        "  Write an archive to a configured backend.\n"
         "\n"
         "Options:\n"
         "  -b, --backend [es|mongo|clickhouse|ldp|fs|swift|s3|lrs]\n"
@@ -311,13 +311,13 @@ def test_cli_push_command_usage():
         "                                  when using `--simultaneous`. Use `-1` to "
         "not\n"
         "                                  set a limit.\n"
-        "  -t, --target TEXT               Endpoint in which to push events (e.g.\n"
+        "  -t, --target TEXT               Endpoint in which to write events (e.g.\n"
         "                                  `statements`)\n"
         "  --help                          Show this message and exit.\n"
     )
     assert expected_output in result.output
 
-    result = runner.invoke(cli, ["push"])
+    result = runner.invoke(cli, ["write"])
     assert result.exit_code > 0
     assert (
         "Missing option '-b' / '--backend'. Choose from:\n\tes,\n\tmongo,"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -10,7 +10,7 @@ from ralph.exceptions import ConfigurationException
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_exists(fs, monkeypatch):
-    """Tests the logging system when a correct configuration is provided."""
+    """Test the logging system when a correct configuration is provided."""
     mock_default_config = {
         "version": 1,
         "propagate": True,
@@ -42,18 +42,18 @@ def test_logger_exists(fs, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["push", "-b", "fs", "test_file"],
+        ["write", "-b", "fs", "test_file"],
         input="test input",
     )
 
     assert result.exit_code == 0
-    assert "Pushing archive test_file to the configured fs backend" in result.output
+    assert "Writing archive test_file to the configured fs backend" in result.output
     assert "Backend parameters:" in result.output
 
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_no_config(fs, monkeypatch):
-    """Tests that an error occurs when no logging configuration exists."""
+    """Test that an error occurs when no logging configuration exists."""
     mock_default_config = None
 
     monkeypatch.setattr(ralph.logger.settings, "LOGGING", mock_default_config)
@@ -67,7 +67,7 @@ def test_logger_no_config(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_bad_config(fs, monkeypatch):
-    """Tests that an error occurs when a logging is improperly configured."""
+    """Test that an error occurs when a logging is improperly configured."""
     mock_default_config = "this is not a valid json"
 
     monkeypatch.setattr(ralph.logger.settings, "LOGGING", mock_default_config)


### PR DESCRIPTION
## Purpose

As mentionned in #383 , cli currently uses `fetch` and `push`. This could be unified with the new terms `read` and `write`.

## Proposal

- [x] change names in cli
- [x] update tests and doc
- [x] add to changelog

