### PR TITLE
(api) Return 400 status on invalid parameter in `/statements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ have an authority field matching that of the user
 - Upgrade `more-itertools` to `10.1.0`
 - Upgrade `sentry_sdk` to `1.29.2`
 - Upgrade `uvicorn` to `0.23.2`
+- API: Invalid parameters now return 400 status code
+- API: Forwarding PUT now uses PUT (instead of POST)
 
 ## [3.9.0] - 2023-07-21
 

--- a/tests/api/test_forwarding.py
+++ b/tests/api/test_forwarding.py
@@ -164,7 +164,7 @@ def test_api_forwarding_forward_xapi_statements_with_successful_request(
 
     caplog.clear()
     with caplog.at_level(logging.DEBUG):
-        asyncio.run(forward_xapi_statements(statements))
+        asyncio.run(forward_xapi_statements(statements, method="post"))
 
     assert [
         f"Forwarded {len(statements)} statements to {forwarding.url} with success."
@@ -211,7 +211,7 @@ def test_api_forwarding_forward_xapi_statements_with_unsuccessful_request(
 
     caplog.clear()
     with caplog.at_level(logging.ERROR):
-        asyncio.run(forward_xapi_statements(statements))
+        asyncio.run(forward_xapi_statements(statements, method="post"))
 
     assert ["Failed to forward xAPI statements. Failure during request."] == [
         message

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -1,4 +1,4 @@
-"""Tests for the GET statements endpoint of the Ralph API."""
+"""Test for the GET statements endpoint of the Ralph API."""
 
 
 import hashlib
@@ -263,7 +263,7 @@ def test_api_statements_get_statements_mine(
 def test_api_statements_get_statements(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route without any filters set up."""
+    """Test the get statements API route without any filters set up."""
     # pylint: disable=redefined-outer-name
 
     statements = [
@@ -291,7 +291,7 @@ def test_api_statements_get_statements(
 def test_api_statements_get_statements_ascending(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given an "ascending" query parameter, should
+    """Test the get statements API route, given an "ascending" query parameter, should
     return statements in ascending order by their timestamp.
     """
     # pylint: disable=redefined-outer-name
@@ -320,7 +320,7 @@ def test_api_statements_get_statements_ascending(
 def test_api_statements_get_statements_by_statement_id(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given a "statementId" query parameter, should
+    """Test the get statements API route, given a "statementId" query parameter, should
     return a list of statements matching the given statementId.
     """
     # pylint: disable=redefined-outer-name
@@ -359,7 +359,7 @@ def test_api_statements_get_statements_by_statement_id(
 def test_api_statements_get_statements_by_agent(
     ifi, insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given an "agent" query parameter, should
+    """Test the get statements API route, given an "agent" query parameter, should
     return a list of statements filtered by the given agent.
     """
     # pylint: disable=redefined-outer-name
@@ -403,7 +403,7 @@ def test_api_statements_get_statements_by_agent(
 def test_api_statements_get_statements_by_verb(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given a "verb" query parameter, should
+    """Test the get statements API route, given a "verb" query parameter, should
     return a list of statements filtered by the given verb id.
     """
     # pylint: disable=redefined-outer-name
@@ -434,7 +434,7 @@ def test_api_statements_get_statements_by_verb(
 def test_api_statements_get_statements_by_activity(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given an "activity" query parameter, should
+    """Test the get statements API route, given an "activity" query parameter, should
     return a list of statements filtered by the given activity id.
     """
     # pylint: disable=redefined-outer-name
@@ -477,7 +477,7 @@ def test_api_statements_get_statements_by_activity(
 def test_api_statements_get_statements_since_timestamp(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given a "since" query parameter, should
+    """Test the get statements API route, given a "since" query parameter, should
     return a list of statements filtered by the given timestamp.
     """
     # pylint: disable=redefined-outer-name
@@ -507,7 +507,7 @@ def test_api_statements_get_statements_since_timestamp(
 def test_api_statements_get_statements_until_timestamp(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given an "until" query parameter,
+    """Test the get statements API route, given an "until" query parameter,
     should return a list of statements filtered by the given timestamp.
     """
     # pylint: disable=redefined-outer-name
@@ -537,7 +537,7 @@ def test_api_statements_get_statements_until_timestamp(
 def test_api_statements_get_statements_with_pagination(
     monkeypatch, insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given a request leading to more results than
+    """Test the get statements API route, given a request leading to more results than
     can fit on the first page, should return a list of statements non exceeding the page
     limit and include a "more" property with a link to get the next page of results.
     """
@@ -607,7 +607,7 @@ def test_api_statements_get_statements_with_pagination(
 def test_api_statements_get_statements_with_pagination_and_query(
     monkeypatch, insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given a request with a query parameter
+    """Test the get statements API route, given a request with a query parameter
     leading to more results than can fit on the first page, should return a list
     of statements non exceeding the page limit and include a "more" property with
     a link to get the next page of results.
@@ -672,7 +672,7 @@ def test_api_statements_get_statements_with_pagination_and_query(
 def test_api_statements_get_statements_with_no_matching_statement(
     insert_statements_and_monkeypatch_backend, auth_credentials
 ):
-    """Tests the get statements API route, given a query yielding no matching statement,
+    """Test the get statements API route, given a query yielding no matching statement,
     should return an empty list.
     """
     # pylint: disable=redefined-outer-name
@@ -701,7 +701,7 @@ def test_api_statements_get_statements_with_no_matching_statement(
 def test_api_statements_get_statements_with_database_query_failure(
     auth_credentials, monkeypatch
 ):
-    """Tests the get statements API route, given a query raising a BackendException,
+    """Test the get statements API route, given a query raising a BackendException,
     should return an error response with HTTP code 500.
     """
     # pylint: disable=redefined-outer-name
@@ -732,14 +732,24 @@ def test_api_statements_get_statements_invalid_query_parameters(
     id_1 = "be67b160-d958-4f51-b8b8-1892002dbac6"
     id_2 = "66c81e98-1763-4730-8cfc-f5ab34f1bad5"
 
-    # Test error when both statementId and voidedStatementId are provided
+    # Check for 400 status code when unknown parameters are provided
+    response = client.get(
+        "/xAPI/statements/?mamamia=herewegoagain",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "The following parameter is not allowed: `mamamia`"
+    }
+
+    # Check for 400 status code when both statementId and voidedStatementId are provided
     response = client.get(
         f"/xAPI/statements/?statementId={id_1}&voidedStatementId={id_2}",
         headers={"Authorization": f"Basic {auth_credentials}"},
     )
     assert response.status_code == 400
 
-    # Check for error when invalid parameters are provided with a statementId
+    # Check for 400 status code when invalid parameters are provided with a statementId
     for invalid_param, value in [
         ("activity", create_mock_activity()["id"]),
         ("agent", json.dumps(create_mock_agent("mbox", 1))),
@@ -757,7 +767,7 @@ def test_api_statements_get_statements_invalid_query_parameters(
             )
         }
 
-    # Check for NO 400 when statementId is passed with authorized parameters
+    # Check for NO 400 status code when statementId is passed with authorized parameters
     for valid_param, value in [("format", "ids"), ("attachments", "true")]:
         response = client.get(
             f"/xAPI/statements/?{id_param}={id_1}&{valid_param}={value}",

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -29,6 +29,35 @@ from tests.fixtures.backends import (
 client = TestClient(app)
 
 
+def test_api_statements_post_invalid_parameters(auth_credentials):
+    """Test that using invalid parameters returns the proper status code."""
+
+    statement = {
+        "actor": {
+            "account": {
+                "homePage": "https://example.com/homepage/",
+                "name": str(uuid4()),
+            },
+            "objectType": "Agent",
+        },
+        "id": str(uuid4()),
+        "object": {"id": "https://example.com/object-id/1/"},
+        "timestamp": "2022-06-22T08:31:38Z",
+        "verb": {"id": "https://example.com/verb-id/1/"},
+    }
+
+    # Check for 400 status code when unknown parameters are provided
+    response = client.post(
+        "/xAPI/statements/?mamamia=herewegoagain",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "The following parameter is not allowed: `mamamia`"
+    }
+
+
 @pytest.mark.parametrize(
     "backend",
     [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
@@ -37,7 +66,7 @@ client = TestClient(app)
 def test_api_statements_post_single_statement_directly(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the post statements API route with one statement."""
+    """Test the post statements API route with one statement."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -81,7 +110,7 @@ def test_api_statements_post_single_statement_directly(
 def test_api_statements_post_single_statement_no_trailing_slash(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests that the statements endpoint also works without the trailing slash."""
+    """Test that the statements endpoint also works without the trailing slash."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -117,7 +146,7 @@ def test_api_statements_post_single_statement_no_trailing_slash(
 def test_api_statements_post_statements_list_of_one(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the post statements API route with one statement in a list."""
+    """Test the post statements API route with one statement in a list."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -160,7 +189,7 @@ def test_api_statements_post_statements_list_of_one(
 def test_api_statements_post_statements_list(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the post statements API route with two statements in a list."""
+    """Test the post statements API route with two statements in a list."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -227,7 +256,7 @@ def test_api_statements_post_statements_list(
 def test_api_statements_post_statements_list_with_duplicates(
     backend, monkeypatch, auth_credentials, es_data_stream, mongo, clickhouse
 ):
-    """Tests the post statements API route with duplicate statement IDs should fail."""
+    """Test the post statements API route with duplicate statement IDs should fail."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -272,7 +301,7 @@ def test_api_statements_post_statements_list_with_duplicates(
 def test_api_statements_post_statements_list_with_duplicate_of_existing_statement(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the post statements API route, given a statement that already exist in the
+    """Test the post statements API route, given a statement that already exist in the
     database (has the same ID), should fail.
     """
     # pylint: disable=invalid-name,unused-argument
@@ -343,7 +372,7 @@ def test_api_statements_post_statements_list_with_duplicate_of_existing_statemen
 def test_api_statements_post_statements_with_a_failure_during_storage(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the post statements API route with a failure happening during storage."""
+    """Test the post statements API route with a failure happening during storage."""
     # pylint: disable=invalid-name,unused-argument, too-many-arguments
 
     def put_mock(*args, **kwargs):
@@ -386,7 +415,7 @@ def test_api_statements_post_statements_with_a_failure_during_storage(
 def test_api_statements_post_statements_with_a_failure_during_id_query(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the post statements API route with a failure during query execution."""
+    """Test the post statements API route with a failure during query execution."""
     # pylint: disable=invalid-name,unused-argument,too-many-arguments
 
     def query_statements_by_ids_mock(*args, **kwargs):
@@ -432,7 +461,7 @@ def test_api_statements_post_statements_with_a_failure_during_id_query(
 def test_post_statements_list_without_statement_forwarding(
     backend, auth_credentials, monkeypatch, es, mongo, clickhouse
 ):
-    """Tests the post statements API route, given an empty forwarding configuration,
+    """Test the post statements API route, given an empty forwarding configuration,
     should not start the forwarding background task.
     """
     # pylint: disable=invalid-name,unused-argument
@@ -502,7 +531,7 @@ async def test_post_statements_list_with_statement_forwarding(
     mongo_forwarding,
     lrs,
 ):
-    """Tests the xAPI forwarding functionality given two ralph instances - a forwarding
+    """Test the xAPI forwarding functionality given two ralph instances - a forwarding
     instance and a receiving instance. When the forwarding instance receives a valid
     xAPI statement it should store and forward it to the receiving instance which in
     turn should store it too.

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -28,6 +28,34 @@ from tests.fixtures.backends import (
 client = TestClient(app)
 
 
+def test_api_statements_put_invalid_parameters(auth_credentials):
+    """Test that using invalid parameters returns the proper status code."""
+    statement = {
+        "actor": {
+            "account": {
+                "homePage": "https://example.com/homepage/",
+                "name": str(uuid4()),
+            },
+            "objectType": "Agent",
+        },
+        "id": str(uuid4()),
+        "object": {"id": "https://example.com/object-id/1/"},
+        "timestamp": "2022-06-22T08:31:38Z",
+        "verb": {"id": "https://example.com/verb-id/1/"},
+    }
+
+    # Check for 400 status code when unknown parameters are provided
+    response = client.put(
+        "/xAPI/statements/?mamamia=herewegoagain",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "The following parameter is not allowed: `mamamia`"
+    }
+
+
 @pytest.mark.parametrize(
     "backend",
     [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
@@ -36,7 +64,7 @@ client = TestClient(app)
 def test_api_statements_put_single_statement_directly(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the put statements API route with one statement."""
+    """Test the put statements API route with one statement."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -79,7 +107,7 @@ def test_api_statements_put_single_statement_directly(
 def test_api_statements_put_single_statement_no_trailing_slash(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests that the statements endpoint also works without the trailing slash."""
+    """Test that the statements endpoint also works without the trailing slash."""
     # pylint: disable=invalid-name,unused-argument
 
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
@@ -115,7 +143,7 @@ def test_api_statements_put_statement_id_mismatch(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
     # pylint: disable=invalid-name,unused-argument
-    """Tests the put statements API route when the statementId doesn't match."""
+    """Test the put statements API route when the statementId doesn't match."""
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
     statement = {
         "actor": {
@@ -153,7 +181,7 @@ def test_api_statements_put_statements_list_of_one(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
     # pylint: disable=invalid-name,unused-argument
-    """Tests that we fail on PUTs with a list, even if it's one statement."""
+    """Test that we fail on PUTs with a list, even if it's one statement."""
     monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
     statement = {
         "actor": {
@@ -186,7 +214,7 @@ def test_api_statements_put_statements_list_of_one(
 def test_api_statements_put_statement_duplicate_of_existing_statement(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the put statements API route, given a statement that already exist in the
+    """Test the put statements API route, given a statement that already exist in the
     database (has the same ID), should fail.
     """
     # pylint: disable=invalid-name,unused-argument
@@ -243,7 +271,7 @@ def test_api_statements_put_statement_duplicate_of_existing_statement(
 def test_api_statement_put_statements_with_a_failure_during_storage(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the put statements API route with a failure happening during storage."""
+    """Test the put statements API route with a failure happening during storage."""
     # pylint: disable=invalid-name,unused-argument, too-many-arguments
 
     def put_mock(*args, **kwargs):
@@ -286,7 +314,7 @@ def test_api_statement_put_statements_with_a_failure_during_storage(
 def test_api_statements_put_statement_with_a_failure_during_id_query(
     backend, monkeypatch, auth_credentials, es, mongo, clickhouse
 ):
-    """Tests the put statements API route with a failure during query execution."""
+    """Test the put statements API route with a failure during query execution."""
     # pylint: disable=invalid-name,unused-argument,too-many-arguments
 
     def query_statements_by_ids_mock(*args, **kwargs):
@@ -332,7 +360,7 @@ def test_api_statements_put_statement_with_a_failure_during_id_query(
 def test_put_statement_without_statement_forwarding(
     backend, auth_credentials, monkeypatch, es, mongo, clickhouse
 ):
-    """Tests the put statements API route, given an empty forwarding configuration,
+    """Test the put statements API route, given an empty forwarding configuration,
     should not start the forwarding background task.
     """
     # pylint: disable=invalid-name,unused-argument
@@ -401,7 +429,7 @@ async def test_put_statement_with_statement_forwarding(
     mongo_forwarding,
     lrs,
 ):
-    """Tests the xAPI forwarding functionality given two ralph instances - a forwarding
+    """Test the xAPI forwarding functionality given two ralph instances - a forwarding
     instance and a receiving instance. When the forwarding instance receives a valid
     xAPI statement it should store and forward it to the receiving instance which in
     turn should store it too.


### PR DESCRIPTION
## Purpose

As mentionned in https://github.com/openfun/ralph/issues/375 , invalid parameters passed to the LRS should prompt a 400 error code from the API (instead of 500 as is currently the case). This PR deals with this issue for GET, POST, and PUT.

Example: `/xAPI/statements?toto=2` should return 400.

## Solution

The proposed solution would return 400 with the following message:

```
{
        "detail": "The following parameter is not allowed: `toto`"
}
```

