### PR TITLE
🔖(minor) bump release to 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.9.0] - 2023-07-21
+
 ### Changed
 
+- Upgrade `fastapi` to `0.100.0`
+- Upgrade `sentry_sdk` to `1.28.1`
+- Upgrade `uvicorn` to `0.23.0`
+- Enforce valid IRI for `activity` parameter in `GET /statements`
 - Change how duplicate xAPI statements are handled by backends
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
@@ -18,11 +24,6 @@ General improvement for the Helm Chart:
 - remove prefix label from ingress object name
 - add missing namespace label
 - make object name consistent
-
-- Upgrade `fastapi` to `0.100.0`
-- Upgrade `sentry_sdk` to `1.28.1`
-- Upgrade `uvicorn` to `0.23.0`
-- Enforce valid IRI for `activity` parameter in `GET /statements`
 
 ## [3.8.0] - 2023-06-21
 
@@ -350,7 +351,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.8.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.9.0...master
+[3.9.0]: https://github.com/openfun/ralph/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/openfun/ralph/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/openfun/ralph/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/openfun/ralph/compare/v3.5.1...v3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to
 - Upgrade `sentry_sdk` to `1.28.1`
 - Upgrade `uvicorn` to `0.23.0`
 - Enforce valid IRI for `activity` parameter in `GET /statements`
-- Change how duplicate xAPI statements are handled by backends
+- Change how duplicate xAPI statements are handled for `clickhouse` backend
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.8.0
+version = 3.9.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.8.0"
+appVersion: "3.9.0"
 
 dependencies:
   - name: mongodb

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.8.0"
+__version__ = "3.9.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.8.0
+  version: 3.9.0


### PR DESCRIPTION
### Changed

- Upgrade `fastapi` to `0.100.0`
- Upgrade `sentry_sdk` to `1.28.1`
- Upgrade `uvicorn` to `0.23.0`
- Enforce valid IRI for `activity` parameter in `GET /statements`
- Change how duplicate xAPI statements are handled for `clickhouse` backend

General improvement for the Helm Chart:

- add dependencies for MongoDB and Clickhouse
- make persistence optional
- allow use existing PVC
- remove prefix label from ingress object name
- add missing namespace label
- make object name consistent

