### PR TITLE
(api) disable lrshttp when called in events loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ have an authority field matching that of the user
 - API: Forwarding PUT now uses PUT (instead of POST)
 - Models: The xAPI `context.contextActivities.category` field is now mandatory
   in the video and virtual classroom profiles. [BC]
+- Backends: `LRSHTTP` methods must not be used in `asyncio` events loop (BC) 
 
 ## [3.9.0] - 2023-07-21
 


### PR DESCRIPTION
## Purpose

As described in https://github.com/openfun/ralph/issues/400 , the current `LRSHTTP` (which is derived from `AsyncLRSHTTP`) methods can't be called from within a running events loop (as is the case in warren). There is no obvious alternative (other than code duplication), as this pattern is not allowed by `asyncio`. As dicussed [here](https://discuss.python.org/t/calling-coroutines-from-sync-code-2/24093/19), it is also considered an anti pattern.

## Proposal

It has been decided to NOT change the code structure. Instead:
- if a method is called OUTSIDE of a running events loop (in a synchronous setting), the code still works as previously.
- if a method is called INSIDE of a running events loop (meaning the user is already working asynchronously), we raise an explicit error directing the user to `AsyncLRSHTTP`. 

The error message would be:
```"This event loop is already running. You must use `AsyncLRSHTTP.status` (instead of `LRSHTTP.status`), or run this code outside the current event loop." ```

## Todo

- [x] add Exception
- [x] test that Exceptions are properly raised