### PR TITLE
Add close method to synchronous backends

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ backend-lrs =
     httpx==0.24.1
     more-itertools==10.1.0
 backend-mongo =
-    motor[srv]>=3.1.1
+    motor[srv]>=3.3.0
     pymongo[srv]>=4.0.0
     python-dateutil>=2.8.2
 backend-s3 =

--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -264,9 +264,10 @@ class AsyncESDataBackend(BaseAsyncDataBackend):
         """Close the AsyncElasticsearch client.
 
         Raise:
-            BackendException: If a failure during the close operation occurs.
+            BackendException: If a failure occurs during the close operation.
         """
         if not self._client:
+            logger.warning("No backend client to close.")
             return
 
         try:

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -100,7 +100,7 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend):
 
         try:
             collections = await database.list_collections()
-            for collection_info in collections:
+            async for collection_info in collections:
                 if details:
                     yield collection_info
                 else:

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -256,7 +256,7 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend):
         """Close the AsyncIOMotorClient client.
 
         Raise:
-            BackendException: If a failure during the close operation occurs.
+            BackendException: If a failure occurs during the close operation.
         """
         try:
             self.client.close()

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -227,6 +227,14 @@ class BaseDataBackend(ABC):
             BackendParameterException: If a backend argument value is not valid.
         """
 
+    @abstractmethod
+    def close(self) -> None:
+        """Close the data backend client.
+
+        Raise:
+            BackendException: If a failure occurs during the close operation.
+        """
+
 
 class BaseAsyncDataBackend(ABC):
     """Base async data backend interface."""
@@ -381,5 +389,5 @@ class BaseAsyncDataBackend(ABC):
         """Close the data backend client.
 
         Raise:
-            BackendException: If a failure during the close operation occurs.
+            BackendException: If a failure occurs during the close operation.
         """

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -382,6 +382,23 @@ class ClickHouseDataBackend(BaseDataBackend):
 
         return count
 
+    def close(self) -> None:
+        """Close the ClickHouse backend client.
+
+        Raise:
+            BackendException: If a failure occurs during the close operation.
+        """
+        if not self._client:
+            logger.warning("No backend client to close.")
+            return
+
+        try:
+            self.client.close()
+        except ClickHouseError as error:
+            msg = "Failed to close ClickHouse client: %s"
+            logger.error(msg, error)
+            raise BackendException(msg % error) from error
+
     @staticmethod
     def _to_insert_tuples(
         data: Iterable[dict],

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -344,6 +344,23 @@ class ESDataBackend(BaseDataBackend):
             raise BackendException(msg % (error, details, count)) from error
         return count
 
+    def close(self) -> None:
+        """Close the Elasticsearch backend client.
+
+        Raise:
+            BackendException: If a failure occurs during the close operation.
+        """
+        if not self._client:
+            logger.warning("No backend client to close.")
+            return
+
+        try:
+            self.client.close()
+        except TransportError as error:
+            msg = "Failed to close Elasticsearch client: %s"
+            logger.error(msg, error)
+            raise BackendException(msg % error) from error
+
     @staticmethod
     def to_documents(
         data: Iterable[dict],

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -308,6 +308,12 @@ class FSDataBackend(HistoryMixin, BaseDataBackend):
         )
         return 1
 
+    def close(self) -> None:
+        """FS backend has nothing to close, this method is not implemented."""
+        msg = "FS data backend does not support `close` method"
+        logger.error(msg)
+        raise NotImplementedError(msg)
+
     @staticmethod
     def _read_raw(file: IO, chunk_size: int, _ignore_errors: bool) -> Iterator[bytes]:
         """Read the `file` in chunks of size `chunk_size` and yield them."""

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -226,6 +226,12 @@ class LDPDataBackend(HistoryMixin, BaseDataBackend):
         logger.error(msg, target)
         raise NotImplementedError(msg % target)
 
+    def close(self) -> None:
+        """LDP client does not support close, this method is not implemented."""
+        msg = "LDP data backend does not support `close` method"
+        logger.error(msg)
+        raise NotImplementedError(msg)
+
     def _get_archive_endpoint(self, stream_id: Union[None, str] = None) -> str:
         """Return OVH's archive endpoint."""
         stream_id = stream_id if stream_id else self.stream_id

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -346,6 +346,23 @@ class SwiftDataBackend(HistoryMixin, BaseDataBackend):
         )
         return count
 
+    def close(self) -> None:
+        """Close the Swift backend client.
+
+        Raise:
+            BackendException: If a failure occurs during the close operation.
+        """
+        if not self._connection:
+            logger.warning("No backend client to close.")
+            return
+
+        try:
+            self.connection.close()
+        except ClientException as error:
+            msg = "Failed to close Swift backend client: %s"
+            logger.error(msg, error)
+            raise BackendException(msg % error) from error
+
     def _details(self, container: str, name: str):
         """Return `name` object details from `container`."""
         try:

--- a/tests/backends/data/test_async_es.py
+++ b/tests/backends/data/test_async_es.py
@@ -825,7 +825,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_datastream(
 
 
 @pytest.mark.anyio
-async def test_backends_data_es_data_backend_close_method(
+async def test_backends_data_es_data_backend_close_method_with_failure(
     async_es_backend, monkeypatch
 ):
     """Test the `AsyncESDataBackend.close` method."""
@@ -840,3 +840,21 @@ async def test_backends_data_es_data_backend_close_method(
 
     with pytest.raises(BackendException, match="Failed to close Elasticsearch client"):
         await backend.close()
+
+
+@pytest.mark.anyio
+async def test_backends_data_es_data_backend_close_method(async_es_backend, caplog):
+    """Test the `AsyncESDataBackend.close` method."""
+
+    # No client instantiated
+    backend = async_es_backend()
+    await backend.close()
+    backend._client = None  # pylint: disable=protected-access
+    with caplog.at_level(logging.WARNING):
+        await backend.close()
+
+    assert (
+        "ralph.backends.data.async_es",
+        logging.WARNING,
+        "No backend client to close.",
+    ) in caplog.record_tuples

--- a/tests/backends/data/test_async_mongo.py
+++ b/tests/backends/data/test_async_mongo.py
@@ -1056,7 +1056,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_custom_c
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_close(
+async def test_backends_data_async_mongo_data_backend_close_method_with_failure(
     async_mongo_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoDataBackend.close` method, given a failed close,
@@ -1084,3 +1084,14 @@ async def test_backends_data_async_mongo_data_backend_close(
         logging.ERROR,
         "Failed to close AsyncIOMotorClient: Close failure",
     ) in caplog.record_tuples
+
+
+@pytest.mark.anyio
+async def test_backends_data_async_mongo_data_backend_close_method(async_mongo_backend):
+    """Test the `AsyncMongoDataBackend.close` method."""
+
+    backend = async_mongo_backend()
+
+    # Not possible to connect to client after closing it
+    await backend.close()
+    assert await backend.status() == DataBackendStatus.AWAY

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -39,6 +39,9 @@ def test_backends_data_base_enforce_query_checks_with_valid_input(value, expecte
         def write(self):  # pylint: disable=arguments-differ,missing-function-docstring
             pass
 
+        def close(self):  # pylint: disable=arguments-differ,missing-function-docstring
+            pass
+
     MockBaseDataBackend().read(query=value)
 
 
@@ -78,6 +81,9 @@ def test_backends_data_base_enforce_query_checks_with_invalid_input(
             pass
 
         def write(self):  # pylint: disable=arguments-differ,missing-function-docstring
+            pass
+
+        def close(self):  # pylint: disable=arguments-differ,missing-function-docstring
             pass
 
     with pytest.raises(BackendParameterException, match=error):

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -108,6 +108,8 @@ def test_backends_data_es_data_backend_instantiation_with_settings():
     except Exception as err:  # pylint:disable=broad-except
         pytest.fail(f"Two ESDataBackends should not raise exceptions: {err}")
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_status_method(monkeypatch, es_backend, caplog):
     """Test the `ESDataBackend.status` method."""
@@ -157,6 +159,8 @@ def test_backends_data_es_data_backend_status_method(monkeypatch, es_backend, ca
         "Exception(Mocked connection error)",
     ) in caplog.record_tuples
 
+    backend.close()
+
 
 @pytest.mark.parametrize(
     "exception, error",
@@ -189,6 +193,8 @@ def test_backends_data_es_data_backend_list_method_with_failure(
         f"Failed to read indices: {error}",
     ) in caplog.record_tuples
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_list_method_without_history(
     es_backend, monkeypatch
@@ -207,6 +213,8 @@ def test_backends_data_es_data_backend_list_method_without_history(
     result = backend.list("target_index*")
     assert isinstance(result, Iterable)
     assert list(result) == list(indices.keys())
+
+    backend.close()
 
 
 def test_backends_data_es_data_backend_list_method_with_details(
@@ -229,6 +237,8 @@ def test_backends_data_es_data_backend_list_method_with_details(
         {"index_2": {"info_2": "baz"}},
     ]
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_list_method_with_history(
     es_backend, caplog, monkeypatch
@@ -246,6 +256,8 @@ def test_backends_data_es_data_backend_list_method_with_history(
         logging.WARNING,
         "The `new` argument is ignored",
     ) in caplog.record_tuples
+
+    backend.close()
 
 
 @pytest.mark.parametrize(
@@ -300,6 +312,8 @@ def test_backends_data_es_data_backend_read_method_with_failure(
         "Failed to open Elasticsearch point in time: %s" % error.replace("\\", ""),
     ) in caplog.record_tuples
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_read_method_with_ignore_errors(
     es, es_backend, monkeypatch, caplog
@@ -319,6 +333,8 @@ def test_backends_data_es_data_backend_read_method_with_ignore_errors(
         "The `ignore_errors` argument is ignored",
     ) in caplog.record_tuples
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_read_method_with_raw_ouput(es, es_backend):
     """Test the `ESDataBackend.read` method with `raw_output` set to `True`."""
@@ -331,6 +347,8 @@ def test_backends_data_es_data_backend_read_method_with_raw_ouput(es, es_backend
         assert isinstance(hit, bytes)
         assert json.loads(hit).get("_source") == documents[i]
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_read_method_without_raw_ouput(es, es_backend):
     """Test the `ESDataBackend.read` method with `raw_output` set to `False`."""
@@ -342,6 +360,8 @@ def test_backends_data_es_data_backend_read_method_without_raw_ouput(es, es_back
     for i, hit in enumerate(hits):
         assert isinstance(hit, dict)
         assert hit.get("_source") == documents[i]
+
+    backend.close()
 
 
 def test_backends_data_es_data_backend_read_method_with_query(es, es_backend, caplog):
@@ -402,6 +422,8 @@ def test_backends_data_es_data_backend_read_method_with_query(es, es_backend, ca
         "'type': 'value_error.extra'}]",
     ) in caplog.record_tuples
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_write_method_with_create_operation(
     es, es_backend, caplog
@@ -449,6 +471,8 @@ def test_backends_data_es_data_backend_write_method_with_create_operation(
     hits = list(backend.read())
     assert [hit["_source"] for hit in hits] == [{"value": str(idx)} for idx in range(9)]
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_write_method_with_delete_operation(
     es,
@@ -473,6 +497,8 @@ def test_backends_data_es_data_backend_write_method_with_delete_operation(
     hits = list(backend.read())
     assert len(hits) == 7
     assert sorted([hit["_source"]["id"] for hit in hits]) == list(range(3, 10))
+
+    backend.close()
 
 
 def test_backends_data_es_data_backend_write_method_with_update_operation(
@@ -518,6 +544,8 @@ def test_backends_data_es_data_backend_write_method_with_update_operation(
         map(lambda x: str(x + 10), range(10))
     )
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_write_method_with_append_operation(
     es_backend, caplog
@@ -536,6 +564,8 @@ def test_backends_data_es_data_backend_write_method_with_append_operation(
         logging.ERROR,
         "Append operation_type is not supported.",
     ) in caplog.record_tuples
+
+    backend.close()
 
 
 def test_backends_data_es_data_backend_write_method_with_target(es, es_backend):
@@ -569,6 +599,8 @@ def test_backends_data_es_data_backend_write_method_with_target(es, es_backend):
             {"value": "1"},
             {"value": "2"},
         ]
+
+    backend.close()
 
 
 def test_backends_data_es_data_backend_write_method_without_ignore_errors(
@@ -639,6 +671,8 @@ def test_backends_data_es_data_backend_write_method_without_ignore_errors(
     hits = list(backend.read())
     assert len(hits) == 5
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_write_method_with_ignore_errors(es, es_backend):
     """Test the `ESDataBackend.write` method with `ignore_errors` set to `True`, given
@@ -676,6 +710,8 @@ def test_backends_data_es_data_backend_write_method_with_ignore_errors(es, es_ba
     assert len(hits) == 11
     assert [hit["_source"] for hit in hits[9:]] == [{"foo": "bar"}, {"foo": "baz"}]
 
+    backend.close()
+
 
 def test_backends_data_es_data_backend_write_method_with_datastream(
     es_data_stream, es_backend
@@ -693,3 +729,45 @@ def test_backends_data_es_data_backend_write_method_with_datastream(
     hits = list(backend.read())
     assert len(hits) == 10
     assert sorted([hit["_source"]["id"] for hit in hits]) == list(range(10))
+
+    backend.close()
+
+
+def test_backends_data_es_data_backend_close_method_with_failure(
+    es_backend, monkeypatch
+):
+    """Test the `ESDataBackend.close` method."""
+
+    backend = es_backend()
+
+    def mock_connection_error():
+        """ES client close mock that raises a connection error."""
+        raise ESConnectionError("", (Exception("Mocked connection error"),))
+
+    monkeypatch.setattr(backend.client, "close", mock_connection_error)
+
+    with pytest.raises(BackendException, match="Failed to close Elasticsearch client"):
+        backend.close()
+
+
+def test_backends_data_es_data_backend_close_method(es_backend, caplog):
+    """Test the `ESDataBackend.close` method."""
+
+    backend = es_backend()
+    backend.status()
+
+    # Not possible to connect to client after closing it
+    backend.close()
+    assert backend.status() == DataBackendStatus.AWAY
+
+    # No client instantiated
+    backend = es_backend()
+    backend._client = None  # pylint: disable=protected-access
+    with caplog.at_level(logging.WARNING):
+        backend.close()
+
+    assert (
+        "ralph.backends.data.es",
+        logging.WARNING,
+        "No backend client to close.",
+    ) in caplog.record_tuples

--- a/tests/backends/data/test_fs.py
+++ b/tests/backends/data/test_fs.py
@@ -1,4 +1,4 @@
-"""Tests for Ralph fs data backend"""
+"""Tests for Ralph fs data backend"""  # pylint: disable = too-many-lines
 import json
 import logging
 import os
@@ -996,3 +996,13 @@ def test_backends_data_fs_data_backend_write_method_without_target(
             "timestamp": frozen_now,
         },
     ]
+
+
+def test_backends_data_fs_data_backend_close_method(fs_backend):
+    """Test that the `FSDataBackend.close` method raise an error."""
+
+    backend = fs_backend()
+
+    error = "FS data backend does not support `close` method"
+    with pytest.raises(NotImplementedError, match=error):
+        backend.close()

--- a/tests/backends/data/test_ldp.py
+++ b/tests/backends/data/test_ldp.py
@@ -698,3 +698,13 @@ def test_backends_data_ldp_data_backend_url_method(monkeypatch, ldp_backend):
     backend = ldp_backend()
     monkeypatch.setattr(backend.client, "post", mock_post)
     assert backend._url(archive_name) == archive_url
+
+
+def test_backends_data_ldp_data_backend_close_method(ldp_backend):
+    """Test that the `LDPDataBackend.close` method raise an error."""
+
+    backend = ldp_backend()
+
+    error = "LDP data backend does not support `close` method"
+    with pytest.raises(NotImplementedError, match=error):
+        backend.close()

--- a/tests/backends/data/test_mongo.py
+++ b/tests/backends/data/test_mongo.py
@@ -51,6 +51,7 @@ def test_backends_data_mongo_data_backend_default_instantiation(monkeypatch, fs)
     assert backend.settings.CLIENT_OPTIONS == MongoClientOptions()
     assert backend.settings.DEFAULT_CHUNK_SIZE == 500
     assert backend.settings.LOCALE_ENCODING == "utf8"
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_instantiation_with_settings():
@@ -75,6 +76,7 @@ def test_backends_data_mongo_data_backend_instantiation_with_settings():
         MongoDataBackend(settings)
     except Exception as err:  # pylint:disable=broad-except
         pytest.fail(f"Two MongoDataBackends should not raise exceptions: {err}")
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_status_with_connection_failure(
@@ -163,6 +165,7 @@ def test_backends_data_mongo_data_backend_status_with_ok_status(mongo_backend):
     """
     backend = mongo_backend()
     assert backend.status() == DataBackendStatus.OK
+    backend.close()
 
 
 @pytest.mark.parametrize("invalid_character", [" ", ".", "/", '"'])
@@ -182,6 +185,7 @@ def test_backends_data_mongo_data_backend_list_method_with_invalid_target(
             list(backend.list(f"foo{invalid_character}bar"))
 
     assert ("ralph.backends.data.mongo", logging.ERROR, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_list_method_with_failure(
@@ -203,6 +207,7 @@ def test_backends_data_mongo_data_backend_list_method_with_failure(
             list(backend.list())
 
     assert ("ralph.backends.data.mongo", logging.ERROR, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_list_method_without_history(
@@ -221,6 +226,7 @@ def test_backends_data_mongo_data_backend_list_method_without_history(
         sorted([MONGO_TEST_COLLECTION, "bar", "baz"])
     )
     assert not list(backend.list("non_existent_database"))
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_list_method_with_history(
@@ -238,6 +244,7 @@ def test_backends_data_mongo_data_backend_list_method_with_history(
         logging.WARNING,
         "The `new` argument is ignored",
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_read_method_with_raw_output(
@@ -262,6 +269,7 @@ def test_backends_data_mongo_data_backend_read_method_with_raw_output(
     assert list(backend.read(raw_output=True, target="foobar")) == expected[:2]
     assert list(backend.read(raw_output=True, chunk_size=2)) == expected
     assert list(backend.read(raw_output=True, chunk_size=1000)) == expected
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_read_method_without_raw_output(
@@ -286,6 +294,7 @@ def test_backends_data_mongo_data_backend_read_method_without_raw_output(
     assert list(backend.read(target="foobar")) == expected[:2]
     assert list(backend.read(chunk_size=2)) == expected
     assert list(backend.read(chunk_size=1000)) == expected
+    backend.close()
 
 
 @pytest.mark.parametrize(
@@ -313,6 +322,7 @@ def test_backends_data_mongo_data_backend_read_method_with_invalid_target(
             list(backend.read(target=invalid_target))
 
     assert ("ralph.backends.data.mongo", logging.ERROR, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_read_method_with_failure(
@@ -336,6 +346,7 @@ def test_backends_data_mongo_data_backend_read_method_with_failure(
             list(backend.read())
 
     assert ("ralph.backends.data.mongo", logging.ERROR, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_read_method_with_ignore_errors(
@@ -370,6 +381,7 @@ def test_backends_data_mongo_data_backend_read_method_with_ignore_errors(
         "Failed to convert document to bytes: "
         "Object of type ObjectId is not JSON serializable",
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_read_method_without_ignore_errors(
@@ -414,6 +426,7 @@ def test_backends_data_mongo_data_backend_read_method_without_ignore_errors(
 
     error_log = ("ralph.backends.data.mongo", logging.ERROR, msg)
     assert len(list(filter(lambda x: x == error_log, caplog.record_tuples))) == 4
+    backend.close()
 
 
 @pytest.mark.parametrize(
@@ -454,6 +467,7 @@ def test_backends_data_mongo_data_backend_read_method_with_query(
     assert list(backend.read(query=query)) == expected
     assert list(backend.read(query=query, chunk_size=1)) == expected
     assert list(backend.read(query=query, chunk_size=1000)) == expected
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_target(
@@ -480,6 +494,7 @@ def test_backends_data_mongo_data_backend_write_method_with_target(
         "_id": "62b9ce92fcde2b2edba56bf4",
         "_source": {"id": "bar", **timestamp},
     }
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_without_target(
@@ -502,6 +517,7 @@ def test_backends_data_mongo_data_backend_write_method_without_target(
         "_id": "62b9ce92fcde2b2edba56bf4",
         "_source": {"id": "bar", **timestamp},
     }
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_duplicated_key_error(
@@ -555,6 +571,7 @@ def test_backends_data_mongo_data_backend_write_method_with_duplicated_key_error
         logging.ERROR,
         exception_info.value.args[0],
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_delete_operation(
@@ -582,6 +599,7 @@ def test_backends_data_mongo_data_backend_write_method_with_delete_operation(
     binary_documents = [json.dumps(documents[2]).encode("utf8")]
     assert backend.write(binary_documents, operation_type=BaseOperationType.DELETE) == 1
     assert not list(backend.read())
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_delete_operation_failure(
@@ -615,6 +633,7 @@ def test_backends_data_mongo_data_backend_write_method_with_delete_operation_fai
         )
 
     assert ("ralph.backends.data.mongo", logging.WARNING, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_update_operation(
@@ -651,6 +670,7 @@ def test_backends_data_mongo_data_backend_write_method_with_update_operation(
         "_id": "62b9ce922c26b46b68ffc68f",
         "_source": {"id": "foo", "new_field": "bar"},
     }
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_update_operation_failure(
@@ -708,6 +728,7 @@ def test_backends_data_mongo_data_backend_write_method_with_update_operation_fai
         logging.ERROR,
         exception_info.value.args[0],
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_append_operation(
@@ -723,6 +744,7 @@ def test_backends_data_mongo_data_backend_write_method_with_append_operation(
             backend.write(data=[], operation_type=BaseOperationType.APPEND)
 
     assert ("ralph.backends.data.mongo", logging.ERROR, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_create_operation(
@@ -741,6 +763,7 @@ def test_backends_data_mongo_data_backend_write_method_with_create_operation(
     results = backend.read()
     assert next(results)["_source"]["timestamp"] == documents[0]["timestamp"]
     assert next(results)["_source"]["timestamp"] == documents[1]["timestamp"]
+    backend.close()
 
 
 @pytest.mark.parametrize(
@@ -777,6 +800,7 @@ def test_backends_data_mongo_data_backend_write_method_with_invalid_documents(
         assert backend.write([document], ignore_errors=True) == 0
 
     assert ("ralph.backends.data.mongo", logging.WARNING, error) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_unparsable_documents(
@@ -801,6 +825,7 @@ def test_backends_data_mongo_data_backend_write_method_with_unparsable_documents
         assert backend.write([b"not valid JSON!"], ignore_errors=True) == 0
 
     assert ("ralph.backends.data.mongo", logging.WARNING, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_no_data(
@@ -813,6 +838,7 @@ def test_backends_data_mongo_data_backend_write_method_with_no_data(
 
     msg = "Data Iterator is empty; skipping write to target."
     assert ("ralph.backends.data.mongo", logging.INFO, msg) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_data_mongo_data_backend_write_method_with_custom_chunk_size(
@@ -870,3 +896,32 @@ def test_backends_data_mongo_data_backend_write_method_with_custom_chunk_size(
         {"_id": "62b9ce92fcde2b2edba56bf4", "_source": {"id": "bar", **new_timestamp}},
         {"_id": "62b9ce92baa5a0964d3320fb", "_source": {"id": "baz", **new_timestamp}},
     ]
+    backend.close()
+
+
+def test_backends_data_mongo_data_backend_close_method_with_failure(
+    mongo_backend, monkeypatch
+):
+    """Test the `MongoDataBackend.close` method."""
+
+    backend = mongo_backend()
+
+    def mock_connection_error():
+        """Mongo client close mock that raises a connection error."""
+        raise PyMongoError("", (Exception("Mocked connection error"),))
+
+    monkeypatch.setattr(backend.client, "close", mock_connection_error)
+
+    with pytest.raises(BackendException, match="Failed to close MongoDB client"):
+        backend.close()
+
+
+def test_backends_data_mongo_data_backend_close_method(mongo_backend):
+    """Test the `MongoDataBackend.close` method."""
+
+    backend = mongo_backend()
+
+    # Still possible to connect to client after closing it, as it creates
+    # a new connection
+    backend.close()
+    assert backend.status() == DataBackendStatus.AWAY

--- a/tests/backends/lrs/test_clickhouse.py
+++ b/tests/backends/lrs/test_clickhouse.py
@@ -218,6 +218,7 @@ def test_backends_database_clickhouse_query_statements(
     monkeypatch.setattr(backend, "read", mock_read)
 
     backend.query_statements(StatementParameters(**params))
+    backend.close()
 
 
 def test_backends_lrs_clickhouse_lrs_backend_query_statements(
@@ -251,6 +252,7 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements(
         StatementParameters(statementId=test_id, limit=10)
     )
     assert result.statements == statements
+    backend.close()
 
 
 def test_backends_lrs_clickhouse_lrs_backend__find(clickhouse, clickhouse_lrs_backend):
@@ -279,6 +281,7 @@ def test_backends_lrs_clickhouse_lrs_backend__find(clickhouse, clickhouse_lrs_ba
     # Check the expected search query results.
     result = backend.query_statements(StatementParameters())
     assert result.statements == statements
+    backend.close()
 
 
 def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids(
@@ -310,6 +313,7 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids(
     # Check the expected search query results.
     result = list(backend.query_statements_by_ids([test_id]))
     assert result[0]["event"] == statements[0]
+    backend.close()
 
 
 def test_backends_lrs_clickhouse_lrs_backend_query_statements_client_failure(
@@ -338,6 +342,7 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements_client_failure(
         logging.ERROR,
         "Failed to read from ClickHouse",
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids_client_failure(
@@ -366,3 +371,4 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids_client_fail
         logging.ERROR,
         "Failed to read from ClickHouse",
     ) in caplog.record_tuples
+    backend.close()

--- a/tests/backends/lrs/test_es.py
+++ b/tests/backends/lrs/test_es.py
@@ -280,6 +280,8 @@ def test_backends_lrs_es_lrs_backend_query_statements_query(
     assert result.pit_id == "foo_pit_id"
     assert result.search_after == "bar_search_after|baz_search_after"
 
+    backend.close()
+
 
 def test_backends_lrs_es_lrs_backend_query_statements(es, es_lrs_backend):
     """Test the `ESLRSBackend.query_statements` method, given a query,
@@ -296,6 +298,8 @@ def test_backends_lrs_es_lrs_backend_query_statements(es, es_lrs_backend):
     result = backend.query_statements(StatementParameters(limit=10))
     assert result.statements == documents
     assert re.match(r"[0-9]+\|0", result.search_after)
+
+    backend.close()
 
 
 def test_backends_lrs_es_lrs_backend_query_statements_with_search_query_failure(
@@ -324,6 +328,8 @@ def test_backends_lrs_es_lrs_backend_query_statements_with_search_query_failure(
         "Failed to read from Elasticsearch",
     ) in caplog.record_tuples
 
+    backend.close()
+
 
 def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_search_query_failure(
     es, es_lrs_backend, monkeypatch, caplog
@@ -350,6 +356,8 @@ def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_search_query_f
         logging.ERROR,
         "Failed to read from Elasticsearch",
     ) in caplog.record_tuples
+
+    backend.close()
 
 
 def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_multiple_indexes(
@@ -387,3 +395,6 @@ def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_multiple_index
     assert not list(backend_1.query_statements_by_ids(["2"]))
     assert not list(backend_2.query_statements_by_ids(["1"]))
     assert list(backend_2.query_statements_by_ids(["2"])) == [index_2_document]
+
+    backend_1.close()
+    backend_2.close()

--- a/tests/backends/lrs/test_mongo.py
+++ b/tests/backends/lrs/test_mongo.py
@@ -242,6 +242,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_query(
     assert result.statements == [{}]
     assert not result.pit_id
     assert result.search_after == "search_after_id"
+    backend.close()
 
 
 def test_backends_lrs_mongo_lrs_backend_query_statements_with_success(
@@ -285,6 +286,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_with_success(
     assert statement_query_result.statements == [
         {"id": "62b9ce922c26b46b68ffc68f", **timestamp, **meta}
     ]
+    backend.close()
 
 
 def test_backends_lrs_mongo_lrs_backend_query_statements_with_query_failure(
@@ -314,6 +316,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_with_query_failure(
         logging.ERROR,
         "Failed to read from MongoDB",
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_query_failure(
@@ -343,6 +346,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_query_failu
         logging.ERROR,
         "Failed to read from MongoDB",
     ) in caplog.record_tuples
+    backend.close()
 
 
 def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_two_collections(
@@ -368,3 +372,5 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_two_collect
     assert not list(backend_1.query_statements_by_ids(["2"]))
     assert not list(backend_2.query_statements_by_ids(["1"]))
     assert list(backend_2.query_statements_by_ids(["2"])) == [{"id": "2", **timestamp}]
+    backend_1.close()
+    backend_2.close()


### PR DESCRIPTION
## Purpose

Synchronous backends such as Elasticsearch or Mongodb need their connection to
be close when finished.

## Proposal

- [x] Add abstract method close to BaseDataBackend
- [x] Implement close method for ES
- [x] Implement close method for MongoDB
- [x] Implement close method for ClickHouse
- [x] Implement close method for S3
- [x] Implement close method for Swift
- [x] Raise `NotImplementedError` in close method for backends FS and LDP

