### PR TITLE
(api) enforce valid IRI with `GET /statements/?activity=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,10 @@ General improvement for the Helm Chart:
 - add missing namespace label
 - make object name consistent
 
-### Changed
-
 - Upgrade `fastapi` to `0.100.0`
 - Upgrade `sentry_sdk` to `1.28.1`
 - Upgrade `uvicorn` to `0.23.0`
+- Enforce valid IRI for `activity` parameter in `GET /statements`
 
 ## [3.8.0] - 2023-06-21
 

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -30,6 +30,7 @@ from ralph.models.xapi.base.agents import (
     BaseXapiAgentWithMboxSha1Sum,
     BaseXapiAgentWithOpenId,
 )
+from ralph.models.xapi.base.common import IRI
 
 from ..models import ErrorDetail, LaxStatement
 
@@ -82,7 +83,7 @@ async def get(
         None,
         description="Filter, only return Statements matching the specified Verb id",
     ),
-    activity: Optional[str] = Query(
+    activity: Optional[IRI] = Query(
         None,
         description=(
             "Filter, only return Statements for which the Object "
@@ -231,7 +232,7 @@ async def get(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
-                "Querying by id only accepts `attachments` and `format` as extra"
+                "Querying by id only accepts `attachments` and `format` as extra "
                 "parameters"
             ),
         )


### PR DESCRIPTION
## Purpose

As pointed out in https://github.com/openfun/ralph/issues/376 , validity of IRI (the expected input) when calling `GET /statements/?activty=` by `activity` is not currently being checked. This PR aims to correct this.

## Proposal

We enforce IRI check when querying by IRI. We return 422 Unprocessable Entity (the default for FastAPI), when input is not a valid IRI.

- [x] change variable type from `str` to `IRI` in `get` function
- [x] update tests and create new test for invalid `IRI`
- [x] update CHANGELOG.md
- [x] factorize activity creation in tests.   

