### PR TITLE
(api) Enrich statements (including with authority) and enforce authority when querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 ### Changed
 
+- In cli, change `push` to `write` and `fetch` to `read`
 - Upgrade `fastapi` to `0.100.0`
 - Upgrade `sentry_sdk` to `1.28.1`
 - Upgrade `uvicorn` to `0.23.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.9.0] - 2023-07-21
+
 ### Changed
 
-- Change how duplicate xAPI statements are handled by backends
+- Upgrade `fastapi` to `0.100.0`
+- Upgrade `sentry_sdk` to `1.28.1`
+- Upgrade `uvicorn` to `0.23.0`
+- Enforce valid IRI for `activity` parameter in `GET /statements`
+- Change how duplicate xAPI statements are handled for `clickhouse` backend
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional
@@ -18,11 +24,6 @@ General improvement for the Helm Chart:
 - remove prefix label from ingress object name
 - add missing namespace label
 - make object name consistent
-
-- Upgrade `fastapi` to `0.100.0`
-- Upgrade `sentry_sdk` to `1.28.1`
-- Upgrade `uvicorn` to `0.23.0`
-- Enforce valid IRI for `activity` parameter in `GET /statements`
 
 ## [3.8.0] - 2023-06-21
 
@@ -350,7 +351,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.8.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.9.0...master
+[3.9.0]: https://github.com/openfun/ralph/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/openfun/ralph/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/openfun/ralph/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/openfun/ralph/compare/v3.5.1...v3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 - Upgrade `uvicorn` to `0.23.0`
 - Enforce valid IRI for `activity` parameter in `GET /statements`
 - Change how duplicate xAPI statements are handled for `clickhouse` backend
+- User credentials must now include an "agent" field which can be created 
+using the cli
+
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to
 - Change how duplicate xAPI statements are handled for `clickhouse` backend
 - User credentials must now include an "agent" field which can be created 
 using the cli
-
+- `GET /statements` now has "mine" option which matches statements that
+have an authority field matching that of the user
 General improvement for the Helm Chart:
 - add dependencies for MongoDB and Clickhouse
 - make persistence optional

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ RALPH_IMAGE_BUILD_TARGET ?= development
 RALPH_LRS_AUTH_USER_NAME  = ralph
 RALPH_LRS_AUTH_USER_PWD   = secret
 RALPH_LRS_AUTH_USER_SCOPE = ralph_scope
+RALPH_LRS_AUTH_USER_AGENT_MBOX = mailto:ralph@example.com
 
 # -- K3D
 K3D_CLUSTER_NAME              ?= ralph
@@ -65,6 +66,7 @@ bin/init-cluster:
 		-u $(RALPH_LRS_AUTH_USER_NAME) \
 		-p $(RALPH_LRS_AUTH_USER_PWD) \
 		-s $(RALPH_LRS_AUTH_USER_SCOPE) \
+		-M $(RALPH_LRS_AUTH_USER_AGENT_MBOX)
 		-w
 
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ $ ralph COMMAND --help
 > You should substitute `COMMAND` by the target command, _e.g._ `list`, to see
 > its usage.
 
+## Migrating
+
+Some major version changes require updating persistence layers. Check out the [migration guide](https://github.com/openfun/ralph/blob/master/UPGRADE.md) for more information.
+
 ## Documentation
 
 We try our best to maintain an up-to-date reference documentation for this

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,8 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 #### Upgrade history syntax
 
-CLI syntax has been changed from `fetch` & `push` to `read` & `write` affecting the command history. You must replace the command 
-history after updating:sed -i 's/"fetch"/"read"/g'
+CLI syntax has been changed from `fetch` & `push` to `read` & `write` affecting the command history. You must replace the command history after updating:
 - locate your history file path, which is in `{ RALPH_APP_DIR }/history.json` (defaults to `.ralph/history.json`)
 - run the commands below to update history
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,18 @@
+# Upgrade
+
+All instructions to upgrade this project from one release to the next will be documented in this file. Upgrades must be run sequentially, meaning you should not skip minor/major releases while upgrading (fix releases can be skipped).
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### 3.x.x to 4.0.0
+
+#### Upgrade history syntax
+
+CLI syntax has been changed from `fetch` & `push` to `read` & `write` affecting the command history. You must replace the command 
+history after updating:sed -i 's/"fetch"/"read"/g'
+- locate your history file path, which is in `{ RALPH_APP_DIR }/history.json` (defaults to `.ralph/history.json`)
+- run the commands below to update history
+```
+$ sed -i 's/"fetch"/"read"/g' { my_history_file_path }
+$ sed -i 's/"push"/"write"/g' { my_history_file_path }
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,20 +36,31 @@ documentation for
 details](https://click.palletsprojects.com/en/8.1.x/api/#click.get_app_dir)).
 
 The expected format is a list of entries (JSON objects) each containing the
-username, the user's `bcrypt` hashed+salted password and scopes they can
-access:
+username, the user's `bcrypt` hashed+salted password, scopes they can
+access, and an `agent` object used to represent the user in the LRS. The 
+`agent` is constrained by [LRS specifications](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#description-2), and must use one of four valid 
+[Inverse Functional Identifiers](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#inversefunctional).
 
 ```json
 [
   {
     "username": "john.doe@example.com",
     "hash": "$2b$12$yBXrzIuRIk6yaft5KUgVFOIPv0PskCCh9PXmF2t7pno.qUZ5LK0D2",
-    "scopes": ["example_scope"]
+    "scopes": ["example_scope"],
+    "agent": {
+      "mbox": "mailto:john.doe@example.com"
+    }
   },
   {
     "username": "simon.says@example.com",
     "hash": "$2b$12$yBXrzIuRIk6yaft5KUgVFOIPv0PskCCh9PXmF2t7pno.qUZ5LK0D2",
-    "scopes": ["second_scope", "third_scope"]
+    "scopes": ["second_scope", "third_scope"],
+    "agent": {
+      "account": {
+        "name": "simonsAccountName",
+        "homePage": "http://www.exampleHomePage.com"
+      }
+    }
   }
 ]
 ```
@@ -61,6 +72,11 @@ $ ralph auth \
     --username janedoe \
     --password supersecret \
     --scope janedoe_scope \
+    --agent-mbox mailto:janedoe@example.com \
+    # or --agent-mbox-sha1sum ebd31e95054c018b10727ccffd2ef2ec3a016ee9\
+    # or --agent-openid "http://jane.openid.example.org/" \
+    # or --agent-account-name exampleAccountname \
+    #    --agent-account-homePage http://www.exampleHomePage.com \
     -w
 ```
 
@@ -91,7 +107,7 @@ Send your username and password to the API server through HTTP Basic Auth:
 ```bash
 $ curl --user john.doe@example.com:PASSWORD http://localhost:8100/whoami
 < HTTP/1.1 200 OK
-< {"username":"john.doe@example.com","scopes":["authenticated","example_scope"]}
+< {"scopes":["example_scope"], "agent": {"mbox": "mailto:john.doe@example.com"}}
 ```
 
 ### OpenID Connect authentication

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -103,18 +103,18 @@ it's time to play with them:
 ```bash
 # Store a JSON file in the Swift backend
 $ echo '{"id": 1, "foo": "bar"}' | \
-    ./bin/ralph push -b swift -f foo.json
+    ./bin/ralph write -b swift -f foo.json
 
 # Check that we have created a new JSON file in the Swift backend
 $ bin/ralph list -b swift
 foo.json
 
-# Fetch the content of the JSON file and index it in Elasticsearch
-$ bin/ralph fetch -b swift foo.json | \
-    bin/ralph push -b es
+# Read the content of the JSON file and index it in Elasticsearch
+$ bin/ralph read -b swift foo.json | \
+    bin/ralph write -b es
 
 # Check that we have properly indexed the JSON file in Elasticsearch
-$ bin/ralph fetch -b es
+$ bin/ralph read -b es
 {"id": 1, "foo": "bar"}
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Ralph is a toolbox for your learning analytics, it can be used as a:
 
-- **library**, to fetch learning events from various backends, (de)serialize or
+- **library**, to read learning events from various backends, (de)serialize or
   convert them from various standard formats such as
   [xAPI](https://adlnet.gov/projects/xapi/),
 - **command-line interface** (CLI), to build data pipelines the UNIX-way™️,
@@ -38,15 +38,15 @@ base commands and UNIX standard streams (`stdin`, `stdout`) to connect them in
 a pipeline. A base example pipeline may be:
 
 ```sh
-$ ralph fetch --backend swift my_archive.gzip | \
+$ ralph read --backend swift my_archive.gzip | \
     gunzip | \
-    ralph push --backend es
+    ralph write --backend es
 ```
 
 In this small pipeline, we stream `my_archive.gzip` content from a Swift
-container to the standard output (using the `fetch` command), uncompress the
+container to the standard output (using the `read` command), uncompress the
 content (using the `gunzip` command), and bulk insert logs in an ElasticSearch
-index (using the `push` command).
+index (using the `write` command).
 
 As UNIX is beautiful, Ralph offers many powerful possibilities by combining its
 commands with other standard commands or command line tools.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = ralph-malph
-version = 3.8.0
+version = 3.9.0
 description = The ultimate toolbox for your learning analytics
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,7 @@ universal = 1
 max-line-length = 88
 extend-ignore = E203
 exclude =
-    .conda
+    .conda,
     .git,
     .venv,
     build,

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.8.0"
+appVersion: "3.9.0"
 
 dependencies:
   - name: mongodb

--- a/src/helm/ralph/values.yaml
+++ b/src/helm/ralph/values.yaml
@@ -129,9 +129,9 @@ ralph_cronjobs:
     command:
       - ralph list --backend ldp --new |
         xargs -I {} -n 1 bash -c "
-        ralph fetch --backend ldp {} |
+        ralph read --backend ldp {} |
         gunzip |
         ralph extract -p gelf |
-        ralph push \
+        ralph write \
         --backend es \
         --es-client-options ca_certs=/usr/local/share/ca-certificates/es-cluster.pem"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "3.8.0"
+__version__ = "3.9.0"

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -49,4 +49,4 @@ async def whoami(
     user: AuthenticatedUser = Depends(get_authenticated_user),
 ):
     """Return the current user's username along with their scopes."""
-    return {"username": user.username, "scopes": user.scopes}
+    return {"agent": user.agent, "scopes": user.scopes}

--- a/src/ralph/api/auth/basic.py
+++ b/src/ralph/api/auth/basic.py
@@ -32,12 +32,12 @@ class UserCredentials(AuthenticatedUser):
     """Pydantic model for user credentials as stored in the credentials file.
 
     Attributes:
-        username (str): Consists of the username for a declared user.
         hash (str): Consists of the hashed password for a declared user.
-        scopes (List): Consists of the scopes a declared has access to.
+        username (str): Consists of the username for a declared user.
     """
 
     hash: str
+    username: str
 
 
 class ServerUsersCredentials(BaseModel):
@@ -182,4 +182,4 @@ def get_authenticated_user(
             headers={"WWW-Authenticate": "Basic"},
         )
 
-    return AuthenticatedUser(username=credentials.username, scopes=user.scopes)
+    return AuthenticatedUser(scopes=user.scopes, agent=user.agent)

--- a/src/ralph/api/auth/user.py
+++ b/src/ralph/api/auth/user.py
@@ -1,6 +1,6 @@
 """Authenticated user for the Ralph API."""
 
-from typing import List, Optional
+from typing import Dict, List
 
 from pydantic import BaseModel
 
@@ -9,9 +9,9 @@ class AuthenticatedUser(BaseModel):
     """Pydantic model for user authentication.
 
     Attributes:
-        username (str): Consists of the username of the current user.
-        scopes (list): Consists of the scopes the user has access to.
+        agent (dict): The agent representing the current user.
+        scopes (list): The scopes the user has access to.
     """
 
-    username: str
-    scopes: Optional[List[str]]
+    agent: Dict
+    scopes: List[str]

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -1,5 +1,6 @@
 """API routes related to statements."""
 
+import json
 import logging
 from datetime import datetime
 from typing import List, Literal, Optional, Union
@@ -16,10 +17,12 @@ from fastapi import (
     Response,
     status,
 )
-from pydantic import parse_raw_as
+from pydantic import parse_obj_as
 from pydantic.types import Json
+from typing_extensions import Annotated
 
 from ralph.api.auth import get_authenticated_user
+from ralph.api.auth.user import AuthenticatedUser
 from ralph.api.forwarding import forward_xapi_statements, get_active_xapi_forwardings
 from ralph.backends.database.base import (
     AgentParameters,
@@ -63,11 +66,32 @@ POST_PUT_RESPONSES = {
 }
 
 
+def _parse_agent_parameters(agent_obj: dict):
+    """Parse a dict and return an AgentParameters object to use in queries."""
+    # Transform agent to `dict` as FastAPI cannot parse JSON (seen as string)
+    agent = parse_obj_as(BaseXapiAgent, agent_obj)
+
+    agent_query_params = {}
+    if isinstance(agent, BaseXapiAgentWithMbox):
+        agent_query_params["mbox"] = agent.mbox
+    elif isinstance(agent, BaseXapiAgentWithMboxSha1Sum):
+        agent_query_params["mbox_sha1sum"] = agent.mbox_sha1sum
+    elif isinstance(agent, BaseXapiAgentWithOpenId):
+        agent_query_params["openid"] = agent.openid
+    elif isinstance(agent, BaseXapiAgentWithAccount):
+        agent_query_params["account__name"] = agent.account.name
+        agent_query_params["account__home_page"] = agent.account.homePage
+
+    # Overwrite `agent` field
+    return AgentParameters(**agent_query_params)
+
+
 @router.get("")
 @router.get("/")
 # pylint: disable=too-many-arguments, too-many-locals
 async def get(
     request: Request,
+    current_user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
     ###
     # Query string parameters defined by the LRS specification
     ###
@@ -179,6 +203,13 @@ async def get(
     ascending: Optional[bool] = Query(
         False, description='If "true", return results in ascending order of stored time'
     ),
+    mine: Optional[bool] = Query(
+        False,
+        description=(
+            'If "true", return only the results for which the authority matches the '
+            '"agent" associated to the user that is making the query.'
+        ),
+    ),
     ###
     # Private use query string parameters
     ###
@@ -242,26 +273,20 @@ async def get(
             ),
         )
 
-    # Parse the agent parameter (JSON) into multiple string parameters
     query_params = dict(request.query_params)
 
+    # Parse the "agent" parameter (JSON) into multiple string parameters
     if query_params.get("agent") is not None:
-        # Transform agent to `dict` as FastAPI cannot parse JSON (seen as string)
+        # Overwrite `agent` field
+        query_params["agent"] = _parse_agent_parameters(
+            json.loads(query_params["agent"])
+        )
 
-        agent = parse_raw_as(BaseXapiAgent, query_params["agent"])
+    if mine:
+        query_params["authority"] = _parse_agent_parameters(current_user.agent)
 
-        agent_query_params = {}
-        if isinstance(agent, BaseXapiAgentWithMbox):
-            agent_query_params["mbox"] = agent.mbox
-        elif isinstance(agent, BaseXapiAgentWithMboxSha1Sum):
-            agent_query_params["mbox_sha1sum"] = agent.mbox_sha1sum
-        elif isinstance(agent, BaseXapiAgentWithOpenId):
-            agent_query_params["openid"] = agent.openid
-        elif isinstance(agent, BaseXapiAgentWithAccount):
-            agent_query_params["account__name"] = agent.account.name
-            agent_query_params["account__home_page"] = agent.account.homePage
-
-        query_params["agent"] = AgentParameters(**agent_query_params)
+    if "mine" in query_params:
+        query_params.pop("mine")
 
     # Query Database
     try:

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -89,23 +89,23 @@ def _enrich_statement_with_timestamp(statement):
     statement["timestamp"] = statement.get("timestamp", statement.get("stored", now()))
     return statement["timestamp"]
 
-def _enrich_statement_with_authority(statement, current_user):
+def _enrich_statement_with_authority(statement, current_user: AuthenticatedUser):
     # authority: Information about whom or what has asserted that this statement is true
     # https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#249-authority
-    # authority = current_user.infer_authority()
-    # if "authority" in statement and statement["authority"] != authority:
-    #     logger.error(
-    #         "Failed to index submitted statements. Submitted authority does not match."
-    #     )
-    #     raise HTTPException(
-    #         status_code=status.HTTP_403_FORBIDDEN,
-    #         detail=(
-    #             "Stated authority does not match credentials. Change or remove"
-    #              "`authority`.",
-    #         )
-    #     )
-    # else:
-    #     statement["authority"] = authority
+    authority = current_user.agent
+    if "authority" in statement and statement["authority"] != authority:
+        logger.error(
+            "Failed to index submitted statements. Submitted authority does not match."
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Stated `authority` does not match credentials. Change or remove"
+                 "`authority` field from incoming statement.",
+            )
+        )
+    else:
+        statement["authority"] = authority
     pass
 
 def _parse_agent_parameters(agent_obj: dict):

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -229,7 +229,7 @@ async def get(
         ),
     ),
 ):
-    """Fetches a single xAPI Statement or multiple xAPI Statements.
+    """Read a single xAPI Statement or multiple xAPI Statements.
 
     LRS Specification:
     https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md#213-get-statements

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -394,12 +394,6 @@ async def put(
 
     statement_as_dict["id"] = str(statement_as_dict["id"])
     if statementId != statement_as_dict["id"]:
-        print('gloubi\n')
-        print(statementId)
-        print('\n')
-        print(statement_as_dict["id"])
-        print(type(statementId))
-        print(type(statement_as_dict["id"]))
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="xAPI statement id does not match given statementId",
@@ -518,7 +512,6 @@ async def post(
             # The LRS specification calls for deep comparison of duplicates. This
             # is done here. If they are not exactly the same, we raise an error.
             if not statements_are_equivalent(statements_dict[existing["_id"]], existing["_source"]):
-                print('jiglyjigy')
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail="Differing statements already exist with the same ID: "

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -21,7 +21,11 @@ from pydantic.types import Json
 
 from ralph.api.auth import get_authenticated_user
 from ralph.api.forwarding import forward_xapi_statements, get_active_xapi_forwardings
-from ralph.backends.database.base import BaseDatabase, StatementParameters
+from ralph.backends.database.base import (
+    AgentParameters,
+    BaseDatabase,
+    StatementParameters,
+)
 from ralph.conf import settings
 from ralph.exceptions import BackendException, BadFormatException
 from ralph.models.xapi.base.agents import (
@@ -240,21 +244,24 @@ async def get(
 
     # Parse the agent parameter (JSON) into multiple string parameters
     query_params = dict(request.query_params)
+
     if query_params.get("agent") is not None:
         # Transform agent to `dict` as FastAPI cannot parse JSON (seen as string)
+
         agent = parse_raw_as(BaseXapiAgent, query_params["agent"])
 
-        query_params.pop("agent")
-
+        agent_query_params = {}
         if isinstance(agent, BaseXapiAgentWithMbox):
-            query_params["agent__mbox"] = agent.mbox
+            agent_query_params["mbox"] = agent.mbox
         elif isinstance(agent, BaseXapiAgentWithMboxSha1Sum):
-            query_params["agent__mbox_sha1sum"] = agent.mbox_sha1sum
+            agent_query_params["mbox_sha1sum"] = agent.mbox_sha1sum
         elif isinstance(agent, BaseXapiAgentWithOpenId):
-            query_params["agent__openid"] = agent.openid
+            agent_query_params["openid"] = agent.openid
         elif isinstance(agent, BaseXapiAgentWithAccount):
-            query_params["agent__account__name"] = agent.account.name
-            query_params["agent__account__home_page"] = agent.account.homePage
+            agent_query_params["account__name"] = agent.account.name
+            agent_query_params["account__home_page"] = agent.account.homePage
+
+        query_params["agent"] = AgentParameters(**agent_query_params)
 
     # Query Database
     try:

--- a/src/ralph/backends/database/mongo.py
+++ b/src/ralph/backends/database/mongo.py
@@ -15,6 +15,7 @@ from ralph.conf import MongoClientOptions, settings
 from ralph.exceptions import BackendException, BadFormatException
 
 from .base import (
+    AgentParameters,
     BaseDatabase,
     BaseQuery,
     DatabaseStatus,
@@ -185,31 +186,56 @@ class MongoDatabase(BaseDatabase):
 
         return success
 
+    @staticmethod
+    def _add_agent_filters(
+        mongo_query_filters: dict, agent_params: AgentParameters, target_field: str
+    ):
+        """Add filters relative to agents to mongo_query_filters.
+
+        Args:
+            mongo_query_filters: filters to be passed to mongo
+            agent_params: query parameters that represent the agent to search for
+            target_field: the field in the database in which to perform the search
+        """
+        if agent_params.mbox:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.mbox": agent_params.mbox}
+            )
+
+        if agent_params.mbox_sha1sum:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.mbox_sha1sum": agent_params.mbox_sha1sum}
+            )
+
+        if agent_params.openid:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.openid": agent_params.openid}
+            )
+
+        if agent_params.account__name:
+            mongo_query_filters.update(
+                {f"_source.{target_field}.account.name": agent_params.account__name}
+            )
+            mongo_query_filters.update(
+                {
+                    f"_source.{target_field}.account.homePage": agent_params.account__home_page  # noqa: E501 # pylint: disable=line-too-long
+                }
+            )
+
     def query_statements(self, params: StatementParameters) -> StatementQueryResult:
-        """Returns the results of a statements query using xAPI parameters."""
+        """Return the results of a statements query using xAPI parameters."""
+        # pylint: disable=too-many-branches
         mongo_query_filters = {}
 
         if params.statementId:
             mongo_query_filters.update({"_source.id": params.statementId})
 
-        if params.agent__mbox:
-            mongo_query_filters.update({"_source.actor.mbox": params.agent__mbox})
-
-        if params.agent__mbox_sha1sum:
-            mongo_query_filters.update(
-                {"_source.actor.mbox_sha1sum": params.agent__mbox_sha1sum}
-            )
-
-        if params.agent__openid:
-            mongo_query_filters.update({"_source.actor.openid": params.agent__openid})
-
-        if params.agent__account__name:
-            mongo_query_filters.update(
-                {"_source.actor.account.name": params.agent__account__name}
-            )
-            mongo_query_filters.update(
-                {"_source.actor.account.homePage": params.agent__account__home_page}
-            )
+        self._add_agent_filters(
+            mongo_query_filters, params.__dict__["agent"], target_field="actor"
+        )
+        self._add_agent_filters(
+            mongo_query_filters, params.__dict__["authority"], target_field="authority"
+        )
 
         if params.verb:
             mongo_query_filters.update({"_source.verb.id": params.verb})

--- a/src/ralph/backends/storage/fs.py
+++ b/src/ralph/backends/storage/fs.py
@@ -62,7 +62,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         logger.debug("Found %d archives", len(archives))
 
         if new:
-            archives = set(archives) - set(self.get_command_history(self.name, "fetch"))
+            archives = set(archives) - set(self.get_command_history(self.name, "read"))
             logger.debug("New archives: %d", len(archives))
 
         for archive in archives:
@@ -86,7 +86,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "filename": details.get("filename"),
                 "size": details.get("size"),
@@ -114,7 +114,7 @@ class FSStorage(HistoryMixin, BaseStorage):
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "push",
+                "command": "write",
                 "id": name,
                 "filename": details.get("filename"),
                 "size": details.get("size"),

--- a/src/ralph/backends/storage/ldp.py
+++ b/src/ralph/backends/storage/ldp.py
@@ -104,7 +104,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         logger.debug("Found %d archives", len(archives))
 
         if new:
-            archives = set(archives) - set(self.get_command_history(self.name, "fetch"))
+            archives = set(archives) - set(self.get_command_history(self.name, "read"))
             logger.debug("New archives: %d", len(archives))
 
         for archive in archives:
@@ -130,7 +130,7 @@ class LDPStorage(HistoryMixin, BaseStorage):
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "filename": details.get("filename"),
                 "size": details.get("size"),

--- a/src/ralph/backends/storage/s3.py
+++ b/src/ralph/backends/storage/s3.py
@@ -64,7 +64,7 @@ class S3Storage(
         """Lists archives in the storage backend."""
         archives_to_skip = set()
         if new:
-            archives_to_skip = set(self.get_command_history(self.name, "fetch"))
+            archives_to_skip = set(self.get_command_history(self.name, "read"))
 
         try:
             paginator = self.client.get_paginator("list_objects_v2")
@@ -114,7 +114,7 @@ class S3Storage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "size": size,
                 "fetched_at": now(),
@@ -141,7 +141,7 @@ class S3Storage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "push",
+                "command": "write",
                 "id": name,
                 "pushed_at": now(),
             }

--- a/src/ralph/backends/storage/swift.py
+++ b/src/ralph/backends/storage/swift.py
@@ -81,7 +81,7 @@ class SwiftStorage(
         """Lists files in the storage backend."""
         archives_to_skip = set()
         if new:
-            archives_to_skip = set(self.get_command_history(self.name, "fetch"))
+            archives_to_skip = set(self.get_command_history(self.name, "read"))
         with SwiftService(self.options) as swift:
             for page in swift.list(self.container):
                 if not page["success"]:
@@ -126,7 +126,7 @@ class SwiftStorage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "fetch",
+                "command": "read",
                 "id": name,
                 "size": size,
                 "fetched_at": now(),
@@ -153,7 +153,7 @@ class SwiftStorage(
         self.append_to_history(
             {
                 "backend": self.name,
-                "command": "push",
+                "command": "write",
                 "id": name,
                 "pushed_at": now(),
             }

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -314,7 +314,7 @@ def auth(
     username,
     password,
     scope,
-    write_credentials,
+    write_to_disk,
     agent_ifi_mbox,
     agent_ifi_mbox_sha1sum,
     agent_ifi_openid,
@@ -392,7 +392,7 @@ def auth(
         agent=agent,
     )
 
-    if write_credentials:
+    if write_to_disk:
         logger.info("Will append new credentials to: %s", settings.AUTH_FILE)
 
         # Force Path object instantiation so that the file creation can be

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -304,7 +304,7 @@ def backends_options(name=None, backend_types: List[BaseModel] = None):
 )
 @click.option(
     "-w",
-    "--write-credentials",
+    "--write-to-disk",
     is_flag=True,
     default=False,
     help="Write new credentials to the LRS authentication file.",

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -304,7 +304,7 @@ def backends_options(name=None, backend_types: List[BaseModel] = None):
 )
 @click.option(
     "-w",
-    "--write",
+    "--write-credentials",
     is_flag=True,
     default=False,
     help="Write new credentials to the LRS authentication file.",
@@ -314,7 +314,7 @@ def auth(
     username,
     password,
     scope,
-    write,
+    write_credentials,
     agent_ifi_mbox,
     agent_ifi_mbox_sha1sum,
     agent_ifi_openid,
@@ -392,7 +392,7 @@ def auth(
         agent=agent,
     )
 
-    if write:
+    if write_credentials:
         logger.info("Will append new credentials to: %s", settings.AUTH_FILE)
 
         # Force Path object instantiation so that the file creation can be
@@ -561,7 +561,7 @@ def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs)
     "--target",
     type=str,
     default=None,
-    help="Endpoint from which to fetch events (e.g. `/statements`)",
+    help="Endpoint from which to read events (e.g. `/statements`)",
 )
 @click.option(
     "-q",
@@ -570,8 +570,8 @@ def convert(from_, to_, ignore_errors, fail_on_unknown, **conversion_set_kwargs)
     default=None,
     help="Query object as a JSON string (database and HTTP backends ONLY)",
 )
-def fetch(backend, archive, chunk_size, target, query, **options):
-    """Fetch an archive or records from a configured backend."""
+def read(backend, archive, chunk_size, target, query, **options):
+    """Read an archive or records from a configured backend."""
     logger.info(
         (
             "Fetching data from the configured %s backend "
@@ -673,9 +673,9 @@ def fetch(backend, archive, chunk_size, target, query, **options):
     "--target",
     type=str,
     default=None,
-    help="Endpoint in which to push events (e.g. `statements`)",
+    help="Endpoint in which to write events (e.g. `statements`)",
 )
-def push(
+def write(
     backend,
     archive,
     chunk_size,
@@ -686,8 +686,9 @@ def push(
     target,
     **options,
 ):
-    """Push an archive to a configured backend."""
-    logger.info("Pushing archive %s to the configured %s backend", archive, backend)
+    """Write an archive to a configured backend."""
+    logger.info("Writing archive %s to the configured %s backend", archive, backend)
+
     logger.debug("Backend parameters: %s", options)
 
     if max_num_simultaneous == 1:

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -133,23 +133,12 @@ def statements_are_equivalent(statement_1: dict, statement_2: dict):
     # Check that unmutable fields have the same values
     fields = ["actor", "verb", "object", "id", "result", "context", "attachements"]
     if any(statement_1.get(field) != statement_2.get(field) for field in fields):
-        print('yoga fire')
         return False
 
-    print('nice judo')
     # Check that fields enriched by the LRS are equal when present in both statements
     other_fields = {"authority", "stored", "timestamp", "version"}
     other_fields = other_fields & statement_1.keys() & statement_2.keys()
     if any(statement_1.get(field) != statement_2.get(field) for field in other_fields):
-        print('free drink')
-        print(other_fields)
-        print('\n')
-        for field in other_fields:
-            print(field)
-            print(statement_1.get(field))
-            print(statement_2.get(field))
-            print("\n")
-
         return False
     
     return True

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -122,11 +122,12 @@ async def gather_with_limited_concurrency(num_tasks: Union[None, int], *tasks):
         group.cancel()
         raise exception
 
+
 def statements_are_equivalent(statement_1: dict, statement_2: dict):
     """Check if statements are equivalent.
-    
-    To be equivalent, they must be identical on all fields not modified on input by the 
-    LRS and idententical on other fields, if these fields are present in both 
+
+    To be equivalent, they must be identical on all fields not modified on input by the
+    LRS and idententical on other fields, if these fields are present in both
     statements. For example, if an "authority" field is present in only one statement,
     they may still be equivalent.
     """
@@ -140,17 +141,18 @@ def statements_are_equivalent(statement_1: dict, statement_2: dict):
     other_fields = other_fields & statement_1.keys() & statement_2.keys()
     if any(statement_1.get(field) != statement_2.get(field) for field in other_fields):
         return False
-    
+
     return True
 
 
-def _assert_statements_are_equivalent(statement_1: dict, statement_2: dict):  
+def _assert_statements_are_equivalent(statement_1: dict, statement_2: dict):
     """Assert that statements are identical on fields not modified by the LRS."""
     assert statements_are_equivalent(statement_1, statement_2)
 
+
 def assert_statement_get_responses_are_equivalent(response_1: dict, response_2: dict):
     """Check that responses to GET /statements are equivalent.
-    
+
     Check that all statements in response are equivalent, meaning that all
     fields not modified by the LRS are equal.
     """
@@ -165,11 +167,14 @@ def assert_statement_get_responses_are_equivalent(response_1: dict, response_2: 
     # Assert the statements part of the response is equivalent
     assert "statements" in response_1.keys()
     assert len(response_1["statements"]) == len(response_2["statements"])
-    for statement_1, statement_2 in zip(response_1["statements"], response_2["statements"]):
+    for statement_1, statement_2 in zip(
+        response_1["statements"], response_2["statements"]
+    ):
         _assert_statements_are_equivalent(statement_1, statement_2)
 
+
 def string_is_date(string):
-    try: 
+    try:
         parse(string)
         return True
     except:

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -123,17 +123,37 @@ async def gather_with_limited_concurrency(num_tasks: Union[None, int], *tasks):
         raise exception
 
 def statements_are_equivalent(statement_1: dict, statement_2: dict):
-    """Check if statements are identical on fields not modified on input by the LRS.
+    """Check if statements are equivalent.
     
-    Fields not being compared are: "timestamp", "stored", "authority".
+    To be equivalent, they must be identical on all fields not modified on input by the 
+    LRS and idententical on other fields, if these fields are present in both 
+    statements. For example, if an "authority" field is present in only one statement,
+    they may still be equivalent.
     """
+    # Check that unmutable fields have the same values
     fields = ["actor", "verb", "object", "id", "result", "context", "attachements"]
-    print('jokeyr\n')
-    import pprint
-    pprint.pprint(statement_1)
-    print('\n')
-    pprint.pprint(statement_2)
-    return all(statement_1.get(field) == statement_2.get(field) for field in fields)
+    if any(statement_1.get(field) != statement_2.get(field) for field in fields):
+        print('yoga fire')
+        return False
+
+    print('nice judo')
+    # Check that fields enriched by the LRS are equal when present in both statements
+    other_fields = {"authority", "stored", "timestamp", "version"}
+    other_fields = other_fields & statement_1.keys() & statement_2.keys()
+    if any(statement_1.get(field) != statement_2.get(field) for field in other_fields):
+        print('free drink')
+        print(other_fields)
+        print('\n')
+        for field in other_fields:
+            print(field)
+            print(statement_1.get(field))
+            print(statement_2.get(field))
+            print("\n")
+
+        return False
+    
+    return True
+
 
 def _assert_statements_are_equivalent(statement_1: dict, statement_2: dict):  
     """Assert that statements are identical on fields not modified by the LRS."""

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.8.0
+  version: 3.9.0

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -21,10 +21,10 @@ ralph_mount_es_ca_secret: false
 #       - "-c"
 #       - ralph list --backend ldp --new |
 #           xargs -I {} -n 1 bash -c "
-#             ralph fetch --backend ldp {} |
+#             ralph read --backend ldp {} |
 #             gunzip |
 #             ralph extract -p gelf |
-#             ralph push \
+#             ralph write \
 #               --backend es \
 #               --es-client-options ca_certs=/usr/local/share/ca-certificates/es-cluster.pem"
 ralph_cronjobs: []

--- a/tests/api/auth/test_basic.py
+++ b/tests/api/auth/test_basic.py
@@ -97,6 +97,7 @@ def test_api_auth_basic_caching_credentials(fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     credentials = HTTPBasicCredentials(username="ralph", password="admin")
 
@@ -117,6 +118,7 @@ def test_api_auth_basic_with_wrong_password(fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     credentials = HTTPBasicCredentials(username="ralph", password="wrong_password")
 
@@ -171,6 +173,7 @@ def test_get_whoami_username_not_found(basic_auth_test_client, fs):
     """Whoami route returns a 401 error when the username cannot be found."""
     credential_bytes = base64.b64encode("john:admin".encode("utf-8"))
     credentials = str(credential_bytes, "utf-8")
+    get_authenticated_user.cache_clear()
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
@@ -192,6 +195,7 @@ def test_get_whoami_wrong_password(basic_auth_test_client, fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     response = basic_auth_test_client.get(
         "/whoami", headers={"Authorization": f"Basic {credentials}"}
@@ -213,6 +217,7 @@ def test_get_whoami_correct_credentials(basic_auth_test_client, fs):
 
     auth_file_path = settings.APP_DIR / "auth.json"
     fs.create_file(auth_file_path, contents=STORED_CREDENTIALS)
+    get_authenticated_user.cache_clear()
 
     response = basic_auth_test_client.get(
         "/whoami", headers={"Authorization": f"Basic {credentials}"}

--- a/tests/api/auth/test_basic.py
+++ b/tests/api/auth/test_basic.py
@@ -23,6 +23,7 @@ STORED_CREDENTIALS = json.dumps(
             "username": "ralph",
             "hash": bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode("UTF-8"),
             "scopes": ["ralph_test_scope"],
+            "agent": {"mbox": "mailto:ralph@example.com"},
         }
     ]
 )
@@ -34,15 +35,26 @@ def test_api_auth_basic_model_serveruserscredentials():
     users = ServerUsersCredentials(
         __root__=[
             UserCredentials(
-                username="johndoe", hash="notrealhash", scopes=["johndoe_scope"]
+                username="johndoe",
+                hash="notrealhash",
+                scopes=["johndoe_scope"],
+                agent={"mbox": "mailto:johndoe@example.com"},
             ),
-            UserCredentials(username="foo", hash="notsorealhash", scopes=["foo_scope"]),
+            UserCredentials(
+                username="foo",
+                hash="notsorealhash",
+                scopes=["foo_scope"],
+                agent={"mbox": "mailto:foo@example.com"},
+            ),
         ]
     )
     other_users = ServerUsersCredentials.parse_obj(
         [
             UserCredentials(
-                username="janedoe", hash="notreallyrealhash", scopes=["janedoe_scope"]
+                username="janedoe",
+                hash="notreallyrealhash",
+                scopes=["janedoe_scope"],
+                agent={"mbox": "mailto:janedoe@example.com"},
             ),
         ]
     )
@@ -71,7 +83,10 @@ def test_api_auth_basic_model_serveruserscredentials():
         users += ServerUsersCredentials.parse_obj(
             [
                 UserCredentials(
-                    username="foo", hash="notsorealhash", scopes=["foo_scope"]
+                    username="foo",
+                    hash="notsorealhash",
+                    scopes=["foo_scope"],
+                    agent={"mbox": "mailto:foo2@example.com"},
                 ),
             ]
         )
@@ -90,7 +105,10 @@ def test_api_auth_basic_caching_credentials(fs):
 
     assert get_authenticated_user.cache.popitem() == (
         ("ralph", "admin"),
-        AuthenticatedUser(username="ralph", scopes=["ralph_test_scope"]),
+        AuthenticatedUser(
+            agent={"mbox": "mailto:ralph@example.com"},
+            scopes=["ralph_test_scope"],
+        ),
     )
 
 
@@ -202,6 +220,6 @@ def test_get_whoami_correct_credentials(basic_auth_test_client, fs):
 
     assert response.status_code == 200
     assert response.json() == {
-        "username": "ralph",
+        "agent": {"mbox": "mailto:ralph@example.com"},
         "scopes": ["ralph_test_scope"],
     }

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -40,7 +40,7 @@ def test_api_auth_oidc_valid(
     assert response.status_code == 200
     assert response.json() == {
         "scopes": ["all", "statements/read"],
-        "agent": {"homePage": "https://iss.example.com", "name": "123|oidc"},
+        "agent": {"openid": "123|oidc"},
     }
 
 

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -38,7 +38,10 @@ def test_api_auth_oidc_valid(
         headers={"Authorization": f"Bearer {encoded_token}"},
     )
     assert response.status_code == 200
-    assert response.json() == {"scopes": None, "username": "some-issuer/123|oidc"}
+    assert response.json() == {
+        "scopes": ["all", "statements/read"],
+        "agent": {"homePage": "https://iss.example.com", "name": "123|oidc"},
+    }
 
 
 @responses.activate

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -266,11 +266,13 @@ def test_api_statements_get_statements_by_agent(
             "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
             "timestamp": datetime.now().isoformat(),
             "actor": agent_1,
+            "authority": agent_1,
         },
         {
             "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
             "timestamp": datetime.now().isoformat(),
             "actor": agent_2,
+            "authority": agent_1,
         },
     ]
     insert_statements_and_monkeypatch_backend(statements)

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -271,7 +271,6 @@ def test_api_statements_post_statements_list(
     # Update statements with the generated id.
     statements[1] = dict(statements[1], **{"id": generated_id})
 
-    # assert get_response.json() == {"statements": statements}
     assert_statement_get_responses_are_equivalent(get_response.json(), {"statements": statements})
 
 
@@ -378,11 +377,11 @@ def test_api_statements_post_statements_list_with_duplicate_of_existing_statemen
 
     es.indices.refresh()
 
-    # Post the statement again, trying to change the version field which is not allowed.
+    # Post the statement again, trying to change the timestamp field which is not allowed.
     response = client.post(
         "/xAPI/statements/",
         headers={"Authorization": f"Basic {auth_credentials}"},
-        json=[dict(statement, **{"version": "1.0.0"})],
+        json=[dict(statement, **{"timestamp": "2023-03-15T14:07:51Z"})],
     )
 
     assert response.status_code == 409
@@ -647,7 +646,8 @@ async def test_post_statements_list_with_statement_forwarding(
                 headers={"Authorization": f"Basic {auth_credentials}"},
             )
             assert response.status_code == 200
-            assert response.json() == {"statements": [statement]}
+            assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
     # The statement should also be stored on the receiving client
     async with AsyncClient() as receiving_client:
@@ -656,7 +656,8 @@ async def test_post_statements_list_with_statement_forwarding(
             headers={"Authorization": f"Basic {auth_credentials}"},
         )
         assert response.status_code == 200
-        assert response.json() == {"statements": [statement]}
+        assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
 
     # Stop receiving LRS client
     await lrs_context.__aexit__(None, None, None)

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -71,7 +71,9 @@ def test_api_statements_post_single_statement_directly(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+    assert_statement_get_responses_are_equivalent(
+        response.json(), {"statements": [statement]}
+    )
 
 
 # pylint: disable=too-many-arguments
@@ -81,7 +83,9 @@ def test_api_statements_post_enriching_without_existing_values(
     """Test that statements are properly enriched when statement provides no values."""
     # pylint: disable=invalid-name,unused-argument
 
-    monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", get_es_test_backend())
+    monkeypatch.setattr(
+        "ralph.api.routers.statements.DATABASE_CLIENT", get_es_test_backend()
+    )
     statement = {
         "actor": {
             "account": {
@@ -108,7 +112,7 @@ def test_api_statements_post_enriching_without_existing_values(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
 
-    statement = response.json()['statements'][0]
+    statement = response.json()["statements"][0]
 
     # Test pre-processing: id
     assert "id" in statement
@@ -130,7 +134,7 @@ def test_api_statements_post_enriching_without_existing_values(
 @pytest.mark.parametrize(
     "field,value,status",
     [
-        ("id", str(uuid4()), 200), 
+        ("id", str(uuid4()), 200),
         ("timestamp", "2022-06-22T08:31:38Z", 200),
         ("stored", "2022-06-22T08:31:38Z", 200),
         ("authority", {"mbox": "mailto:test_ralph@example.com"}, 200),
@@ -144,7 +148,9 @@ def test_api_statements_post_enriching_with_existing_values(
     """Test that statements are properly enriched when values are provided."""
     # pylint: disable=invalid-name,unused-argument
 
-    monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", get_es_test_backend())
+    monkeypatch.setattr(
+        "ralph.api.routers.statements.DATABASE_CLIENT", get_es_test_backend()
+    )
     statement = {
         "actor": {
             "account": {
@@ -173,7 +179,7 @@ def test_api_statements_post_enriching_with_existing_values(
         response = client.get(
             "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
         )
-        statement = response.json()['statements'][0]
+        statement = response.json()["statements"][0]
 
         # Test enriching
 
@@ -261,7 +267,9 @@ def test_api_statements_post_statements_list_of_one(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+    assert_statement_get_responses_are_equivalent(
+        response.json(), {"statements": [statement]}
+    )
 
 
 @pytest.mark.parametrize(
@@ -326,9 +334,9 @@ def test_api_statements_post_statements_list(
     # Update statements with the generated id.
     statements[1] = dict(statements[1], **{"id": generated_id})
 
-    assert_statement_get_responses_are_equivalent(get_response.json(), {"statements": statements})
-
-
+    assert_statement_get_responses_are_equivalent(
+        get_response.json(), {"statements": statements}
+    )
 
 
 @pytest.mark.parametrize(
@@ -449,8 +457,9 @@ def test_api_statements_post_statements_list_with_duplicate_of_existing_statemen
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
-    
+    assert_statement_get_responses_are_equivalent(
+        response.json(), {"statements": [statement]}
+    )
 
 
 @pytest.mark.parametrize(
@@ -701,8 +710,9 @@ async def test_post_statements_list_with_statement_forwarding(
                 headers={"Authorization": f"Basic {auth_credentials}"},
             )
             assert response.status_code == 200
-            assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
-
+            assert_statement_get_responses_are_equivalent(
+                response.json(), {"statements": [statement]}
+            )
 
     # The statement should also be stored on the receiving client
     async with AsyncClient() as receiving_client:
@@ -711,8 +721,9 @@ async def test_post_statements_list_with_statement_forwarding(
             headers={"Authorization": f"Basic {auth_credentials}"},
         )
         assert response.status_code == 200
-        assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
-
+        assert_statement_get_responses_are_equivalent(
+            response.json(), {"statements": [statement]}
+        )
 
     # Stop receiving LRS client
     await lrs_context.__aexit__(None, None, None)

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -11,6 +11,7 @@ from ralph.backends.database.es import ESDatabase
 from ralph.backends.database.mongo import MongoDatabase
 from ralph.conf import XapiForwardingConfigurationSettings
 from ralph.exceptions import BackendException
+from ralph.utils import assert_statement_get_responses_are_equivalent, string_is_date
 
 from tests.fixtures.backends import (
     ES_TEST_FORWARDING_INDEX,
@@ -24,6 +25,7 @@ from tests.fixtures.backends import (
     get_es_test_backend,
     get_mongo_test_backend,
 )
+
 
 client = TestClient(app)
 
@@ -68,7 +70,63 @@ def test_api_statements_put_single_statement_directly(
         "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
+
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
+)
+# pylint: disable=too-many-arguments
+def test_api_statements_put_pre_processing(
+    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+):
+    """Tests the put statements pre-processing."""
+    # pylint: disable=invalid-name,unused-argument
+
+    monkeypatch.setattr("ralph.api.routers.statements.DATABASE_CLIENT", backend())
+    statement = {
+        "actor": {
+            "account": {
+                "homePage": "https://example.com/homepage/",
+                "name": str(uuid4()),
+            },
+            "objectType": "Agent",
+        },
+        "id": str(uuid4()),
+        "object": {"id": "https://example.com/object-id/1/"},
+        "timestamp": "2022-06-22T08:31:38Z",
+        "verb": {"id": "https://example.com/verb-id/1/"},
+    }
+
+    response = client.put(
+        f"/xAPI/statements/?statementId={statement['id']}",
+        headers={"Authorization": f"Basic {auth_credentials}"},
+        json=statement,
+    )
+
+    assert response.status_code == 204
+
+    es.indices.refresh()
+
+    response = client.get(
+        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+    )
+
+    # Test pre-processing: id
+    assert "id" in response.json()['statements'][0]
+
+    # Test pre-processing: timestamp
+    assert "timestamp" in response.json()["statements"][0]
+    assert string_is_date(response.json()["statements"][0]["timestamp"])
+
+    # Test pre-processing: stored
+    assert "stored" in response.json()["statements"][0]
+    assert string_is_date(response.json()["statements"][0]["stored"])
+
+    # Test pre-processing: authority
+    # TODO
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -61,8 +61,7 @@ def test_api_statements_put_single_statement_directly(
         headers={"Authorization": f"Basic {auth_credentials}"},
         json=statement,
     )
-    print('yologr')
-    print(response.content)
+    
     assert response.status_code == 204
 
     es.indices.refresh()

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -61,7 +61,8 @@ def test_api_statements_put_single_statement_directly(
         headers={"Authorization": f"Basic {auth_credentials}"},
         json=statement,
     )
-
+    print('yologr')
+    print(response.content)
     assert response.status_code == 204
 
     es.indices.refresh()
@@ -274,11 +275,11 @@ def test_api_statements_put_statement_duplicate_of_existing_statement(
 
     es.indices.refresh()
 
-    # Put the statement twice, trying to change the version field which is not allowed.
+    # Put the statement twice, trying to change the timestamp field which is not allowed.
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
         headers={"Authorization": f"Basic {auth_credentials}"},
-        json=dict(statement, **{"version": "1.0.0"}),
+        json=dict(statement, **{"timestamp": "2023-03-15T14:07:51Z"}),
     )
 
     assert response.status_code == 409
@@ -291,7 +292,7 @@ def test_api_statements_put_statement_duplicate_of_existing_statement(
         headers={"Authorization": f"Basic {auth_credentials}"},
     )
     assert response.status_code == 200
-    assert response.json() == {"statements": [statement]}
+    assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
 
 
 @pytest.mark.parametrize(
@@ -544,7 +545,7 @@ async def test_put_statement_with_statement_forwarding(
                 headers={"Authorization": f"Basic {auth_credentials}"},
             )
             assert response.status_code == 200
-            assert response.json() == {"statements": [statement]}
+            assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
 
     # The statement should also be stored on the receiving client
     async with AsyncClient() as receiving_client:
@@ -553,7 +554,7 @@ async def test_put_statement_with_statement_forwarding(
             headers={"Authorization": f"Basic {auth_credentials}"},
         )
         assert response.status_code == 200
-        assert response.json() == {"statements": [statement]}
+        assert_statement_get_responses_are_equivalent(response.json(), {"statements": [statement]})
 
     # Stop receiving LRS client
     await lrs_context.__aexit__(None, None, None)

--- a/tests/backends/storage/test_ldp.py
+++ b/tests/backends/storage/test_ldp.py
@@ -229,14 +229,14 @@ def test_backends_storage_ldp_list_method_history_management(
     # Apply the monkeypatch for requests.post to mock_get
     monkeypatch.setattr(storage.client, "get", mock_list)
 
-    # Create a fetch history
+    # Create a read history
     fs.create_file(
         settings.HISTORY_FILE,
         contents=json.dumps(
             [
                 {
                     "backend": "ldp",
-                    "command": "fetch",
+                    "command": "read",
                     "id": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
                     "filename": "20201002.tgz",
                     "size": 23424233,
@@ -244,7 +244,7 @@ def test_backends_storage_ldp_list_method_history_management(
                 },
                 {
                     "backend": "ldp",
-                    "command": "fetch",
+                    "command": "read",
                     "id": "997db3eb-b9ca-485d-810f-b530a6cef7c6",
                     "filename": "20201002.tgz",
                     "size": 23424233,
@@ -252,7 +252,7 @@ def test_backends_storage_ldp_list_method_history_management(
                 },
                 {
                     "backend": "ldp",
-                    "command": "fetch",
+                    "command": "read",
                     "id": "08075b54-8d24-42ea-a509-9f10b0e3b416",
                     "filename": "20201002.tgz",
                     "size": 23424233,
@@ -430,7 +430,7 @@ def test_backends_storage_ldp_read_method(monkeypatch, fs, settings_fs):
     assert storage.history == [
         {
             "backend": "ldp",
-            "command": "fetch",
+            "command": "read",
             "id": "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
             "filename": "2020-06-16.gz",
             "size": 67906662,

--- a/tests/backends/storage/test_s3.py
+++ b/tests/backends/storage/test_s3.py
@@ -99,8 +99,8 @@ def test_backends_storage_s3_list_should_yield_archive_names(
     ]
 
     history = [
-        {"id": "2022-04-29.gz", "backend": "s3", "command": "fetch"},
-        {"id": "2022-04-30.gz", "backend": "s3", "command": "fetch"},
+        {"id": "2022-04-29.gz", "backend": "s3", "command": "read"},
+        {"id": "2022-04-30.gz", "backend": "s3", "command": "read"},
     ]
 
     s3 = s3()
@@ -224,7 +224,7 @@ def test_backends_storage_s3_read_with_valid_name_should_write_to_history(
     assert s3.history == [
         {
             "backend": "s3",
-            "command": "fetch",
+            "command": "read",
             "id": "2022-09-29.gz",
             "size": len(body),
             "fetched_at": freezed_now,
@@ -300,8 +300,8 @@ def test_backends_storage_s3_write_should_write_to_history_new_or_overwritten_ar
     )
 
     history = [
-        {"id": "2022-09-29.gz", "backend": "s3", "command": "fetch"},
-        {"id": "2022-09-30.gz", "backend": "s3", "command": "fetch"},
+        {"id": "2022-09-29.gz", "backend": "s3", "command": "read"},
+        {"id": "2022-09-30.gz", "backend": "s3", "command": "read"},
     ]
 
     freezed_now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
@@ -309,7 +309,7 @@ def test_backends_storage_s3_write_should_write_to_history_new_or_overwritten_ar
     new_history_entry = [
         {
             "backend": "s3",
-            "command": "push",
+            "command": "write",
             "id": archive_name,
             "pushed_at": freezed_now,
         }
@@ -359,8 +359,8 @@ def test_backends_storage_s3_write_should_log_the_error(
     )
 
     history = [
-        {"id": "2022-09-29.gz", "backend": "s3", "command": "fetch"},
-        {"id": "2022-09-30.gz", "backend": "s3", "command": "fetch"},
+        {"id": "2022-09-29.gz", "backend": "s3", "command": "read"},
+        {"id": "2022-09-30.gz", "backend": "s3", "command": "read"},
     ]
 
     fs.create_file(settings.HISTORY_FILE, contents=json.dumps(history))

--- a/tests/backends/storage/test_swift.py
+++ b/tests/backends/storage/test_swift.py
@@ -61,8 +61,8 @@ def test_backends_storage_swift_list_should_yield_archive_names(
         {"name": "2020-05-01.gz"},
     ]
     history = [
-        {"id": "2020-04-29.gz", "backend": "swift", "command": "fetch"},
-        {"id": "2020-04-30.gz", "backend": "swift", "command": "fetch"},
+        {"id": "2020-04-29.gz", "backend": "swift", "command": "read"},
+        {"id": "2020-04-30.gz", "backend": "swift", "command": "read"},
     ]
 
     def mock_list_with_pages(*args, **kwargs):  # pylint:disable=unused-argument
@@ -141,7 +141,7 @@ def test_backends_storage_swift_read_with_valid_name_should_write_to_history(
     assert swift.history == [
         {
             "backend": "swift",
-            "command": "fetch",
+            "command": "read",
             "id": "2020-04-29.gz",
             "size": 12,
             "fetched_at": freezed_now,
@@ -192,8 +192,8 @@ def test_backends_storage_swift_write_should_write_to_history_new_or_overwriten_
     should raise a FileExistsError.
     """
     history = [
-        {"id": "2020-04-29.gz", "backend": "swift", "command": "fetch"},
-        {"id": "2020-04-30.gz", "backend": "swift", "command": "fetch"},
+        {"id": "2020-04-29.gz", "backend": "swift", "command": "read"},
+        {"id": "2020-04-30.gz", "backend": "swift", "command": "read"},
     ]
     listing = [
         {"name": "2020-04-29.gz"},
@@ -205,7 +205,7 @@ def test_backends_storage_swift_write_should_write_to_history_new_or_overwriten_
     new_history_entry = [
         {
             "backend": "swift",
-            "command": "push",
+            "command": "write",
             "id": archive_name,
             "pushed_at": freezed_now,
         }
@@ -249,8 +249,8 @@ def test_backends_storage_swift_write_should_log_the_error(
     """
     error = "Unauthorized. Check username/id, password"
     history = [
-        {"id": "2020-04-29.gz", "backend": "swift", "command": "fetch"},
-        {"id": "2020-04-30.gz", "backend": "swift", "command": "fetch"},
+        {"id": "2020-04-29.gz", "backend": "swift", "command": "read"},
+        {"id": "2020-04-30.gz", "backend": "swift", "command": "read"},
     ]
     listing = [
         {"name": "2020-04-29.gz"},

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -21,6 +21,7 @@ AUDIENCE = "http://clientHost:8100"
 ISSUER_URI = "http://providerHost:8080/auth/realms/real_name"
 PUBLIC_KEY_ID = "example-key-id"
 
+
 def create_user(
     fs_,
     username: str,

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -21,7 +21,6 @@ AUDIENCE = "http://clientHost:8100"
 ISSUER_URI = "http://providerHost:8080/auth/realms/real_name"
 PUBLIC_KEY_ID = "example-key-id"
 
-
 def create_user(
     fs_,
     username: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ test_logger = logging.getLogger("ralph")
 
 
 def test_cli_comma_separated_key_value_param_type():
-    """Tests the CommaSeparatedKeyValueParamType custom parameter type."""
+    """Test the CommaSeparatedKeyValueParamType custom parameter type."""
     param_type = CommaSeparatedKeyValueParamType()
 
     # Bad options
@@ -114,14 +114,14 @@ def test_cli_comma_separated_key_value_param_type():
     ],
 )
 def test_cli_comma_separated_tuple_param_type_with_valid_input(value, expected):
-    """Tests the CommaSeparatedTupleParamType parameter type with valid input."""
+    """Test the CommaSeparatedTupleParamType parameter type with valid input."""
     param_type = CommaSeparatedTupleParamType()
     assert param_type.convert(value, None, None) == expected
 
 
 @pytest.mark.parametrize("value", [None, {}, ["foo"], 10, True])
 def test_cli_comma_separated_tuple_param_type_with_invalid_input(value):
-    """Tests the CommaSeparatedTupleParamType parameter type with invalid input."""
+    """Test the CommaSeparatedTupleParamType parameter type with invalid input."""
     param_type = CommaSeparatedTupleParamType()
     with pytest.raises(
         BadParameter,
@@ -132,14 +132,14 @@ def test_cli_comma_separated_tuple_param_type_with_invalid_input(value):
 
 @pytest.mark.parametrize("value,expected", [('{"foo": "bar"}', {"foo": "bar"})])
 def test_cli_json_string_param_type_with_valid_input(value, expected):
-    """Tests the JSONStringParamType custom parameter type with valid input."""
+    """Test the JSONStringParamType custom parameter type with valid input."""
     param_type = JSONStringParamType()
     assert param_type.convert(value, None, None) == expected
 
 
 @pytest.mark.parametrize("value", ["foo", None, {}])
 def test_cli_json_string_param_type_with_invalid_input(value):
-    """Tests the JSONStringParamType custom parameter type with invalid input."""
+    """Test the JSONStringParamType custom parameter type with invalid input."""
     param_type = JSONStringParamType()
     with pytest.raises(
         BadParameter,
@@ -149,7 +149,7 @@ def test_cli_json_string_param_type_with_invalid_input(value):
 
 
 def test_cli_help_option():
-    """Tests ralph --help command."""
+    """Test ralph --help command."""
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
 
@@ -435,7 +435,7 @@ def test_cli_auth_command_when_writing_auth_file_whith_incorrect_auth_file(fs):
 
 
 def test_cli_extract_command_with_gelf_parser(gelf_logger):
-    """Tests the extract command using the GELF parser."""
+    """Test the extract command using the GELF parser."""
     gelf_logger.info('{"username": "foo"}')
 
     runner = CliRunner()
@@ -448,7 +448,7 @@ def test_cli_extract_command_with_gelf_parser(gelf_logger):
 
 
 def test_cli_extract_command_with_es_parser():
-    """Tests the extract command using the ElasticSearchParser."""
+    """Test the extract command using the ElasticSearchParser."""
     es_output = (
         "\n".join(
             [
@@ -475,7 +475,7 @@ def test_cli_extract_command_with_es_parser():
 
 @custom_given(UIPageClose)
 def test_cli_validate_command_with_edx_format(event):
-    """Tests the validate command using the edx format."""
+    """Test the validate command using the edx format."""
     event_str = event.json()
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "-f", "edx"], input=event_str)
@@ -486,7 +486,7 @@ def test_cli_validate_command_with_edx_format(event):
 @custom_given(UIPageClose)
 @pytest.mark.parametrize("valid_uuid", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
 def test_cli_convert_command_from_edx_to_xapi_format(valid_uuid, event):
-    """Tests the convert command from edx to xapi format."""
+    """Test the convert command from edx to xapi format."""
     event_str = event.json()
     runner = CliRunner()
     command = f"-v ERROR convert -f edx -t xapi -u {valid_uuid} -p https://fun-mooc.fr"
@@ -500,7 +500,7 @@ def test_cli_convert_command_from_edx_to_xapi_format(valid_uuid, event):
 
 @pytest.mark.parametrize("invalid_uuid", ["", None, 1, {}])
 def test_cli_convert_command_with_invalid_uuid(invalid_uuid):
-    """Tests that the convert command raises an exception when the uuid namespace is
+    """Test that the convert command raises an exception when the uuid namespace is
     invalid.
     """
     runner = CliRunner()
@@ -523,14 +523,14 @@ def dummy_verbosity_check():
 
 @pytest.mark.parametrize("verbosity", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
 def test_cli_verbosity_option_should_impact_logging_behaviour(verbosity):
-    """Tests that the verbosity option impacts logging output."""
+    """Test that the verbosity option impacts logging output."""
     runner = CliRunner()
     result = runner.invoke(cli, ["-v", verbosity, "dummy-verbosity-check"])
     assert verbosity in result.output
 
 
-def test_cli_fetch_command_with_ldp_backend(monkeypatch):
-    """Tests the fetch command using the LDP backend."""
+def test_cli_read_command_with_ldp_backend(monkeypatch):
+    """Test the read command using the LDP backend."""
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size=500):
@@ -542,7 +542,7 @@ def test_cli_fetch_command_with_ldp_backend(monkeypatch):
     monkeypatch.setattr(LDPStorage, "read", mock_read)
 
     runner = CliRunner()
-    command = "fetch -b ldp --ldp-endpoint ovh-eu a547d9b3-6f2f-4913-a872-cf4efe699a66"
+    command = "read -b ldp --ldp-endpoint ovh-eu a547d9b3-6f2f-4913-a872-cf4efe699a66"
     result = runner.invoke(cli, command.split())
 
     assert result.exit_code == 0
@@ -551,8 +551,8 @@ def test_cli_fetch_command_with_ldp_backend(monkeypatch):
 
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-def test_cli_fetch_command_with_fs_backend(fs, monkeypatch):
-    """Tests the fetch command using the FS backend."""
+def test_cli_read_command_with_fs_backend(fs, monkeypatch):
+    """Test the read command using the FS backend."""
     archive_content = {"foo": "bar"}
 
     def mock_read(this, name, chunk_size):
@@ -564,14 +564,14 @@ def test_cli_fetch_command_with_fs_backend(fs, monkeypatch):
     monkeypatch.setattr(FSStorage, "read", mock_read)
 
     runner = CliRunner()
-    result = runner.invoke(cli, "fetch -b fs foo".split())
+    result = runner.invoke(cli, "read -b fs foo".split())
 
     assert result.exit_code == 0
     assert '{"foo": "bar"}' in result.output
 
 
-def test_cli_fetch_command_with_es_backend(es):
-    """Tests ralph fetch command using the es backend."""
+def test_cli_read_command_with_es_backend(es):
+    """Test ralph read command using the es backend."""
     # pylint: disable=invalid-name
 
     # Insert documents
@@ -589,7 +589,7 @@ def test_cli_fetch_command_with_es_backend(es):
     runner = CliRunner()
     es_hosts = ",".join(ES_TEST_HOSTS)
     es_client_options = "verify_certs=True"
-    command = f"""-v ERROR fetch -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}
+    command = f"""-v ERROR read -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}
         --es-client-options {es_client_options}"""
     result = runner.invoke(cli, command.split())
     assert result.exit_code == 0
@@ -614,20 +614,20 @@ def test_cli_fetch_command_with_es_backend(es):
     assert expected == result.output
 
 
-def test_cli_fetch_command_client_options_with_es_backend(es):
-    """Tests ralph fetch command with multiple client options using the es backend."""
+def test_cli_read_command_client_options_with_es_backend(es):
+    """Test ralph read command with multiple client options using the es backend."""
     # pylint: disable=invalid-name
 
     runner = CliRunner()
     es_client_options = "ca_certs=/path/,verify_certs=True"
-    command = f"""-v ERROR fetch -b es --es-client-options {es_client_options}"""
+    command = f"""-v ERROR read -b es --es-client-options {es_client_options}"""
     result = runner.invoke(cli, command.split())
     assert result.exit_code == 1
     assert "TLS options require scheme to be 'https'" in str(result.exception)
 
 
-def test_cli_fetch_command_with_es_backend_query(es):
-    """Tests ralph fetch command using the es backend and a query."""
+def test_cli_read_command_with_es_backend_query(es):
+    """Test ralph read command using the es backend and a query."""
     # pylint: disable=invalid-name
 
     # Insert documents
@@ -653,7 +653,7 @@ def test_cli_fetch_command_with_es_backend_query(es):
 
     command = (
         "-v ERROR "
-        "fetch "
+        "read "
         "-b es "
         f"--es-hosts {es_hosts} "
         f"--es-index {ES_TEST_INDEX} "
@@ -682,18 +682,18 @@ def test_cli_fetch_command_with_es_backend_query(es):
     assert expected == result.output
 
 
-def test_cli_fetch_command_with_ws_backend(events, ws):
-    """Tests ralph fetch command using the ws backend."""
+def test_cli_read_command_with_ws_backend(events, ws):
+    """Test ralph read command using the ws backend."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["fetch", "-b", "ws", "--ws-uri", f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}"],
+        ["read", "-b", "ws", "--ws-uri", f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}"],
     )
     assert "\n".join([json.dumps(event) for event in events]) in result.output
 
 
 def test_cli_list_command_with_ldp_backend(monkeypatch):
-    """Tests the list command using the LDP backend."""
+    """Test the list command using the LDP backend."""
     archive_list = [
         "5d5c4c93-04a4-42c5-9860-f51fa4044aa1",
         "997db3eb-b9ca-485d-810f-b530a6cef7c6",
@@ -765,7 +765,7 @@ def test_cli_list_command_with_ldp_backend(monkeypatch):
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 def test_cli_list_command_with_fs_backend(fs, monkeypatch):
-    """Tests the list command using the LDP backend."""
+    """Test the list command using the LDP backend."""
     archive_list = [
         "file1",
         "file2",
@@ -825,8 +825,8 @@ def test_cli_list_command_with_fs_backend(fs, monkeypatch):
 
 
 # pylint: disable=invalid-name
-def test_cli_push_command_with_fs_backend(fs):
-    """Tests the push command using the FS backend."""
+def test_cli_write_command_with_fs_backend(fs):
+    """Test the write command using the FS backend."""
     fs.create_dir(str(settings.APP_DIR))
 
     filename = Path("file1")
@@ -834,7 +834,7 @@ def test_cli_push_command_with_fs_backend(fs):
 
     # Create a file
     runner = CliRunner()
-    result = runner.invoke(cli, "push -b fs file1".split(), input="test content")
+    result = runner.invoke(cli, "write -b fs file1".split(), input="test content")
 
     assert result.exit_code == 0
 
@@ -845,13 +845,13 @@ def test_cli_push_command_with_fs_backend(fs):
 
     # Trying to create the same file without -f should raise an error
     runner = CliRunner()
-    result = runner.invoke(cli, "push -b fs file1".split(), input="other content")
+    result = runner.invoke(cli, "write -b fs file1".split(), input="other content")
     assert result.exit_code == 1
     assert "file1 already exists and overwrite is not allowed" in result.output
 
     # Try to create the same file with -f
     runner = CliRunner()
-    result = runner.invoke(cli, "push -b fs -f file1".split(), input="other content")
+    result = runner.invoke(cli, "write -b fs -f file1".split(), input="other content")
 
     assert result.exit_code == 0
 
@@ -861,8 +861,8 @@ def test_cli_push_command_with_fs_backend(fs):
     assert "other content" in content
 
 
-def test_cli_push_command_with_es_backend(es):
-    """Tests ralph push command using the es backend."""
+def test_cli_write_command_with_es_backend(es):
+    """Test ralph write command using the es backend."""
     # pylint: disable=invalid-name
 
     # Documents
@@ -872,7 +872,7 @@ def test_cli_push_command_with_es_backend(es):
     es_hosts = ",".join(ES_TEST_HOSTS)
     result = runner.invoke(
         cli,
-        f"push -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}".split(),
+        f"write -b es --es-hosts {es_hosts} --es-index {ES_TEST_INDEX}".split(),
         input="\n".join(json.dumps(record) for record in records),
     )
     assert result.exit_code == 0
@@ -888,7 +888,7 @@ def test_cli_push_command_with_es_backend(es):
 
 @pytest.mark.parametrize("host_,port_", [("0.0.0.0", "8000"), ("127.0.0.1", "80")])
 def test_cli_runserver_command_with_host_and_port_arguments(host_, port_, monkeypatch):
-    """Tests the ralph runserver command should consider the host and port arguments."""
+    """Test the ralph runserver command should consider the host and port arguments."""
 
     def mock_uvicorn_run(_, host=None, port=None, **kwargs):
         """Mocks uvicorn.run asserting host and port values."""
@@ -904,7 +904,7 @@ def test_cli_runserver_command_with_host_and_port_arguments(host_, port_, monkey
 
 
 def test_cli_runserver_command_environment_file_generation(monkeypatch):
-    """Tests the ralph runserver command should create the expected environment file."""
+    """Test the ralph runserver command should create the expected environment file."""
 
     def mock_uvicorn_run(_, env_file=None, **kwargs):
         """Mocks uvicorn.run asserting environment file content."""

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -26,7 +26,7 @@ def test_cli_auth_command_usage():
             "-O, --agent-ifi-openid TEXT",
             "-A, --agent-ifi-account TEXT",
             "-N, --agent-name TEXT",
-            "-w, --write",
+            "-w, --write-credentials",
         ]
     )
 
@@ -36,7 +36,7 @@ def test_cli_auth_command_usage():
 
 
 def test_cli_extract_command_usage():
-    """Tests ralph extract command usage."""
+    """Test ralph extract command usage."""
     runner = CliRunner()
     result = runner.invoke(cli, ["extract", "--help"])
 
@@ -55,7 +55,7 @@ def test_cli_extract_command_usage():
 
 
 def test_cli_validate_command_usage():
-    """Tests ralph validate command usage."""
+    """Test ralph validate command usage."""
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "--help"])
 
@@ -75,7 +75,7 @@ def test_cli_validate_command_usage():
 
 
 def test_cli_convert_command_usage():
-    """Tests ralph convert command usage."""
+    """Test ralph convert command usage."""
     runner = CliRunner()
     result = runner.invoke(cli, ["convert", "--help"])
 
@@ -101,10 +101,10 @@ def test_cli_convert_command_usage():
     assert "Error: Missing option '-p' / '--platform-url'" in result.output
 
 
-def test_cli_fetch_command_usage():
-    """Test ralph fetch command usage."""
+def test_cli_read_command_usage():
+    """Test ralph read command usage."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["fetch", "--help"])
+    result = runner.invoke(cli, ["read", "--help"])
 
     assert result.exit_code == 0
     assert (
@@ -166,7 +166,7 @@ def test_cli_fetch_command_usage():
         "    --es-index TEXT\n"
         "    --es-hosts VALUE1,VALUE2,VALUE3\n"
         "  -c, --chunk-size INTEGER        Get events by chunks of size #\n"
-        "  -t, --target TEXT               Endpoint from which to fetch events (e.g.\n"
+        "  -t, --target TEXT               Endpoint from which to read events (e.g.\n"
         "                                  `/statements`)\n"
         '  -q, --query \'{"KEY": "VALUE", "KEY": "VALUE"}\'\n'
         "                                  Query object as a JSON string (database "
@@ -174,7 +174,7 @@ def test_cli_fetch_command_usage():
         "                                  HTTP backends ONLY)\n"
     ) in result.output
     logging.warning(result.output)
-    result = runner.invoke(cli, ["fetch"])
+    result = runner.invoke(cli, ["read"])
     assert result.exit_code > 0
     assert (
         "Error: Missing option '-b' / '--backend'. "
@@ -232,17 +232,17 @@ def test_cli_list_command_usage():
     ) in result.output
 
 
-def test_cli_push_command_usage():
-    """Test ralph push command usage."""
+def test_cli_write_command_usage():
+    """Test ralph write command usage."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["push", "--help"])
+    result = runner.invoke(cli, ["write", "--help"])
 
     assert result.exit_code == 0
 
     expected_output = (
-        "Usage: ralph push [OPTIONS] [ARCHIVE]\n"
+        "Usage: ralph write [OPTIONS] [ARCHIVE]\n"
         "\n"
-        "  Push an archive to a configured backend.\n"
+        "  Write an archive to a configured backend.\n"
         "\n"
         "Options:\n"
         "  -b, --backend [es|mongo|clickhouse|ldp|fs|swift|s3|lrs]\n"
@@ -311,13 +311,13 @@ def test_cli_push_command_usage():
         "                                  when using `--simultaneous`. Use `-1` to "
         "not\n"
         "                                  set a limit.\n"
-        "  -t, --target TEXT               Endpoint in which to push events (e.g.\n"
+        "  -t, --target TEXT               Endpoint in which to write events (e.g.\n"
         "                                  `statements`)\n"
         "  --help                          Show this message and exit.\n"
     )
     assert expected_output in result.output
 
-    result = runner.invoke(cli, ["push"])
+    result = runner.invoke(cli, ["write"])
     assert result.exit_code > 0
     assert (
         "Missing option '-b' / '--backend'. Choose from:\n\tes,\n\tmongo,"

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -14,18 +14,21 @@ def test_cli_auth_command_usage():
     result = runner.invoke(cli, ["auth", "--help"])
 
     assert result.exit_code == 0
-    assert (
-        "Options:\n"
-        "  -u, --username TEXT  The user for which we generate credentials.  "
-        "[required]\n"
-        "  -p, --password TEXT  The password to encrypt for this user. Will be "
-        "prompted\n"
-        "                       if missing.  [required]\n"
-        "  -s, --scope TEXT     The user scope(s). This option can be provided "
-        "multiple\n"
-        "                       times.  [required]\n"
-        "  -w, --write          Write new credentials to the LRS authentication file.\n"
-    ) in result.output
+    assert all(
+        text in result.output
+        for text in [
+            "Options:",
+            "-u, --username TEXT",
+            "-p, --password TEXT",
+            "-s, --scope TEXT",
+            "-M, --agent-ifi-mbox TEXT",
+            "-S, --agent-ifi-mbox-sha1sum TEXT",
+            "-O, --agent-ifi-openid TEXT",
+            "-A, --agent-ifi-account TEXT",
+            "-N, --agent-name TEXT",
+            "-w, --write",
+        ]
+    )
 
     result = runner.invoke(cli, ["auth"])
     assert result.exit_code > 0

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -26,7 +26,7 @@ def test_cli_auth_command_usage():
             "-O, --agent-ifi-openid TEXT",
             "-A, --agent-ifi-account TEXT",
             "-N, --agent-name TEXT",
-            "-w, --write-credentials",
+            "-w, --write-to-disk",
         ]
     )
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -10,7 +10,7 @@ from ralph.exceptions import ConfigurationException
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_exists(fs, monkeypatch):
-    """Tests the logging system when a correct configuration is provided."""
+    """Test the logging system when a correct configuration is provided."""
     mock_default_config = {
         "version": 1,
         "propagate": True,
@@ -42,18 +42,18 @@ def test_logger_exists(fs, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["push", "-b", "fs", "test_file"],
+        ["write", "-b", "fs", "test_file"],
         input="test input",
     )
 
     assert result.exit_code == 0
-    assert "Pushing archive test_file to the configured fs backend" in result.output
+    assert "Writing archive test_file to the configured fs backend" in result.output
     assert "Backend parameters:" in result.output
 
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_no_config(fs, monkeypatch):
-    """Tests that an error occurs when no logging configuration exists."""
+    """Test that an error occurs when no logging configuration exists."""
     mock_default_config = None
 
     monkeypatch.setattr(ralph.logger.settings, "LOGGING", mock_default_config)
@@ -67,7 +67,7 @@ def test_logger_no_config(fs, monkeypatch):
 
 # pylint: disable=invalid-name, unused-argument
 def test_logger_bad_config(fs, monkeypatch):
-    """Tests that an error occurs when a logging is improperly configured."""
+    """Test that an error occurs when a logging is improperly configured."""
     mock_default_config = "this is not a valid json"
 
     monkeypatch.setattr(ralph.logger.settings, "LOGGING", mock_default_config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,10 +147,6 @@ def test_utils_assert_statement_get_responses_are_equivalent():
         "result": "result_1",
         "context": "context_1",
         "attachements": "attachements_1",
-
-        "timestamp": "timestamp_2",
-        "stored": "stored_2",
-        "authority": "authority_2",
     }
 
     statement_3 = {
@@ -173,7 +169,7 @@ def test_utils_assert_statement_get_responses_are_equivalent():
 
     # Test that statements 1 and 2 are equivalent
     ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_2)
-
+    
     # Test that statements 1 and 3 are NOT equivalent
     with pytest.raises(AssertionError):
         ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,3 +117,74 @@ def test_utils_set_dict_value_from_path_updating_fields():
     dictionary = {"foo": {"bar": "bar_value"}}
     ralph_utils.set_dict_value_from_path(dictionary, ["foo", "bar"], "baz")
     assert dictionary == {"foo": {"bar": "baz"}}
+
+def test_utils_assert_statement_get_responses_are_equivalent():
+    """Test the equivalency assertion for get responses.
+    
+    Equivalency (term NOT in specifaction) means that two statements have 
+    identical values on all fields except `authority`, `stored` and `timestamp`
+    (where the value may or may not be identical).
+    """
+    statement_1 = {
+        "actor": {"actor_field": "actor_1"},
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+
+        "timestamp": "timestamp_1",
+        "stored": "stored_1",
+        "authority": "authority_1"
+    }
+
+    statement_2 = {
+        "actor": {"actor_field": "actor_1"},
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+
+        "timestamp": "timestamp_2",
+        "stored": "stored_2",
+        "authority": "authority_2",
+    }
+
+    statement_3 = {
+        "actor": {"actor_field": "actor_3"},
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+
+        "timestamp": "timestamp_1",
+        "stored": "stored_1",
+        "authority": "authority_1",
+    }
+
+    get_response_1 = {"statements": [statement_1]}
+    get_response_2 = {"statements": [statement_2]}
+    get_response_3 = {"statements": [statement_3]}
+
+    # Test that statements 1 and 2 are equivalent
+    ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_2)
+
+    # Test that statements 1 and 3 are NOT equivalent
+    with pytest.raises(AssertionError):
+        ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_3)
+
+
+def test_utils_string_is_date():
+    """Test that strings representing dates are properly identified."""
+    string = '2022-06-22T08:31:38Z'
+    assert ralph_utils.string_is_date(string)
+
+    string = '40223-06-22T08:31:38Z'
+    assert not ralph_utils.string_is_date(string)
+
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,10 +118,11 @@ def test_utils_set_dict_value_from_path_updating_fields():
     ralph_utils.set_dict_value_from_path(dictionary, ["foo", "bar"], "baz")
     assert dictionary == {"foo": {"bar": "baz"}}
 
+
 def test_utils_assert_statement_get_responses_are_equivalent():
     """Test the equivalency assertion for get responses.
-    
-    Equivalency (term NOT in specifaction) means that two statements have 
+
+    Equivalency (term NOT in specifaction) means that two statements have
     identical values on all fields except `authority`, `stored` and `timestamp`
     (where the value may or may not be identical).
     """
@@ -133,10 +134,9 @@ def test_utils_assert_statement_get_responses_are_equivalent():
         "result": "result_1",
         "context": "context_1",
         "attachements": "attachements_1",
-
         "timestamp": "timestamp_1",
         "stored": "stored_1",
-        "authority": "authority_1"
+        "authority": "authority_1",
     }
 
     statement_2 = {
@@ -157,7 +157,6 @@ def test_utils_assert_statement_get_responses_are_equivalent():
         "result": "result_1",
         "context": "context_1",
         "attachements": "attachements_1",
-
         "timestamp": "timestamp_1",
         "stored": "stored_1",
         "authority": "authority_1",
@@ -168,19 +167,21 @@ def test_utils_assert_statement_get_responses_are_equivalent():
     get_response_3 = {"statements": [statement_3]}
 
     # Test that statements 1 and 2 are equivalent
-    ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_2)
-    
+    ralph_utils.assert_statement_get_responses_are_equivalent(
+        get_response_1, get_response_2
+    )
+
     # Test that statements 1 and 3 are NOT equivalent
     with pytest.raises(AssertionError):
-        ralph_utils.assert_statement_get_responses_are_equivalent(get_response_1, get_response_3)
+        ralph_utils.assert_statement_get_responses_are_equivalent(
+            get_response_1, get_response_3
+        )
 
 
 def test_utils_string_is_date():
     """Test that strings representing dates are properly identified."""
-    string = '2022-06-22T08:31:38Z'
+    string = "2022-06-22T08:31:38Z"
     assert ralph_utils.string_is_date(string)
 
-    string = '40223-06-22T08:31:38Z'
+    string = "40223-06-22T08:31:38Z"
     assert not ralph_utils.string_is_date(string)
-
-


### PR DESCRIPTION
# WORK IN PROGRESS (do not review)

## Purpose

Description...

## Proposal

Description...

- [ ] enrich statements with `id`, `timestamp`, `stored`, `authority` 
- [ ] update existing tests to replace equality assertions by equivalency assertions
- [ ] write new tests checking that statements are properly enriched
- [ ] add configuration option for mandatory Authority option
- [ ] update changelog

