### PR TITLE
[WIP] Upgrade to Pydantic v2

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -44,9 +44,9 @@ RALPH_APP_DIR=/app/.ralph
 
 # ES database backend
 
-RALPH_BACKENDS__DATABASE__ES__HOSTS=http://elasticsearch:9200
+RALPH_BACKENDS__DATABASE__ES__HOSTS=(http://elasticsearch:9200,)
 RALPH_BACKENDS__DATABASE__ES__INDEX=statements
-RALPH_BACKENDS__DATABASE__ES__TEST_HOSTS=http://elasticsearch:9200
+RALPH_BACKENDS__DATABASE__ES__TEST_HOSTS=(http://elasticsearch:9200,)
 RALPH_BACKENDS__DATABASE__ES__TEST_INDEX=test-index-foo
 RALPH_BACKENDS__DATABASE__ES__TEST_FORWARDING_INDEX=test-index-foo-2
 

--- a/.env.dist
+++ b/.env.dist
@@ -44,9 +44,9 @@ RALPH_APP_DIR=/app/.ralph
 
 # ES database backend
 
-RALPH_BACKENDS__DATABASE__ES__HOSTS=(http://elasticsearch:9200,)
+RALPH_BACKENDS__DATABASE__ES__HOSTS=http://elasticsearch:9200
 RALPH_BACKENDS__DATABASE__ES__INDEX=statements
-RALPH_BACKENDS__DATABASE__ES__TEST_HOSTS=(http://elasticsearch:9200,)
+RALPH_BACKENDS__DATABASE__ES__TEST_HOSTS=http://elasticsearch:9200
 RALPH_BACKENDS__DATABASE__ES__TEST_INDEX=test-index-foo
 RALPH_BACKENDS__DATABASE__ES__TEST_FORWARDING_INDEX=test-index-foo-2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,8 @@ install_requires =
     ; By default, we only consider core dependencies required to use Ralph as a
     ; library (mostly models).
     langcodes>=3.2.0
-    pydantic[dotenv,email]>=1.10.0, <2.0
+    pydantic[email]>=2.1.1, <3.0
+    pydantic-settings>=2.0.2
     rfc3987>=1.3.0
 package_dir =
     =src

--- a/src/ralph/api/auth/oidc.py
+++ b/src/ralph/api/auth/oidc.py
@@ -9,7 +9,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OpenIdConnect
 from jose import ExpiredSignatureError, JWTError, jwt
 from jose.exceptions import JWTClaimsError
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import ConfigDict, AnyUrl, BaseModel
 
 from ralph.api.auth.user import AuthenticatedUser
 from ralph.conf import settings
@@ -43,13 +43,11 @@ class IDToken(BaseModel):
 
     iss: str
     sub: str
-    aud: Optional[str]
+    aud: Optional[str] = None
     exp: int
     iat: int
-    scope: Optional[str]
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = Extra.ignore
+    scope: Optional[str] = None
+    model_config = ConfigDict(extra="ignore")
 
 
 @lru_cache()

--- a/src/ralph/api/models.py
+++ b/src/ralph/api/models.py
@@ -6,7 +6,7 @@ validation.
 from typing import Optional, Union
 from uuid import UUID
 
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import ConfigDict, AnyUrl, BaseModel
 
 from ..models.xapi.base.agents import BaseXapiAgent
 from ..models.xapi.base.groups import BaseXapiGroup
@@ -28,14 +28,7 @@ class BaseModelWithLaxConfig(BaseModel):
     Common base lax model to perform light input validation as
     we receive statements through the API.
     """
-
-    class Config:
-        """Enable extra properties.
-
-        Useful for not having to perform comprehensive validation.
-        """
-
-        extra = Extra.allow
+    model_config = ConfigDict(extra="allow")
 
 
 class LaxObjectField(BaseModelWithLaxConfig):
@@ -64,6 +57,6 @@ class LaxStatement(BaseModelWithLaxConfig):
     """
 
     actor: Union[BaseXapiAgent, BaseXapiGroup]
-    id: Optional[UUID]
+    id: Optional[UUID] = None
     object: LaxObjectField
     verb: LaxVerbField

--- a/src/ralph/backends/database/base.py
+++ b/src/ralph/backends/database/base.py
@@ -9,7 +9,7 @@ from enum import Enum, unique
 from typing import BinaryIO, List, Literal, Optional, TextIO, Union
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from ralph.exceptions import BackendParameterException
 
@@ -18,11 +18,7 @@ logger = logging.getLogger(__name__)
 
 class BaseQuery(BaseModel):
     """Base query model."""
-
-    class Config:
-        """Base query model configuration."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 @dataclass

--- a/src/ralph/backends/database/clickhouse.py
+++ b/src/ralph/backends/database/clickhouse.py
@@ -36,8 +36,8 @@ class ClickHouseInsert(BaseModel):
 class ClickHouseQuery(BaseQuery):
     """ClickHouse query model."""
 
-    where_clause: Optional[str]
-    return_fields: Optional[List[str]]
+    where_clause: Optional[str] = None
+    return_fields: Optional[List[str]] = None
 
 
 class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-attributes

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -40,7 +40,7 @@ class OpType(Enum):
 class ESQuery(BaseQuery):
     """Elasticsearch body query model."""
 
-    query: Optional[dict]
+    query: Optional[dict] = None
 
 
 class ESDatabase(BaseDatabase):

--- a/src/ralph/backends/database/mongo.py
+++ b/src/ralph/backends/database/mongo.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 class MongoQuery(BaseQuery):
     """Mongo query model."""
 
-    filter: Optional[dict]
-    projection: Optional[dict]
+    filter: Optional[dict] = None
+    projection: Optional[dict] = None
 
 
 class MongoDatabase(BaseDatabase):

--- a/src/ralph/backends/http/async_lrs.py
+++ b/src/ralph/backends/http/async_lrs.py
@@ -31,13 +31,13 @@ class StatementResponse(BaseModel):
     """Pydantic model for `get` statements response."""
 
     statements: Union[List[dict], dict]
-    more: Optional[str]
+    more: Optional[str] = None
 
 
 class LRSQuery(BaseQuery):
     """LRS body query model."""
 
-    query: Optional[dict]
+    query: Optional[dict] = None
 
 
 class AsyncLRSHTTP(BaseHTTP):

--- a/src/ralph/backends/http/base.py
+++ b/src/ralph/backends/http/base.py
@@ -58,7 +58,7 @@ class BaseQuery(BaseModel):
     """Base query model."""
     model_config = ConfigDict(extra="forbid")
 
-    query_string: Optional[str]
+    query_string: Optional[str] = None # TODO: validate that this is the behavior we want
 
 
 class BaseHTTP(ABC):

--- a/src/ralph/backends/http/base.py
+++ b/src/ralph/backends/http/base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from enum import Enum, unique
 from typing import Iterator, List, Optional, Union
 
-from pydantic import BaseModel, ValidationError
+from pydantic import ConfigDict, BaseModel, ValidationError
 
 from ralph.exceptions import BackendParameterException
 
@@ -56,11 +56,7 @@ def enforce_query_checks(method):
 
 class BaseQuery(BaseModel):
     """Base query model."""
-
-    class Config:
-        """Base query model configuration."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     query_string: Optional[str]
 

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 try:
-    from typing import Literal
+    from typing import Literal, Optional
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal, Optional
 
 try:
     from click import get_app_dir
@@ -19,26 +19,36 @@ except ImportError:
     from unittest.mock import Mock
 
     get_app_dir = Mock(return_value=".")
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, BaseSettings, Extra, Field
+from pydantic import ConfigDict, AnyHttpUrl, AnyUrl, BaseModel, Field
 
 from .utils import import_string
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 MODEL_PATH_SEPARATOR = "__"
 
 
-class BaseSettingsConfig:
-    """Pydantic model for BaseSettings Configuration."""
+# class BaseSettingsConfig(SettingsConfigDict):
+#     """Pydantic model for BaseSettings Configuration."""
 
-    case_sensitive = True
-    env_nested_delimiter = "__"
-    env_prefix = "RALPH_"
+#     case_sensitive = True
+#     env_nested_delimiter = "__"
+#     env_prefix = "RALPH_"
+
+BASE_SETTINGS_CONFIG = SettingsConfigDict(    
+    case_sensitive = True,
+    env_nested_delimiter = "__",
+    env_prefix = "RALPH_",
+)
 
 
 class CoreSettings(BaseSettings):
-    """Pydantice model for Ralph's core settings."""
+    """Pydantic model for Ralph's core settings."""
 
-    class Config(BaseSettingsConfig):
-        """Pydantic Configuration."""
+    # TODO[pydantic]: The `Config` class inherits from another class, please create the `model_config` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    # class Config(BaseSettingsConfig):
+    #     """Pydantic Configuration."""
+    model_config = BASE_SETTINGS_CONFIG
 
     APP_DIR: Path = get_app_dir("ralph")
     LOCALE_ENCODING: str = getattr(io, "LOCALE_ENCODING", "utf8")
@@ -47,9 +57,9 @@ class CoreSettings(BaseSettings):
 core_settings = CoreSettings()
 
 
-class CommaSeparatedTuple(str):
+class CommaSeparatedTuple():
     """Pydantic field type validating comma separated strings or tuples."""
-
+    
     @classmethod
     def __get_validators__(cls):  # noqa: D105
         def validate(value: Union[str, Tuple[str]]) -> Tuple[str]:
@@ -67,9 +77,9 @@ class CommaSeparatedTuple(str):
 
 class InstantiableSettingsItem(BaseModel):
     """Pydantic model for a settings configuration item that can be instantiated."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        underscore_attrs_are_private = True
+    # TODO[pydantic]: The following keys were removed: `underscore_attrs_are_private`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = SettingsConfigDict(underscore_attrs_are_private=True)
 
     _class_path: str = None
 
@@ -83,9 +93,7 @@ class InstantiableSettingsItem(BaseModel):
 
 class ClientOptions(BaseModel):
     """Pydantic model for additionnal client options."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = Extra.forbid
+    model_config = ConfigDict(extra="forbid")
 
 
 class ClickhouseClientOptions(ClientOptions):
@@ -124,7 +132,8 @@ class MongoClientOptions(ClientOptions):
 
 
 class ESDatabaseBackendSettings(InstantiableSettingsItem):
-    """Pydantic modelf for Elasticsearch database backend configuration settings."""
+    """Pydantic modelf for Elasticsearch database backend configuration settings."""    
+    model_config = SettingsConfigDict(arbitrary_types_allowed=True) # TODO: fix this
 
     _class_path: str = "ralph.backends.database.es.ESDatabase"
 
@@ -158,9 +167,7 @@ class DatabaseBackendSettings(BaseModel):
 
 class HeadersParameters(BaseModel):
     """Pydantic model for headers parameters."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = Extra.allow
+    model_config = ConfigDict(extra="allow")
 
 
 class LRSHeaders(HeadersParameters):
@@ -305,9 +312,7 @@ class ParserSettings(BaseModel):
 
 class XapiForwardingConfigurationSettings(BaseModel):
     """Pydantic model for xAPI forwarding configuration item."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        min_anystr_length = 1
+    model_config = ConfigDict(str_min_length=1)
 
     url: AnyUrl
     is_active: bool
@@ -320,11 +325,16 @@ class XapiForwardingConfigurationSettings(BaseModel):
 class Settings(BaseSettings):
     """Pydantic model for Ralph's global environment & configuration settings."""
 
-    class Config(BaseSettingsConfig):
-        """Pydantic Configuration."""
+    # TODO[pydantic]: The `Config` class inherits from another class, please create the `model_config` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    # class Config(BaseSettingsConfig):
+    #     """Pydantic Configuration."""
 
-        env_file = ".env"
-        env_file_encoding = core_settings.LOCALE_ENCODING
+    #     env_file = ".env"
+    #     env_file_encoding = core_settings.LOCALE_ENCODING
+
+    #model_config = SettingsConfigDict(env_file = ".env", env_file_encoding = core_settings.LOCALE_ENCODING) | BaseSettingsConfig()
+    model_config = BASE_SETTINGS_CONFIG | SettingsConfigDict(env_file = ".env", env_file_encoding = core_settings.LOCALE_ENCODING)
 
     class AuthBackends(Enum):
         """Enum of the authentication backends."""
@@ -334,10 +344,10 @@ class Settings(BaseSettings):
 
     _CORE: CoreSettings = core_settings
     AUTH_FILE: Path = _CORE.APP_DIR / "auth.json"
-    AUTH_CACHE_MAX_SIZE = 100
-    AUTH_CACHE_TTL = 3600
+    AUTH_CACHE_MAX_SIZE : int = 100
+    AUTH_CACHE_TTL : int = 3600
     BACKENDS: BackendSettings = BackendSettings()
-    CONVERTER_EDX_XAPI_UUID_NAMESPACE: str = None
+    CONVERTER_EDX_XAPI_UUID_NAMESPACE: Optional[str] = None
     DEFAULT_BACKEND_CHUNK_SIZE: int = 500
     EXECUTION_ENVIRONMENT: str = "development"
     HISTORY_FILE: Path = _CORE.APP_DIR / "history.json"
@@ -374,15 +384,15 @@ class Settings(BaseSettings):
     }
     PARSERS: ParserSettings = ParserSettings()
     RUNSERVER_AUTH_BACKEND: AuthBackends = AuthBackends.BASIC
-    RUNSERVER_AUTH_OIDC_AUDIENCE: str = None
-    RUNSERVER_AUTH_OIDC_ISSUER_URI: AnyHttpUrl = None
+    RUNSERVER_AUTH_OIDC_AUDIENCE: Optional[str] = None
+    RUNSERVER_AUTH_OIDC_ISSUER_URI: Optional[AnyHttpUrl] = None
     RUNSERVER_BACKEND: Literal["clickhouse", "es", "mongo"] = "es"
     RUNSERVER_HOST: str = "0.0.0.0"  # nosec
     RUNSERVER_MAX_SEARCH_HITS_COUNT: int = 100
     RUNSERVER_POINT_IN_TIME_KEEP_ALIVE: str = "1m"
     RUNSERVER_PORT: int = 8100
     SENTRY_CLI_TRACES_SAMPLE_RATE: float = 1.0
-    SENTRY_DSN: str = None
+    SENTRY_DSN: Optional[str] = None
     SENTRY_IGNORE_HEALTH_CHECKS: bool = False
     SENTRY_LRS_TRACES_SAMPLE_RATE: float = 1.0
     XAPI_FORWARDINGS: List[XapiForwardingConfigurationSettings] = []

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -21,8 +21,7 @@ except ImportError:
     from unittest.mock import Mock
 
     get_app_dir = Mock(return_value=".")
-from pydantic import BaseModel, ConfigDict, AnyHttpUrl, AnyUrl, BaseModel, Field, GetCoreSchemaHandler
-from pydantic_core import CoreSchema, core_schema
+from pydantic import BaseModel, ConfigDict, AnyHttpUrl, AnyUrl, BaseModel, Field, GetCoreSchemaHandler, parse_obj_as
 
 from .utils import import_string
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -100,23 +99,22 @@ from pydantic.functional_validators import AfterValidator
 
 #     raise TypeError("Invalid comma separated list")
 
-# class CommaSeparatedTuple(BaseModel):
+class CommaSeparatedTuple(BaseModel):
+    @model_validator(mode='before')
+    @classmethod
+    def validate(cls, value: Union[str, Tuple[str]]) -> Tuple[str]:
+        """Checks whether the value is a comma separated string or a tuple."""
 
-#     @model_validator(mode='before')
-#     @classmethod
-#     def validate(cls, value: Union[str, Tuple[str]]) -> Tuple[str]:
-#         """Checks whether the value is a comma separated string or a tuple."""
+        if isinstance(value, tuple):
+            return value
 
-#         if isinstance(value, tuple):
-#             return value
+        if isinstance(value, str):
+            return tuple(value.split(","))
 
-#         if isinstance(value, str):
-#             return tuple(value.split(","))
-
-#         raise TypeError("Invalid comma separated list")
+        raise TypeError("Invalid comma separated list")
 
 
-def validate_comma_separated_tuple(value: Union[str, Tuple[str]]) -> Tuple[str]:
+def validate_comma_separated_tuple(value: Union[str, Tuple[str, ...]]) -> Tuple[str]:
     """Checks whether the value is a comma separated string or a tuple."""
 
     if isinstance(value, tuple):
@@ -127,12 +125,7 @@ def validate_comma_separated_tuple(value: Union[str, Tuple[str]]) -> Tuple[str]:
 
     raise TypeError("Invalid comma separated list")
 
-from pydantic import parse_obj_as
 CommaSeparatedTuple = Annotated[Union[str, Tuple[str, ...]], AfterValidator(validate_comma_separated_tuple)]
-print('gyolo')
-aze = parse_obj_as(CommaSeparatedTuple, ("test", "toast"))
-print(type(aze))
-
 
        
 

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -5,12 +5,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, List, Tuple, Union
 
-
-
 try:
-    from typing import Literal, Optional
+    from typing import Annotated, Literal, Optional
 except ImportError:
-    from typing_extensions import Literal, Optional
+    from typing_extensions import Annotated, Literal, Optional
 
 try:
     from click import get_app_dir
@@ -21,10 +19,12 @@ except ImportError:
     from unittest.mock import Mock
 
     get_app_dir = Mock(return_value=".")
-from pydantic import BaseModel, ConfigDict, AnyHttpUrl, AnyUrl, BaseModel, Field, GetCoreSchemaHandler, parse_obj_as
+from pydantic import BaseModel, ConfigDict, AnyHttpUrl, AnyUrl, BaseModel, Field, GetCoreSchemaHandler, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic.functional_validators import AfterValidator
 
 from .utils import import_string
-from pydantic_settings import BaseSettings, SettingsConfigDict
+
 
 MODEL_PATH_SEPARATOR = "__"
 
@@ -57,61 +57,6 @@ class CoreSettings(BaseSettings):
 
 
 core_settings = CoreSettings()
-
-
-# class CommaSeparatedTuple(str):
-#     """Pydantic field type validating comma separated strings or tuples."""
-
-#     @classmethod
-#     def validate(cls, value: Union[str, Tuple[str]]) -> Tuple[str]:
-#         """Checks whether the value is a comma separated string or a tuple."""
-#         if isinstance(value, tuple):
-#             return value
-
-#         if isinstance(value, str):
-#             return tuple(value.split(","))
-
-#         raise TypeError("Invalid comma separated list")
-
-#     @classmethod
-#     def __get_pydantic_core_schema__(
-#         cls, source_type: Any, handler: GetCoreSchemaHandler
-#     ) -> CoreSchema:
-#         return core_schema.no_info_after_validator_function(
-#             cls.validate, handler(tuple)
-#         )
-    
-
-from typing_extensions import Annotated
-
-from pydantic import BaseModel, ValidationError, model_validator
-from pydantic.functional_validators import AfterValidator
-
-
-# def validate(value: Union[str, Tuple[str]]) -> Tuple[str]:
-#     """Checks whether the value is a comma separated string or a tuple."""
-
-#     if isinstance(value, tuple):
-#         return value
-
-#     if isinstance(value, str):
-#         return tuple(value.split(","))
-
-#     raise TypeError("Invalid comma separated list")
-
-class CommaSeparatedTuple(BaseModel):
-    @model_validator(mode='before')
-    @classmethod
-    def validate(cls, value: Union[str, Tuple[str]]) -> Tuple[str]:
-        """Checks whether the value is a comma separated string or a tuple."""
-
-        if isinstance(value, tuple):
-            return value
-
-        if isinstance(value, str):
-            return tuple(value.split(","))
-
-        raise TypeError("Invalid comma separated list")
 
 
 def validate_comma_separated_tuple(value: Union[str, Tuple[str, ...]]) -> Tuple[str]:

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -8,16 +8,14 @@ from typing import Dict, Optional, Union
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Annotated, Literal
 
-from pydantic import AnyHttpUrl, BaseModel, constr
+from pydantic import StringConstraints, ConfigDict, AnyHttpUrl, BaseModel
 
 
 class BaseModelWithConfig(BaseModel):
     """Pydantic model for base configuration shared among all models."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class ContextModuleField(BaseModelWithConfig):
@@ -28,14 +26,14 @@ class ContextModuleField(BaseModelWithConfig):
         display_name (str): Consists of a short description or title of the component.
     """
 
-    usage_key: constr(regex=r"^block-v1:.+\+.+\+.+type@.+@[a-f0-9]{32}$")  # noqa:F722
+    usage_key: Annotated[str, StringConstraints(pattern=r"^block-v1:.+\+.+\+.+type@.+@[a-f0-9]{32}$")]  # noqa:F722
     display_name: str
     original_usage_key: Optional[
-        constr(
-            regex=r"^block-v1:.+\+.+\+.+type@problem\+block@[a-f0-9]{32}$"  # noqa:F722
-        )
-    ]
-    original_usage_version: Optional[str]
+        Annotated[str, StringConstraints(
+            pattern=r"^block-v1:.+\+.+\+.+type@problem\+block@[a-f0-9]{32}$"  # noqa:F722
+        )]
+    ] = None
+    original_usage_version: Optional[str] = None
 
 
 class BaseContextField(BaseModelWithConfig):
@@ -80,12 +78,12 @@ class BaseContextField(BaseModelWithConfig):
                 `request.META['PATH_INFO']`
     """
 
-    course_id: constr(regex=r"^$|^course-v1:.+\+.+\+.+$")  # noqa:F722
-    course_user_tags: Optional[Dict[str, str]]
-    module: Optional[ContextModuleField]
+    course_id: Annotated[str, StringConstraints(pattern=r"^$|^course-v1:.+\+.+\+.+$")]  # noqa:F722
+    course_user_tags: Optional[Dict[str, str]] = None
+    module: Optional[ContextModuleField] = None
     org_id: str
     path: Path
-    user_id: Union[int, Literal[""], None]
+    user_id: Union[int, Literal[""], None] = None
 
 
 class AbstractBaseEventField(BaseModelWithConfig):
@@ -150,7 +148,7 @@ class BaseEdxModel(BaseModelWithConfig):
                 In JSON the value is `null` instead of `None`.
     """
 
-    username: Union[constr(min_length=2, max_length=30), Literal[""]]
+    username: Union[Annotated[str, StringConstraints(min_length=2, max_length=30)], Literal[""]]
     ip: Union[IPv4Address, Literal[""]]
     agent: str
     host: str

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 try:
-    from typing import Literal
+    from typing import Annotated, Literal
 except ImportError:
     from typing_extensions import Annotated, Literal
 

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -5,9 +5,9 @@ from typing import Union
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Annotated, Literal
 
-from pydantic import AnyUrl, constr
+from pydantic import StringConstraints, AnyUrl
 
 from .base import BaseEdxModel
 
@@ -28,4 +28,4 @@ class BaseBrowserModel(BaseEdxModel):
 
     event_source: Literal["browser"]
     page: AnyUrl
-    session: Union[constr(regex=r"^[a-f0-9]{32}$"), Literal[""]]  # noqa: F722
+    session: Union[Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}$")], Literal[""]]  # noqa: F722

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -3,7 +3,7 @@
 from typing import Union
 
 try:
-    from typing import Literal
+    from typing import Annotated, Literal
 except ImportError:
     from typing_extensions import Annotated, Literal
 

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -27,4 +27,4 @@ class EnrollmentEventField(AbstractBaseEventField):
     mode: Union[
         Literal["audit"], Literal["honor"], Literal["professional"], Literal["verified"]
     ]
-    user_id: Union[int, Literal[""], None]
+    user_id: Union[int, Literal[""], None] = None

--- a/src/ralph/models/edx/navigational/fields/events.py
+++ b/src/ralph/models/edx/navigational/fields/events.py
@@ -1,8 +1,9 @@
 """Navigational event field definition."""
 
-from pydantic import constr
+from pydantic import StringConstraints
 
 from ...base import AbstractBaseEventField
+from typing_extensions import Annotated
 
 
 class NavigationalEventField(AbstractBaseEventField):
@@ -20,11 +21,11 @@ class NavigationalEventField(AbstractBaseEventField):
             being navigated away from.
     """
 
-    id: constr(
-        regex=(
+    id: Annotated[str, StringConstraints(
+        pattern=(
             r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type"  # noqa : F722
             r"@sequential\+block@[a-f0-9]{32}$"  # noqa : F722
         )
-    )
+    )]
     new: int
     old: int

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-from pydantic import Json, validator
+from pydantic import field_validator, Json
 
 from ralph.models.selector import selector
 
@@ -74,7 +74,8 @@ class UISeqNext(BaseBrowserModel):
     event_type: Literal["seq_next"]
     name: Literal["seq_next"]
 
-    @validator("event")
+    @field_validator("event")
+    @classmethod
     @classmethod
     def validate_next_jump_event_field(cls, value):
         """Checks that event.new is equal to event.old + 1."""
@@ -104,7 +105,8 @@ class UISeqPrev(BaseBrowserModel):
     event_type: Literal["seq_prev"]
     name: Literal["seq_prev"]
 
-    @validator("event")
+    @field_validator("event")
+    @classmethod
     @classmethod
     def validate_prev_jump_event_field(cls, value):
         """Checks that event.new is equal to event.old - 1."""

--- a/src/ralph/models/edx/open_response_assessment/fields/events.py
+++ b/src/ralph/models/edx/open_response_assessment/fields/events.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 try:
-    from typing import Literal
+    from typing import Annotated, iteral
 except ImportError:
     from typing_extensions import Annotated, Literal
 

--- a/src/ralph/models/edx/open_response_assessment/fields/events.py
+++ b/src/ralph/models/edx/open_response_assessment/fields/events.py
@@ -6,11 +6,11 @@ from typing import Dict, List, Optional, Union
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Annotated, Literal
 
 from uuid import UUID
 
-from pydantic import constr
+from pydantic import StringConstraints
 
 from ralph.models.edx.base import AbstractBaseEventField, BaseModelWithConfig
 
@@ -29,15 +29,15 @@ class ORAGetPeerSubmissionEventField(AbstractBaseEventField):
             available.
     """
 
-    course_id: constr(max_length=255)
-    item_id: constr(
-        regex=(
+    course_id: Annotated[str, StringConstraints(max_length=255)]
+    item_id: Annotated[str, StringConstraints(
+        pattern=(
             r"^block-v1:.+\+.+\+.+type@openassessment"  # noqa : F722
             r"+block@[a-f0-9]{32}$"  # noqa : F722
         )
-    )
+    )]
     requesting_student_id: str
-    submission_returned_uuid: Union[str, None]
+    submission_returned_uuid: Union[str, None] = None
 
 
 class ORAGetSubmissionForStaffGradingEventField(AbstractBaseEventField):
@@ -57,13 +57,13 @@ class ORAGetSubmissionForStaffGradingEventField(AbstractBaseEventField):
             Currently set to `full-grade`.
     """
 
-    item_id: constr(
-        regex=(
+    item_id: Annotated[str, StringConstraints(
+        pattern=(
             r"^block-v1:.+\+.+\+.+type@openassessment"  # noqa : F722
             r"+block@[a-f0-9]{32}$"  # noqa : F722
         )
-    )
-    submission_returned_uuid: Union[str, None]
+    )]
+    submission_returned_uuid: Union[str, None] = None
     requesting_staff_id: str
     type: Literal["full-grade"]
 
@@ -93,7 +93,7 @@ class ORAAssessEventPartsField(BaseModelWithConfig):
 
     option: str
     criterion: ORAAssessEventPartsCriterionField
-    feedback: Optional[str]
+    feedback: Optional[str] = None
 
 
 class ORAAssessEventRubricField(BaseModelWithConfig):
@@ -109,7 +109,7 @@ class ORAAssessEventRubricField(BaseModelWithConfig):
             assess the response.
     """
 
-    content_hash: constr(regex=r"^[a-f0-9]{1,40}$")  # noqa: F722
+    content_hash: Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{1,40}$")]  # noqa: F722
 
 
 class ORAAssessEventField(AbstractBaseEventField):
@@ -138,7 +138,7 @@ class ORAAssessEventField(AbstractBaseEventField):
     parts: List[ORAAssessEventPartsField]
     rubric: ORAAssessEventRubricField
     scored_at: datetime
-    scorer_id: constr(max_length=40)
+    scorer_id: Annotated[str, StringConstraints(max_length=40)]
     score_type: Literal["PE", "SE", "ST"]
     submission_uuid: UUID
 
@@ -187,8 +187,8 @@ class ORACreateSubmissionEventAnswerField(BaseModelWithConfig):
     """
 
     parts: List[Dict[Literal["text"], str]]
-    file_keys: Optional[List[str]]
-    files_descriptions: Optional[List[str]]
+    file_keys: Optional[List[str]] = None
+    files_descriptions: Optional[List[str]] = None
 
 
 class ORACreateSubmissionEventField(AbstractBaseEventField):
@@ -223,7 +223,7 @@ class ORASaveSubmissionEventSavedResponseField(BaseModelWithConfig):
     """
 
     text: str
-    file_upload_key: Optional[str]
+    file_upload_key: Optional[str] = None
 
 
 class ORASaveSubmissionEventField(AbstractBaseEventField):
@@ -270,6 +270,6 @@ class ORAUploadFileEventField(BaseModelWithConfig):
         fileType (str): Consists of the MIME type of the uploaded file.
     """
 
-    fileName: constr(max_length=255)
+    fileName: Annotated[str, StringConstraints(max_length=255)]
     fileSize: int
     fileType: str

--- a/src/ralph/models/edx/peer_instruction/fields/events.py
+++ b/src/ralph/models/edx/peer_instruction/fields/events.py
@@ -1,8 +1,9 @@
 """Peer instruction event field definition."""
 
-from pydantic import constr
+from pydantic import StringConstraints
 
 from ...base import AbstractBaseEventField
+from typing_extensions import Annotated
 
 
 class PeerInstructionEventField(AbstractBaseEventField):
@@ -18,5 +19,5 @@ class PeerInstructionEventField(AbstractBaseEventField):
     """
 
     answer: int
-    rationale: constr(max_length=12500)
+    rationale: Annotated[str, StringConstraints(max_length=12500)]
     truncated: bool

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -6,9 +6,9 @@ from typing import Dict, List, Optional, Union
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Annotated, Literal
 
-from pydantic import constr
+from pydantic import StringConstraints
 
 from ...base import AbstractBaseEventField, BaseModelWithConfig
 
@@ -40,13 +40,13 @@ class CorrectMap(BaseModelWithConfig):
         queuestate (json): see QueueStateField.
     """
 
-    answervariable: Union[Literal[None], None, str]
+    answervariable: Union[Literal[None], None, str] = None
     correctness: Union[Literal["correct"], Literal["incorrect"]]
-    hint: Optional[str]
-    hintmode: Optional[Union[Literal["on_request"], Literal["always"]]]
+    hint: Optional[str] = None
+    hintmode: Optional[Union[Literal["on_request"], Literal["always"]]] = None
     msg: str
-    npoints: Optional[int]
-    queuestate: Optional[QueueState]
+    npoints: Optional[int] = None
+    queuestate: Optional[QueueState] = None
 
 
 class State(BaseModelWithConfig):
@@ -61,10 +61,10 @@ class State(BaseModelWithConfig):
     """
 
     correct_map: Dict[
-        constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
+        Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],  # noqa : F722
         CorrectMap,
     ]
-    done: Optional[bool]
+    done: Optional[bool] = None
     input_state: dict
     seed: int
     student_answers: dict
@@ -134,7 +134,7 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
             `student_answer` response. Consists either of `single` or `compound` value.
     """
 
-    choice_all: Optional[List[str]]
+    choice_all: Optional[List[str]] = None
     correctness: bool
     hint_label: str
     hints: List[dict]
@@ -169,23 +169,23 @@ class ProblemCheckEventField(AbstractBaseEventField):
     """
 
     answers: Dict[
-        constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
+        Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],  # noqa : F722
         Union[List[str], str],
     ]
     attempts: int
     correct_map: Dict[
-        constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
+        Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],  # noqa : F722
         CorrectMap,
     ]
     grade: int
     max_grade: int
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
     state: State
     submission: Dict[
-        constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
+        Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],  # noqa : F722
         SubmissionAnswerField,
     ]
     success: Union[Literal["correct"], Literal["incorrect"]]
@@ -203,14 +203,14 @@ class ProblemCheckFailEventField(AbstractBaseEventField):
     """
 
     answers: Dict[
-        constr(regex=r"^[a-f0-9]{32}_[0-9]_[0-9]$"),  # noqa : F722
+        Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],  # noqa : F722
         Union[List[str], str],
     ]
     failure: Union[Literal["closed"], Literal["unreset"]]
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
     state: State
 
 
@@ -234,10 +234,10 @@ class ProblemRescoreEventField(AbstractBaseEventField):
     new_total: int
     orig_score: int
     orig_total: int
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
     state: State
     success: Union[Literal["correct"], Literal["incorrect"]]
 
@@ -252,10 +252,10 @@ class ProblemRescoreFailEventField(AbstractBaseEventField):
     """
 
     failure: Union[Literal["closed"], Literal["unreset"]]
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
     state: State
 
 
@@ -292,10 +292,10 @@ class ResetProblemEventField(AbstractBaseEventField):
 
     new_state: State
     old_state: State
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
 
 
 class ResetProblemFailEventField(AbstractBaseEventField):
@@ -309,10 +309,10 @@ class ResetProblemFailEventField(AbstractBaseEventField):
 
     failure: Union[Literal["closed"], Literal["not_done"]]
     old_state: State
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
 
 
 class SaveProblemFailEventField(AbstractBaseEventField):
@@ -328,10 +328,10 @@ class SaveProblemFailEventField(AbstractBaseEventField):
 
     answers: Dict[str, Union[int, str, list, dict]]
     failure: Union[Literal["closed"], Literal["done"]]
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
     state: State
 
 
@@ -346,10 +346,10 @@ class SaveProblemSuccessEventField(AbstractBaseEventField):
     """
 
     answers: Dict[str, Union[int, str, list, dict]]
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]
     state: State
 
 
@@ -360,7 +360,7 @@ class ShowAnswerEventField(AbstractBaseEventField):
         problem_id (str): Consists of the ID of the problem being shown.
     """
 
-    problem_id: constr(
-        regex=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
+    problem_id: Annotated[str, StringConstraints(
+        pattern=r"^block-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+"  # noqa : F722
         r"type@problem\+block@[a-f0-9]{32}$"  # noqa : F722
-    )
+    )]

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 try:
-    from typing import Literal
+    from typing import Annotated, Literal
 except ImportError:
     from typing_extensions import Annotated, Literal
 

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -3,11 +3,11 @@
 from typing import Optional, Union
 
 try:
-    from typing import Literal
+    from typing import Annotated, Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Annotated, Literal
 
-from pydantic import Field, constr
+from pydantic import Field, StringConstraints
 
 from ...base import AbstractBaseEventField
 
@@ -23,11 +23,11 @@ class TextbookInteractionBaseEventField(AbstractBaseEventField):
     """
 
     page: int
-    chapter: constr(
-        regex=(
+    chapter: Annotated[str, StringConstraints(
+        pattern=(
             r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa
         )
-    )
+    )]
 
 
 class TextbookPdfThumbnailsToggledEventField(TextbookInteractionBaseEventField):
@@ -73,11 +73,11 @@ class TextbookPdfChapterNavigatedEventField(AbstractBaseEventField):
     """
 
     name: Literal["textbook.pdf.chapter.navigated"]
-    chapter: constr(
-        regex=(
+    chapter: Annotated[str, StringConstraints(
+        pattern=(
             r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa
         )
-    )
+    )]
     chapter_title: str
 
 
@@ -262,11 +262,11 @@ class BookEventField(AbstractBaseEventField):
             clicked or `nextpage` value when the previous page button is clicked.
     """
 
-    chapter: constr(
-        regex=(
+    chapter: Annotated[str, StringConstraints(
+        pattern=(
             r"^\/asset-v1:[^\/+]+(\/|\+)[^\/+]+(\/|\+)[^\/?]+type@asset\+block.+$"  # noqa
         )
-    )
+    )]
     name: Union[
         Literal["textbook.pdf.page.loaded"], Literal["textbook.pdf.page.navigatednext"]
     ]

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -271,7 +271,7 @@ class BookEventField(AbstractBaseEventField):
         Literal["textbook.pdf.page.loaded"], Literal["textbook.pdf.page.navigatednext"]
     ]
     new: int
-    old: Optional[int]
+    old: Optional[int] = None # TODO: validate that this is the behavior we want
     type: Union[Literal["gotopage"], Literal["prevpage"], Literal["nextpage"]] = Field(
         alias="type"
     )

--- a/src/ralph/models/edx/video/fields/events.py
+++ b/src/ralph/models/edx/video/fields/events.py
@@ -6,6 +6,7 @@ except ImportError:
     from typing_extensions import Literal
 
 from ...base import AbstractBaseEventField
+from pydantic import ConfigDict
 
 
 class VideoBaseEventField(AbstractBaseEventField):
@@ -17,9 +18,7 @@ class VideoBaseEventField(AbstractBaseEventField):
         id (str): Consists of the additional videos name if given by the
             course creators, or the system-generated hash code otherwise.
     """
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
     code: str
     id: str

--- a/src/ralph/models/edx/video/statements.py
+++ b/src/ralph/models/edx/video/statements.py
@@ -65,7 +65,7 @@ class UIPlayVideo(BaseBrowserModel):
         PlayVideoEventField,
     ]
     event_type: Literal["play_video"]
-    name: Optional[Literal["play_video", "edx.video.played"]]
+    name: Optional[Literal["play_video", "edx.video.played"]] = None
 
 
 class UIPauseVideo(BaseBrowserModel):
@@ -87,7 +87,7 @@ class UIPauseVideo(BaseBrowserModel):
         PauseVideoEventField,
     ]
     event_type: Literal["pause_video"]
-    name: Optional[Literal["pause_video", "edx.video.paused"]]
+    name: Optional[Literal["pause_video", "edx.video.paused"]] = None
 
 
 class UISeekVideo(BaseBrowserModel):
@@ -110,7 +110,7 @@ class UISeekVideo(BaseBrowserModel):
         SeekVideoEventField,
     ]
     event_type: Literal["seek_video"]
-    name: Optional[Literal["seek_video", "edx.video.position.changed"]]
+    name: Optional[Literal["seek_video", "edx.video.position.changed"]] = None
 
 
 class UIStopVideo(BaseBrowserModel):
@@ -132,7 +132,7 @@ class UIStopVideo(BaseBrowserModel):
         StopVideoEventField,
     ]
     event_type: Literal["stop_video"]
-    name: Optional[Literal["stop_video", "edx.video.stopped"]]
+    name: Optional[Literal["stop_video", "edx.video.stopped"]] = None
 
 
 class UIHideTranscript(BaseBrowserModel):
@@ -199,7 +199,7 @@ class UISpeedChangeVideo(BaseBrowserModel):
         SpeedChangeVideoEventField,
     ]
     event_type: Literal["speed_change_video"]
-    name: Optional[Literal["speed_change_video"]]
+    name: Optional[Literal["speed_change_video"]] = None
 
 
 class UIVideoHideCCMenu(BaseBrowserModel):
@@ -220,7 +220,7 @@ class UIVideoHideCCMenu(BaseBrowserModel):
         VideoBaseEventField,
     ]
     event_type: Literal["video_hide_cc_menu"]
-    name: Optional[Literal["video_hide_cc_menu"]]
+    name: Optional[Literal["video_hide_cc_menu"]] = None
 
 
 class UIVideoShowCCMenu(BaseBrowserModel):
@@ -243,4 +243,4 @@ class UIVideoShowCCMenu(BaseBrowserModel):
         VideoBaseEventField,
     ]
     event_type: Literal["video_show_cc_menu"]
-    name: Optional[Literal["video_show_cc_menu"]]
+    name: Optional[Literal["video_show_cc_menu"]] = None

--- a/src/ralph/models/xapi/base/agents.py
+++ b/src/ralph/models/xapi/base/agents.py
@@ -42,8 +42,8 @@ class BaseXapiAgentCommonProperties(BaseModelWithConfig, ABC):
         name (str): Consists of the full name of the Agent.
     """
 
-    objectType: Optional[Literal["Agent"]]
-    name: Optional[StrictStr]
+    objectType: Optional[Literal["Agent"]] = None
+    name: Optional[StrictStr] = None
 
 
 class BaseXapiAgentWithMbox(BaseXapiAgentCommonProperties, BaseXapiMboxIFI):

--- a/src/ralph/models/xapi/base/attachments.py
+++ b/src/ralph/models/xapi/base/attachments.py
@@ -23,8 +23,8 @@ class BaseXapiAttachment(BaseModelWithConfig):
 
     usageType: IRI
     display: LanguageMap
-    description: Optional[LanguageMap]
+    description: Optional[LanguageMap] = None
     contentType: str
     length: int
     sha2: str
-    fileUrl: Optional[AnyUrl]
+    fileUrl: Optional[AnyUrl] = None

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -8,19 +8,8 @@ from pydantic.functional_validators import AfterValidator, BeforeValidator
 from rfc3987 import parse
 
 
-# class IRI(str):
-#     """Pydantic custom data type validating RFC 3987 IRIs."""
-
-#     @classmethod
-#     def __get_validators__(cls):  # noqa: D105
-#         def validate(iri: str):
-#             """Checks whether the provided IRI is a valid RFC 3987 IRI."""
-#             parse(iri, rule="IRI")
-#             return cls(iri)
-
-#         yield validate
-
 def validate_iri(iri):
+    """Checks whether the provided IRI is a valid RFC 3987 IRI."""
     parse(iri, rule="IRI")
     return iri
 
@@ -36,22 +25,6 @@ def validate_language_tag(tag: str):
 LanguageTag = Annotated[str, AfterValidator(validate_language_tag)]
 
 LanguageMap = Dict[LanguageTag, StrictStr]
-
-
-# class MailtoEmail(str):
-#     """Pydantic custom data type validating `mailto:email` format."""
-
-#     @classmethod
-#     def validate(cls, mailto: str):
-#         """Check whether the provided value follows the `mailto:email` format."""
-#         if not mailto.startswith("mailto:"):
-#             raise TypeError("Invalid `mailto:email` value")
-#         valid = validate_email(mailto[7:])
-#         return cls(f"mailto:{valid[1]}")
-
-#     @classmethod
-#     def __get_validators__(cls):  # noqa: D105
-#         yield cls.validate
 
 def validate_mailto_email(mailto: str):
     """Check whether the provided value follows the `mailto:email` format."""

--- a/src/ralph/models/xapi/base/contexts.py
+++ b/src/ralph/models/xapi/base/contexts.py
@@ -25,10 +25,10 @@ class BaseXapiContextContextActivities(BaseModelWithConfig):
             properties.
     """
 
-    parent: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]]
-    grouping: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]]
-    category: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]]
-    other: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]]
+    parent: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
+    grouping: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
+    category: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
+    other: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
 
 
 class BaseXapiContext(BaseModelWithConfig):
@@ -46,12 +46,12 @@ class BaseXapiContext(BaseModelWithConfig):
         extensions (dict): Consists of an dictionary of other properties as needed.
     """
 
-    registration: Optional[UUID]
-    instructor: Optional[BaseXapiAgent]
-    team: Optional[BaseXapiGroup]
-    contextActivities: Optional[BaseXapiContextContextActivities]
-    revision: Optional[StrictStr]
-    platform: Optional[StrictStr]
-    language: Optional[LanguageTag]
-    statement: Optional[BaseXapiStatementRef]
-    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]]
+    registration: Optional[UUID] = None
+    instructor: Optional[BaseXapiAgent] = None
+    team: Optional[BaseXapiGroup] = None
+    contextActivities: Optional[BaseXapiContextContextActivities] = None
+    revision: Optional[StrictStr] = None
+    platform: Optional[StrictStr] = None
+    language: Optional[LanguageTag] = None
+    statement: Optional[BaseXapiStatementRef] = None
+    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]] = None

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -31,7 +31,7 @@ class BaseXapiGroupCommonProperties(BaseModelWithConfig, ABC):
     """
 
     objectType: Literal["Group"]
-    name: Optional[StrictStr]
+    name: Optional[StrictStr] = None
 
 
 class BaseXapiAnonymousGroup(BaseXapiGroupCommonProperties):

--- a/src/ralph/models/xapi/base/ifi.py
+++ b/src/ralph/models/xapi/base/ifi.py
@@ -1,9 +1,10 @@
 """Base xAPI `Inverse Functional Identifier` definitions."""
 
-from pydantic import AnyUrl, StrictStr, constr
+from pydantic import StringConstraints, AnyUrl, StrictStr
 
 from ..config import BaseModelWithConfig
 from .common import IRI, MailtoEmail
+from typing_extensions import Annotated
 
 
 class BaseXapiAccount(BaseModelWithConfig):
@@ -35,7 +36,7 @@ class BaseXapiMboxSha1SumIFI(BaseModelWithConfig):
         mbox_sha1sum (str): Consists of the SHA1 hash of the Agent's email address.
     """
 
-    mbox_sha1sum: constr(regex=r"^[0-9a-f]{40}$")  # noqa:F722
+    mbox_sha1sum: Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{40}$")]  # noqa:F722
 
 
 class BaseXapiOpenIdIFI(BaseModelWithConfig):

--- a/src/ralph/models/xapi/base/objects.py
+++ b/src/ralph/models/xapi/base/objects.py
@@ -35,10 +35,10 @@ class BaseXapiSubStatement(BaseModelWithConfig):
     verb: BaseXapiVerb
     object: BaseXapiUnnestedObject
     objectType: Literal["SubStatement"]
-    result: Optional[BaseXapiResult]
-    context: Optional[BaseXapiContext]
-    timestamp: Optional[datetime]
-    attachments: Optional[List[BaseXapiAttachment]]
+    result: Optional[BaseXapiResult] = None
+    context: Optional[BaseXapiContext] = None
+    timestamp: Optional[datetime] = None
+    attachments: Optional[List[BaseXapiAttachment]] = None
 
 
 BaseXapiObject = Union[

--- a/src/ralph/models/xapi/base/results.py
+++ b/src/ralph/models/xapi/base/results.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import Dict, Optional, Union
 
-from pydantic import Field, StrictBool, StrictStr, root_validator
+from pydantic import Field, StrictBool, StrictStr, model_validator
 
 from ..config import BaseModelWithConfig
 from .common import IRI
@@ -26,7 +26,7 @@ class BaseXapiResultScore(BaseModelWithConfig):
     min: Optional[Decimal] = None
     max: Optional[Decimal] = None
 
-    @root_validator
+    @model_validator(mode='after') # TODO: needs review
     @classmethod
     def check_raw_min_max_relation(cls, values):
         """Checks the relationship `min < raw < max`."""

--- a/src/ralph/models/xapi/base/results.py
+++ b/src/ralph/models/xapi/base/results.py
@@ -4,10 +4,11 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import Dict, Optional, Union
 
-from pydantic import StrictBool, StrictStr, conint, root_validator
+from pydantic import Field, StrictBool, StrictStr, root_validator
 
 from ..config import BaseModelWithConfig
 from .common import IRI
+from typing_extensions import Annotated
 
 
 class BaseXapiResultScore(BaseModelWithConfig):
@@ -20,10 +21,10 @@ class BaseXapiResultScore(BaseModelWithConfig):
         max (Decimal): Consists of highest possible score.
     """
 
-    scaled: Optional[conint(ge=-1, le=1)]
-    raw: Optional[Decimal]
-    min: Optional[Decimal]
-    max: Optional[Decimal]
+    scaled: Optional[Annotated[int, Field(ge=-1, le=1)]] = None
+    raw: Optional[Decimal] = None
+    min: Optional[Decimal] = None
+    max: Optional[Decimal] = None
 
     @root_validator
     @classmethod
@@ -58,9 +59,9 @@ class BaseXapiResult(BaseModelWithConfig):
         extensions (dict): Consists of a dictionary of other properties as needed.
     """
 
-    score: Optional[BaseXapiResultScore]
-    success: Optional[StrictBool]
-    completion: Optional[StrictBool]
-    response: Optional[StrictStr]
-    duration: Optional[timedelta]
-    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]]
+    score: Optional[BaseXapiResultScore] = None
+    success: Optional[StrictBool] = None
+    completion: Optional[StrictBool] = None
+    response: Optional[StrictStr] = None
+    duration: Optional[timedelta] = None
+    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]] = None

--- a/src/ralph/models/xapi/base/statements.py
+++ b/src/ralph/models/xapi/base/statements.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, Optional, Union
 from uuid import UUID
 
-from pydantic import constr, root_validator
+from pydantic import model_validator, StringConstraints
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -14,6 +14,7 @@ from .groups import BaseXapiGroup
 from .objects import BaseXapiObject
 from .results import BaseXapiResult
 from .verbs import BaseXapiVerb
+from typing_extensions import Annotated
 
 
 class BaseXapiStatement(BaseModelWithConfig):
@@ -33,19 +34,20 @@ class BaseXapiStatement(BaseModelWithConfig):
         attachments (list): Consists of a list of attachments.
     """
 
-    id: Optional[UUID]
+    id: Optional[UUID] = None
     actor: Union[BaseXapiAgent, BaseXapiGroup]
     verb: BaseXapiVerb
     object: BaseXapiObject
-    result: Optional[BaseXapiResult]
-    context: Optional[BaseXapiContext]
-    timestamp: Optional[datetime]
-    stored: Optional[datetime]
-    authority: Optional[Union[BaseXapiAgent, BaseXapiGroup]]
-    version: constr(regex=r"^1\.0\.[0-9]+$") = "1.0.0"  # noqa:F722
-    attachments: Optional[List[BaseXapiAttachment]]
+    result: Optional[BaseXapiResult] = None
+    context: Optional[BaseXapiContext] = None
+    timestamp: Optional[datetime] = None
+    stored: Optional[datetime] = None
+    authority: Optional[Union[BaseXapiAgent, BaseXapiGroup]] = None
+    version: Annotated[str, StringConstraints(pattern=r"^1\.0\.[0-9]+$")] = "1.0.0"  # noqa:F722
+    attachments: Optional[List[BaseXapiAttachment]] = None
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     @classmethod
     def check_abscence_of_empty_and_invalid_values(cls, values):
         """Checks the model for empty and invalid values.

--- a/src/ralph/models/xapi/base/unnested_objects.py
+++ b/src/ralph/models/xapi/base/unnested_objects.py
@@ -1,6 +1,6 @@
 """Base xAPI `Object` definitions (1)."""
 
-from typing import Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Union
 
 try:
     from typing import Literal
@@ -9,7 +9,7 @@ except ImportError:
 
 from uuid import UUID
 
-from pydantic import AnyUrl, StrictStr, constr, validator
+from pydantic import AnyUrl, StrictStr, Field, validator
 
 from ..config import BaseModelWithConfig
 from .common import IRI, LanguageMap
@@ -41,7 +41,7 @@ class BaseXapiInteractionComponent(BaseModelWithConfig):
         description (LanguageMap): Consists of the description of the interaction.
     """
 
-    id: constr(regex=r"^[^\s]+$")  # noqa:F722
+    id: Annotated[str, Field(pattern=r"^[^\s]+$")]
     description: Optional[LanguageMap]
 
 

--- a/src/ralph/models/xapi/base/unnested_objects.py
+++ b/src/ralph/models/xapi/base/unnested_objects.py
@@ -26,11 +26,11 @@ class BaseXapiActivityDefinition(BaseModelWithConfig):
         extensions (dict): Consists of a dictionary of other properties as needed.
     """
 
-    name: Optional[LanguageMap]
-    description: Optional[LanguageMap]
-    type: Optional[IRI]
-    moreInfo: Optional[AnyUrl]
-    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]]
+    name: Optional[LanguageMap] = None # TODO: needs validation that this is the behavior we want
+    description: Optional[LanguageMap] = None
+    type: Optional[IRI] = None
+    moreInfo: Optional[AnyUrl] = None
+    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]] = None
 
 
 class BaseXapiInteractionComponent(BaseModelWithConfig):

--- a/src/ralph/models/xapi/base/unnested_objects.py
+++ b/src/ralph/models/xapi/base/unnested_objects.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from uuid import UUID
 
-from pydantic import AnyUrl, StrictStr, Field, validator
+from pydantic import AnyUrl, StrictStr, validator, StringConstraints
 
 from ..config import BaseModelWithConfig
 from .common import IRI, LanguageMap
@@ -41,7 +41,7 @@ class BaseXapiInteractionComponent(BaseModelWithConfig):
         description (LanguageMap): Consists of the description of the interaction.
     """
 
-    id: Annotated[str, Field(pattern=r"^[^\s]+$")]
+    id: Annotated[str, StringConstraints(pattern=r"^[^\s]+$")]
     description: Optional[LanguageMap]
 
 

--- a/src/ralph/models/xapi/base/verbs.py
+++ b/src/ralph/models/xapi/base/verbs.py
@@ -15,4 +15,4 @@ class BaseXapiVerb(BaseModelWithConfig):
     """
 
     id: IRI
-    display: Optional[LanguageMap]
+    display: Optional[LanguageMap] = None

--- a/src/ralph/models/xapi/concepts/activity_types/video.py
+++ b/src/ralph/models/xapi/concepts/activity_types/video.py
@@ -37,5 +37,5 @@ class VideoActivity(BaseXapiActivity):
         definition (dict): See VideoActivityDefinition.
     """
 
-    name: Optional[Dict[Literal[LANG_EN_US_DISPLAY], str]]
+    name: Optional[Dict[Literal[LANG_EN_US_DISPLAY], str]] = None # TODO: validate that this is the behavior we want
     definition: VideoActivityDefinition = VideoActivityDefinition()

--- a/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
@@ -22,4 +22,4 @@ class PostedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/acrossx/verbs/posted"
     ] = "https://w3id.org/xapi/acrossx/verbs/posted"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["posted"]]]  = None # TODO: validate that this is the behavior we want
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["posted"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
@@ -22,4 +22,4 @@ class PostedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/acrossx/verbs/posted"
     ] = "https://w3id.org/xapi/acrossx/verbs/posted"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["posted"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["posted"]]]  = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
@@ -20,7 +20,7 @@ class JoinVerb(BaseXapiVerb):
     """
 
     id: Literal["http://activitystrea.ms/join"] = "http://activitystrea.ms/join"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["joined"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["joined"]]] = None # TODO: validate that this is the behavior we want
 
 
 class LeaveVerb(BaseXapiVerb):
@@ -32,4 +32,4 @@ class LeaveVerb(BaseXapiVerb):
     """
 
     id: Literal["http://activitystrea.ms/leave"] = "http://activitystrea.ms/leave"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["left"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["left"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
@@ -22,7 +22,7 @@ class AskedVerb(BaseXapiVerb):
     id: Literal[
         "http://adlnet.gov/expapi/verbs/asked"
     ] = "http://adlnet.gov/expapi/verbs/asked"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["asked"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["asked"]]] = None # TODO: validate that this is the behavior we want
 
 
 class AnsweredVerb(BaseXapiVerb):
@@ -36,4 +36,4 @@ class AnsweredVerb(BaseXapiVerb):
     id: Literal[
         "http://adlnet.gov/expapi/verbs/answered"
     ] = "http://adlnet.gov/expapi/verbs/answered"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["answered"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["answered"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
@@ -22,7 +22,7 @@ class CompletedVerb(BaseXapiVerb):
     id: Literal[
         "http://adlnet.gov/expapi/verbs/completed"
     ] = "http://adlnet.gov/expapi/verbs/completed"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["completed"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["completed"]]] = None # TODO: validate that this is the behavior we want
 
 
 class InitializedVerb(BaseXapiVerb):
@@ -36,7 +36,7 @@ class InitializedVerb(BaseXapiVerb):
     id: Literal[
         "http://adlnet.gov/expapi/verbs/initialized"
     ] = "http://adlnet.gov/expapi/verbs/initialized"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["initialized"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["initialized"]]] = None # TODO: validate that this is the behavior we want
 
 
 class InteractedVerb(BaseXapiVerb):
@@ -50,7 +50,7 @@ class InteractedVerb(BaseXapiVerb):
     id: Literal[
         "http://adlnet.gov/expapi/verbs/interacted"
     ] = "http://adlnet.gov/expapi/verbs/interacted"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["interacted"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["interacted"]]] = None # TODO: validate that this is the behavior we want
 
 
 class TerminatedVerb(BaseXapiVerb):
@@ -64,4 +64,4 @@ class TerminatedVerb(BaseXapiVerb):
     id: Literal[
         "http://adlnet.gov/expapi/verbs/terminated"
     ] = "http://adlnet.gov/expapi/verbs/terminated"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["terminated"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["terminated"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
@@ -23,7 +23,7 @@ class ViewedVerb(BaseXapiVerb):
     id: Literal[
         "http://id.tincanapi.com/verb/viewed"
     ] = "http://id.tincanapi.com/verb/viewed"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["viewed"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["viewed"]]] = None # TODO: validate that this is the behavior we want
 
 
 class DownloadedVerb(BaseXapiVerb):
@@ -37,4 +37,4 @@ class DownloadedVerb(BaseXapiVerb):
     id: Literal[
         "http://id.tincanapi.com/verb/downloaded"
     ] = "http://id.tincanapi.com/verb/downloaded"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["downloaded"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["downloaded"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/video.py
+++ b/src/ralph/models/xapi/concepts/verbs/video.py
@@ -22,7 +22,7 @@ class PlayedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/video/verbs/played"
     ] = "https://w3id.org/xapi/video/verbs/played"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["played"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["played"]]] = None # TODO: validate that this is the behavior we want
 
 
 class PausedVerb(BaseXapiVerb):
@@ -36,7 +36,7 @@ class PausedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/video/verbs/paused"
     ] = "https://w3id.org/xapi/video/verbs/paused"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["paused"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["paused"]]] = None # TODO: validate that this is the behavior we want
 
 
 class SeekedVerb(BaseXapiVerb):
@@ -50,4 +50,4 @@ class SeekedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/video/verbs/seeked"
     ] = "https://w3id.org/xapi/video/verbs/seeked"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["seeked"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["seeked"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
+++ b/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
@@ -24,7 +24,7 @@ class MutedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/muted"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/muted"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["muted"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["muted"]]] = None # TODO: validate that this is the behavior we want
 
 
 class UnmutedVerb(BaseXapiVerb):
@@ -39,7 +39,7 @@ class UnmutedVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/unmuted"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/unmuted"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unmuted"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unmuted"]]] = None # TODO: validate that this is the behavior we want
 
 
 class StartedCameraVerb(BaseXapiVerb):
@@ -54,7 +54,7 @@ class StartedCameraVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/started-camera"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/started-camera"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["started camera"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["started camera"]]] = None # TODO: validate that this is the behavior we want
 
 
 class StoppedCameraVerb(BaseXapiVerb):
@@ -69,7 +69,7 @@ class StoppedCameraVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/stopped-camera"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/stopped-camera"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["stopped camera"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["stopped camera"]]] = None # TODO: validate that this is the behavior we want
 
 
 class SharedScreenVerb(BaseXapiVerb):
@@ -84,7 +84,7 @@ class SharedScreenVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/shared-screen"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/shared-screen"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["shared screen"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["shared screen"]]] = None # TODO: validate that this is the behavior we want
 
 
 class UnsharedScreenVerb(BaseXapiVerb):
@@ -99,7 +99,7 @@ class UnsharedScreenVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/unshared-screen"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/unshared-screen"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unshared screen"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unshared screen"]]] = None # TODO: validate that this is the behavior we want
 
 
 class RaisedHandVerb(BaseXapiVerb):
@@ -114,7 +114,7 @@ class RaisedHandVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/raised-hand"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/raised-hand"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["raised hand"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["raised hand"]]] = None # TODO: validate that this is the behavior we want
 
 
 class LoweredHandVerb(BaseXapiVerb):
@@ -129,4 +129,4 @@ class LoweredHandVerb(BaseXapiVerb):
     id: Literal[
         "https://w3id.org/xapi/virtual-classroom/verbs/lowered-hand"
     ] = "https://w3id.org/xapi/virtual-classroom/verbs/lowered-hand"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["lowered hand"]]]
+    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["lowered hand"]]] = None # TODO: validate that this is the behavior we want

--- a/src/ralph/models/xapi/config.py
+++ b/src/ralph/models/xapi/config.py
@@ -1,19 +1,13 @@
 """Base xAPI model configuration."""
 
-from pydantic import BaseModel, Extra
+from pydantic import ConfigDict, BaseModel
 
 
 class BaseModelWithConfig(BaseModel):
     """Pydantic model for base configuration shared among all models."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = Extra.forbid
-        min_anystr_length = 1
+    model_config = ConfigDict(extra="forbid", str_min_length=1)
 
 
 class BaseExtensionModelWithConfig(BaseModel):
     """Pydantic model for extension configuration shared among all models."""
-
-    class Config:  # pylint: disable=missing-class-docstring # noqa: D106
-        extra = Extra.allow
-        min_anystr_length = 0
+    model_config = ConfigDict(extra="allow", str_min_length=0)

--- a/src/ralph/models/xapi/video/results.py
+++ b/src/ralph/models/xapi/video/results.py
@@ -131,8 +131,8 @@ class VideoCompletedResult(BaseXapiResult):
     """
 
     extensions: VideoCompletedResultExtensions
-    completion: Optional[Literal[True]]
-    duration: Optional[timedelta]
+    completion: Optional[Literal[True]] = None
+    duration: Optional[timedelta] = None
 
 
 class VideoTerminatedResult(BaseXapiResult):

--- a/src/ralph/models/xapi/video/statements.py
+++ b/src/ralph/models/xapi/video/statements.py
@@ -84,7 +84,7 @@ class VideoPlayed(BaseVideoStatement):
 
     verb: PlayedVerb = PlayedVerb()
     result: VideoPlayedResult
-    context: Optional[VideoPlayedContext]
+    context: Optional[VideoPlayedContext] = None
 
 
 class VideoPaused(BaseVideoStatement):
@@ -127,7 +127,7 @@ class VideoSeeked(BaseVideoStatement):
 
     verb: SeekedVerb = SeekedVerb()
     result: VideoSeekedResult
-    context: Optional[VideoSeekedContext]
+    context: Optional[VideoSeekedContext] = None
 
 
 class VideoCompleted(BaseVideoStatement):

--- a/tests/fixtures/hypothesis_configuration.py
+++ b/tests/fixtures/hypothesis_configuration.py
@@ -11,12 +11,13 @@ from ralph.models.xapi.base.common import IRI, LanguageTag, MailtoEmail
 settings.register_profile("development", max_examples=1)
 settings.load_profile("development")
 
-st.register_type_strategy(str, st.text(min_size=1))
-st.register_type_strategy(StrictStr, st.text(min_size=1))
-st.register_type_strategy(AnyUrl, provisional.urls())
-st.register_type_strategy(AnyHttpUrl, provisional.urls())
-st.register_type_strategy(IRI, provisional.urls())
-st.register_type_strategy(
-    MailtoEmail, st.builds(operator.add, st.just("mailto:"), st.emails())
-)
-st.register_type_strategy(LanguageTag, st.just("en-US"))
+# TODO: uncomment and fix below
+# st.register_type_strategy(str, st.text(min_size=1))
+# st.register_type_strategy(StrictStr, st.text(min_size=1))
+# st.register_type_strategy(AnyUrl, provisional.urls())
+# st.register_type_strategy(AnyHttpUrl, provisional.urls())
+# st.register_type_strategy(IRI, provisional.urls())
+# st.register_type_strategy(
+#     MailtoEmail, st.builds(operator.add, st.just("mailto:"), st.emails())
+# )
+# st.register_type_strategy(LanguageTag, st.just("en-US"))


### PR DESCRIPTION
## Purpose

As mentionned in https://github.com/openfun/ralph/issues/401 , upgrading to pydantic 2 should greatly improve performances. Also it would allow projects depending on `ralph` (such as `warren`) to upgrade more easily. 

## Dealing with common errors when migrating

### ERROR: Extra not permitted

In `conf.py`, errors such as: 
```
    super().__init__(
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
E   LOCALE_ENCODING
E     Extra inputs are not permitted [type=extra_forbidden, input_value='utf-8', input_type=str]
E       For further information visit https://errors.pydantic.dev/2.1/v/extra_forbidden
```

may be due to a change in default behavior in models `extra=ignore` to `extra=failure`. We may set this parameter manually to fix this issue.


### ERROR: Unable to generate pydantic-core schema 
```
E   pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'ralph.models.xapi.base.common.IRI'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to fully support it.
E
E   If you got this error by calling handler(<some type>) within `__get_pydantic_core_schema__` then you likely need to call `handler.generate_schema(<some type>)` since we do not call `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.
E
```
To fix this we change the way we define classes.

**Previously in Ralph**
```
class CommaSeparatedTuple(BaseModel):
    @model_validator(mode='before')
    @classmethod
    def validate(cls, value: Union[str, Tuple[str]]) -> Tuple[str]:
        """Checks whether the value is a comma separated string or a tuple."""

        if isinstance(value, tuple):
            return value

        if isinstance(value, str):
            return tuple(value.split(","))

        raise TypeError("Invalid comma separated list")
```
**New in Ralph** 
```
def validate_comma_separated_tuple(value: Union[str, Tuple[str, ...]]) -> Tuple[str]:
    """Checks whether the value is a comma separated string or a tuple."""

    if isinstance(value, tuple):
        return value

    if isinstance(value, str):
        return tuple(value.split(","))

    raise TypeError("Invalid comma separated list")

CommaSeparatedTuple = Annotated[Union[str, Tuple[str, ...]], AfterValidator(validate_comma_separated_tuple)]
```

### ERROR: Missing values

A recurrent error is the one below, which should be linked to the change of behavior when using `Optional[...]` in Pydantic V2. Previously, it would assign a default value of `None`, which is no longer the case. This should have been dealt with by `bump-pydantic` but was not always the case. It would be nice to know why before confirming this solution.
```
src/ralph/models/xapi/video/statements.py:85: in VideoPlayed
    verb: PlayedVerb = PlayedVerb()
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for PlayedVerb
E   display
E     Field required [type=missing, input_value={}, input_type=dict]
E       For further information visit https://errors.pydantic.dev/2.1/v/missing
```

**Previously in Ralph**
```
class VideoActivity(BaseXapiActivity):
    name: Optional[Dict[Literal[LANG_EN_US_DISPLAY], str]]
```
**New in Ralph** 
```
class VideoActivity(BaseXapiActivity):
    name: Optional[Dict[Literal[LANG_EN_US_DISPLAY], str]] = None
```
