### PR TITLE
Implement enrollments converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Implement xAPI LMS Profile statements validation
+- `EdX` to `xAPI` converters for enrollment events
 
 ### Changed
 

--- a/src/ralph/models/edx/converters/xapi/__init__.py
+++ b/src/ralph/models/edx/converters/xapi/__init__.py
@@ -2,6 +2,10 @@
 
 # flake8: noqa
 
+from .enrollment import (
+    EdxCourseEnrollmentActivatedToLMSRegisteredCourse,
+    EdxCourseEnrollmentDeactivatedToLMSUnregisteredCourse,
+)
 from .navigational import UIPageCloseToPageTerminated
 from .server import ServerEventToPageViewed
 from .video import (

--- a/src/ralph/models/edx/converters/xapi/enrollment.py
+++ b/src/ralph/models/edx/converters/xapi/enrollment.py
@@ -1,0 +1,46 @@
+"""Enrollment event xAPI Converter."""
+
+from ralph.models.converter import ConversionItem
+from ralph.models.edx.enrollment.statements import (
+    EdxCourseEnrollmentActivated,
+    EdxCourseEnrollmentDeactivated,
+)
+from ralph.models.xapi.lms.statements import LMSRegisteredCourse, LMSUnregisteredCourse
+
+from .base import BaseXapiConverter
+
+
+class LMSBaseXapiConverter(BaseXapiConverter):
+    """Base LMS xAPI Converter."""
+
+    def _get_conversion_items(self):
+        """Return a set of ConversionItems used for conversion."""
+        conversion_items = super()._get_conversion_items()
+        return conversion_items.union(
+            {
+                ConversionItem(
+                    "object__id",
+                    "event__course_id",
+                    lambda course_id: f"{self.platform_url}/courses/{course_id}/info",
+                ),
+                ConversionItem(
+                    "context__contextActivities__category",
+                    None,
+                    lambda _: [{"id": "https://w3id.org/xapi/lms"}],
+                ),
+            },
+        )
+
+
+class EdxCourseEnrollmentActivatedToLMSRegisteredCourse(LMSBaseXapiConverter):
+    """Convert a common edX `edx.course.enrollment.activated` event to xAPI."""
+
+    __src__ = EdxCourseEnrollmentActivated
+    __dest__ = LMSRegisteredCourse
+
+
+class EdxCourseEnrollmentDeactivatedToLMSUnregisteredCourse(LMSBaseXapiConverter):
+    """Convert a common edX `edx.course.enrollment.deactivated` event to xAPI."""
+
+    __src__ = EdxCourseEnrollmentDeactivated
+    __dest__ = LMSUnregisteredCourse

--- a/tests/models/edx/converters/xapi/test_enrollment.py
+++ b/tests/models/edx/converters/xapi/test_enrollment.py
@@ -1,0 +1,118 @@
+"""Tests for the enrollment events xAPI converter."""
+
+import json
+from uuid import UUID, uuid5
+
+import pytest
+from hypothesis import provisional
+
+from ralph.models.converter import convert_dict_event
+from ralph.models.edx.converters.xapi.enrollment import (
+    EdxCourseEnrollmentActivatedToLMSRegisteredCourse,
+    EdxCourseEnrollmentDeactivatedToLMSUnregisteredCourse,
+)
+from ralph.models.edx.enrollment.statements import (
+    EdxCourseEnrollmentActivated,
+    EdxCourseEnrollmentDeactivated,
+)
+
+from tests.fixtures.hypothesis_strategies import custom_given
+
+
+@custom_given(EdxCourseEnrollmentActivated, provisional.urls())
+@pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
+def test_models_edx_converters_xapi_enrollment_edx_course_enrollment_activated_to_lms_registered_course(  # noqa: E501, pylint:disable=line-too-long
+    uuid_namespace, event, platform_url
+):
+    """Test that converting with `EdxCourseEnrollmentActivatedToLMSRegisteredCourse`
+    returns the expected xAPI statement.
+    """
+
+    event.event.course_id = "edX/DemoX/Demo_Course"
+    event.context.org_id = ""
+    event.context.user_id = "1"
+    event_str = event.json()
+    event = json.loads(event_str)
+    xapi_event = convert_dict_event(
+        event,
+        event_str,
+        EdxCourseEnrollmentActivatedToLMSRegisteredCourse(uuid_namespace, platform_url),
+    )
+    xapi_event_dict = json.loads(xapi_event.json(exclude_none=True, by_alias=True))
+
+    assert xapi_event_dict == {
+        "id": str(uuid5(UUID(uuid_namespace), event_str)),
+        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "verb": {"id": "http://adlnet.gov/expapi/verbs/registered"},
+        "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/lms",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
+        },
+        "object": {
+            "id": f"{platform_url}/courses/{event['event']['course_id']}/info",
+            "definition": {
+                "type": "http://adlnet.gov/expapi/activities/course",
+            },
+        },
+        "timestamp": event["time"],
+        "version": "1.0.0",
+    }
+
+
+@custom_given(EdxCourseEnrollmentDeactivated, provisional.urls())
+@pytest.mark.parametrize("uuid_namespace", ["ee241f8b-174f-5bdb-bae9-c09de5fe017f"])
+def test_models_edx_converters_xapi_enrollment_edx_course_enrollment_deactivated_to_lms_unregistered_course(  # noqa: E501, pylint:disable=line-too-long
+    uuid_namespace, event, platform_url
+):
+    """Test that converting with
+    `EdxCourseEnrollmentDeactivatedToLMSUnregisteredCourse` returns the expected xAPI
+    statement.
+    """
+
+    event.event.course_id = "edX/DemoX/Demo_Course"
+    event.context.org_id = ""
+    event.context.user_id = "1"
+    event_str = event.json()
+    event = json.loads(event_str)
+    xapi_event = convert_dict_event(
+        event,
+        event_str,
+        EdxCourseEnrollmentDeactivatedToLMSUnregisteredCourse(
+            uuid_namespace, platform_url
+        ),
+    )
+    xapi_event_dict = json.loads(xapi_event.json(exclude_none=True, by_alias=True))
+
+    assert xapi_event_dict == {
+        "id": str(uuid5(UUID(uuid_namespace), event_str)),
+        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "verb": {"id": "http://id.tincanapi.com/verb/unregistered"},
+        "context": {
+            "contextActivities": {
+                "category": [
+                    {
+                        "id": "https://w3id.org/xapi/lms",
+                        "definition": {
+                            "type": "http://adlnet.gov/expapi/activities/profile"
+                        },
+                    }
+                ],
+            },
+        },
+        "object": {
+            "id": f"{platform_url}/courses/{event['event']['course_id']}/info",
+            "definition": {
+                "type": "http://adlnet.gov/expapi/activities/course",
+            },
+        },
+        "timestamp": event["time"],
+        "version": "1.0.0",
+    }


### PR DESCRIPTION
## Purpose

`LMS` xAPI profile supports statements templates for course registration activities.
Enrollment events from Edx can be converted in xAPI

## Proposal

- [x] Converter models for `edx.course.enrollment.activated` and `edx.course.enrollment.deactivated`
- [x] Tests for converter models
