### PR TITLE
(backend) Add `max_statements` to read in LRSHTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ have an authority field matching that of the user
   in the video and virtual classroom profiles. [BC]
 - Backends: `LRSHTTP` methods must not be used in `asyncio` events loop (BC)
 - Add variable to override PVC name in arnold deployment
+- Backends: add `max_statements` option to `AsyncLRSHTTP`
 
 ## [3.9.0] - 2023-07-21
 

--- a/src/ralph/backends/http/base.py
+++ b/src/ralph/backends/http/base.py
@@ -7,6 +7,7 @@ from enum import Enum, unique
 from typing import Iterator, List, Optional, Union
 
 from pydantic import BaseModel, ValidationError
+from pydantic.types import PositiveInt
 
 from ralph.exceptions import BackendParameterException
 
@@ -114,9 +115,11 @@ class BaseHTTP(ABC):
         self,
         query: Union[str, BaseQuery] = None,
         target: str = None,
-        chunk_size: Union[None, int] = 500,
+        chunk_size: Optional[PositiveInt] = 500,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        greedy: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Iterator[Union[bytes, dict]]:
         """Yield records read from the HTTP response results."""
 
@@ -124,9 +127,11 @@ class BaseHTTP(ABC):
     async def write(  # pylint: disable=too-many-arguments
         self,
         data: Union[List[bytes], List[dict]],
-        target: Union[None, str] = None,
-        chunk_size: Union[None, int] = 500,
+        target: Optional[str] = None,
+        chunk_size: Optional[PositiveInt] = 500,
         ignore_errors: bool = False,
-        operation_type: Union[None, OperationType] = None,
+        operation_type: Optional[OperationType] = None,
+        simultaneous: bool = False,
+        max_num_simultaneous: Optional[int] = None,
     ) -> int:
         """Writes statements into the HTTP server given an input endpoint."""

--- a/tests/backends/http/test_base.py
+++ b/tests/backends/http/test_base.py
@@ -1,8 +1,8 @@
 """Tests for Ralph base HTTP backend."""
 
-from typing import Iterator, List, Union
+from typing import Iterator, Union
 
-from ralph.backends.http.base import BaseHTTP, BaseQuery, OperationType
+from ralph.backends.http.base import BaseHTTP, BaseQuery
 
 
 def test_backends_http_base_abstract_interface_with_implemented_abstract_method():
@@ -21,24 +21,10 @@ def test_backends_http_base_abstract_interface_with_implemented_abstract_method(
         ) -> Iterator[Union[str, dict]]:
             """Fakes the list method."""
 
-        async def read(  # pylint: disable=too-many-arguments
-            self,
-            query: Union[str, BaseQuery] = None,
-            target: str = None,
-            chunk_size: Union[None, int] = None,
-            raw_output: bool = False,
-            ignore_errors: bool = False,
-        ):
+        async def read(self):  # pylint: disable=arguments-differ
             """Fakes the read method."""
 
-        async def write(  # pylint: disable=too-many-arguments
-            self,
-            data: Union[List[bytes], List[dict]],
-            target: Union[None, str] = None,
-            chunk_size: Union[None, int] = 500,
-            ignore_errors: bool = False,
-            operation_type: Union[None, OperationType] = None,
-        ):
+        async def write(self):  # pylint: disable=arguments-differ
             """Fakes the write method."""
 
     GoodStorage()


### PR DESCRIPTION
## Purpose

As suggested in https://github.com/openfun/ralph/issues/418 , it would be nice to introduce a limit to the number of statements that can be returned by `AsyncLRSHTTP.read()`. This PR implements this feature (with option named `max_statements`)

## Proposal

This is implemented by simply adding a break condition when looping on the statements generator. 

- [x] implement `max_statements` for `AsyncLRSHTTP`
- [x] test `max_statements` 

