### PR TITLE
🔧(arnold) use var to allow override pvc name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ have an authority field matching that of the user
 - Models: The xAPI `context.contextActivities.category` field is now mandatory
   in the video and virtual classroom profiles. [BC]
 - Backends: `LRSHTTP` methods must not be used in `asyncio` events loop (BC)
+- Add variable to override PVC name in arnold deployment
 
 ## [3.9.0] - 2023-07-21
 

--- a/src/tray/templates/services/app/cronjob_pipeline.yml.j2
+++ b/src/tray/templates/services/app/cronjob_pipeline.yml.j2
@@ -52,7 +52,7 @@ items:
               volumes:
                 - name: ralph-v-history
                   persistentVolumeClaim:
-                    claimName: ralph-pvc-history
+                    claimName: "{{ ralph_pvc_history_name }}"
 {% if ralph_mount_es_ca_secret %}
                 - name: es-ca-certificate
                   secret:

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -95,7 +95,7 @@ spec:
       volumes:
         - name: ralph-v-history
           persistentVolumeClaim:
-            claimName: ralph-pvc-history
+            claimName: "{{ ralph_pvc_history_name }}"
 {% if ralph_mount_es_ca_secret %}
         - name: es-ca-certificate
           secret:

--- a/src/tray/templates/volumes/history.yml.j2
+++ b/src/tray/templates/volumes/history.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: ralph-pvc-history
+  name: "{{ ralph_pvc_history_name }}"
   namespace: "{{ namespace_name }}"
   labels:
     app: ralph

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -43,3 +43,6 @@ ralph_lrs_command:
 ralph_lrs_auth_secret_name: "ralph-lrs-auth-{{ ralph_vault_checksum | default('undefined_ralph_vault_checksum') }}"
 ralph_ingress_class_name: "{{ default_ingress_class_name }}"
 ralph_sentry_ignore_health_checks: false
+
+# -- pvc
+ralph_pvc_history_name: "ralph-pvc-history"


### PR DESCRIPTION
## Purpose

Add the variable ralph_pvc_history_name in tray to allow to override the persistent volume name.

