### PR TITLE
(api) Enrich incoming statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ have an authority field matching that of the user
 - Backends: `LRSHTTP` methods must not be used in `asyncio` events loop (BC)
 - Add variable to override PVC name in arnold deployment
 - Backends: add `max_statements` option to `AsyncLRSHTTP`
+- API: Incoming statements are enriched with `id`, `timestamp`, `stored`
+  and `authority`
 
 ## [3.9.0] - 2023-07-21
 

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -120,3 +120,25 @@ async def gather_with_limited_concurrency(num_tasks: Union[None, int], *tasks):
     except Exception as exception:
         group.cancel()
         raise exception
+
+
+def statements_are_equivalent(statement_1: dict, statement_2: dict):
+    """Check if statements are equivalent.
+
+    To be equivalent, they must be identical on all fields not modified on input by the
+    LRS and identical on other fields, if these fields are present in both
+    statements. For example, if an "authority" field is present in only one statement,
+    they may still be equivalent.
+    """
+    # Check that unmutable fields have the same values
+    fields = ["actor", "verb", "object", "id", "result", "context", "attachements"]
+
+    # Check that some fields enriched by the LRS are equal when in both statements
+    # The LRS specification excludes the fields below from equivalency. It was
+    # decided to include them anyway as their value is inherent to the statements.
+    other_fields = {"timestamp", "version"}  # "authority" and "stored" remain ignored.
+    fields.extend(other_fields & statement_1.keys() & statement_2.keys())
+
+    if any(statement_1.get(field) != statement_2.get(field) for field in fields):
+        return False
+    return True

--- a/tests/backends/http/test_async_lrs.py
+++ b/tests/backends/http/test_async_lrs.py
@@ -44,11 +44,11 @@ def _gen_statement(id_=None, verb=None, timestamp=None):
     if timestamp is None:
         timestamp = datetime.strftime(
             datetime.fromtimestamp(time.time() - random.random()),
-            "%y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S",
         )
     elif isinstance(timestamp, int):
         timestamp = datetime.strftime(
-            datetime.fromtimestamp((time.time() - timestamp), "%y-%m-%dT%H:%M:%S")
+            datetime.fromtimestamp((time.time() - timestamp), "%Y-%m-%dT%H:%M:%S")
         )
     return {"id": id_, "verb": verb, "timestamp": timestamp}
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,50 @@
+"""Utilities for testing Ralph."""
+import datetime
+import uuid
+
+from ralph.utils import statements_are_equivalent
+
+
+def string_is_date(string: str):
+    """Check if string can be parsed as a date."""
+    try:
+        datetime.datetime.fromisoformat(string)
+        return True
+    except ValueError:
+        return False
+
+
+def string_is_uuid(string: str):
+    """Check if string is a valid uuid."""
+    try:
+        uuid.UUID(string)
+        return True
+    except ValueError:
+        return False
+
+
+def assert_statement_get_responses_are_equivalent(response_1: dict, response_2: dict):
+    """Check that responses to GET /statements are equivalent.
+
+    Check that all statements in response are equivalent, meaning that all
+    fields not modified by the LRS are equal.
+    """
+
+    assert response_1.keys() == response_2.keys()
+
+    def _all_but_statements(response):
+        return {key: val for key, val in response.items() if key != "statements"}
+
+    assert _all_but_statements(response_1) == _all_but_statements(response_2)
+
+    # Assert the statements part of the response is equivalent
+    assert "statements" in response_1.keys()
+    assert "statements" in response_2.keys()
+    assert len(response_1["statements"]) == len(response_2["statements"])
+
+    for statement_1, statement_2 in zip(
+        response_1["statements"], response_2["statements"]
+    ):
+        assert statements_are_equivalent(
+            statement_1, statement_2
+        ), "Statements in get responses are not equivalent, or not in the same order."

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,123 @@
+"""Tests for test helpers."""
+
+from uuid import uuid4
+
+import pytest
+
+from .helpers import (
+    assert_statement_get_responses_are_equivalent,
+    string_is_date,
+    string_is_uuid,
+)
+
+
+def test_helpers_string_is_date():
+    """Test that strings representing dates are properly identified."""
+    string = "2022-06-22T08:31:38+00:00"
+    assert string_is_date(string)
+
+    string = "a2023-06-22T08:31:38+00:00"
+    assert not string_is_date(string)
+
+
+def test_helpers_string_is_uuid():
+    """Test that strings representing uuids are properly identified."""
+    string = str(uuid4())
+    assert string_is_uuid(string)
+
+    string = "not_a_valid_uuid"
+    assert not string_is_uuid(string)
+
+
+@pytest.mark.parametrize(
+    "modified_fields,are_equivalent",
+    [
+        (
+            {
+                "timestamp": None,
+                "version": None,
+                "authority": "authority_2",
+                "stored": "stored_2",
+            },
+            True,
+        ),
+        ({"actor": {"actor_field": "actor_2"}}, False),
+        ({"verb": "verb_2"}, False),
+        ({"object": "object_2"}, False),
+        ({"id": "id_2"}, False),
+        ({"result": "result_2"}, False),
+        ({"context": "context_2"}, False),
+        ({"attachements": "attachements_2"}, False),
+        ({"timestamp": "timestamp_2"}, False),
+        ({"version": "version_2"}, False),
+    ],
+)
+def test_helpers_assert_statement_get_responses_are_equivalent(
+    modified_fields, are_equivalent
+):
+    """Test the equivalency assertion for get responses.
+
+    Equivalency (term NOT in specification) means that two statements have
+    identical values on all fields except `authority`, `stored` and `timestamp`
+    (where the value may or may not be identical).
+    """
+    statement_1 = {
+        "actor": {"actor_field": "actor_1"},
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+        "authority": "authority_1",
+        "stored": "stored_1",
+        "timestamp": "timestamp_1",
+        "version": "version_1",
+    }
+
+    # Statement to compare to
+    statement_2 = statement_1.copy()
+    statement_2.update(modified_fields)
+    statement_2 = {key: value for key, value in statement_2.items() if value}
+
+    get_response_1 = {"statements": [statement_1]}
+    get_response_2 = {"statements": [statement_2]}
+
+    if are_equivalent:
+        assert_statement_get_responses_are_equivalent(get_response_1, get_response_2)
+        assert_statement_get_responses_are_equivalent(get_response_2, get_response_1)
+    else:
+        with pytest.raises(AssertionError, match="are not equivalent"):
+            assert_statement_get_responses_are_equivalent(
+                get_response_1, get_response_2
+            )
+        with pytest.raises(AssertionError, match="are not equivalent"):
+            assert_statement_get_responses_are_equivalent(
+                get_response_2, get_response_1
+            )
+
+
+def test_helpers_assert_statement_get_responses_are_equivalent_length_error():
+    """Test that responses with different numbers of statements return an error."""
+
+    statement = {
+        "actor": {"actor_field": "actor_1"},
+        "verb": "verb_1",
+        "object": "object_1",
+        "id": "id_1",
+        "result": "result_1",
+        "context": "context_1",
+        "attachements": "attachements_1",
+        "authority": "authority_1",
+        "stored": "stored_1",
+        "timestamp": "timestamp_1",
+        "version": "version_1",
+    }
+
+    get_response_1 = {"statements": [statement]}
+    get_response_2 = {"statements": [statement, statement]}
+
+    with pytest.raises(AssertionError):
+        assert_statement_get_responses_are_equivalent(get_response_1, get_response_2)
+    with pytest.raises(AssertionError):
+        assert_statement_get_responses_are_equivalent(get_response_2, get_response_1)


### PR DESCRIPTION
## Purpose

The xAPI specification states that statements SHOULD or MUST be enriched with the following fields: 

- "id" (https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#24-statement-properties)
- "timestamp" (https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#247-timestamp)
- "stored" (https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Data.md#248-stored)
- "authority" (https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#249-authority)

Currently, only the "id" field is being added. This PR aims improve compliance by enriching incoming statments with the fields above. Adding "authority" is also a necessary step to implement permissions.

## Proposal

The main change besides enrichment is testing. Currently, tests check that incoming and retrieved statements are equal. The proposal changes this in an equivalency. Proposed equivalency between statements is defined as:

```
    To be equivalent, they must be identical on all fields not modified on input by the
    LRS and idententical on other fields when these fields are present in both
    statements. For example, if an "authority" field is present in only one statement,
    they may still be equivalent.
```

- [x] write and test an equivalency function
- [x] write enrichment functions for each field and add them to POST and PUT functions
- [x] adapt existing tests to test for equivalency 
- [x] write tests for enrichment


NB: This proposal creates a new `tests/helpers.py` file for utilities common to multiple test files. We may refactor tests to include statement generation in this file (for example).