### PR TITLE
Add LRS statement query parameter Pydantic model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Changed
 
+- Refactor LRS Statements resource query parameters defined for `ralph` API
 - Helm chart: improve chart modularity
 - User credentials must now include an "agent" field which can be created
 using the cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Implement Pydantic model for LRS Statements resource query parameters
 - Implement xAPI LMS Profile statements validation
 - `EdX` to `xAPI` converters for enrollment events
 

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -29,7 +29,7 @@ from ralph.api.models import ErrorDetail, LaxStatement
 from ralph.backends.database.base import (
     AgentParameters,
     BaseDatabase,
-    StatementParameters,
+    RalphStatementsQuery,
 )
 from ralph.conf import settings
 from ralph.exceptions import BackendException, BadFormatException
@@ -109,7 +109,7 @@ def _parse_agent_parameters(agent_obj: dict):
         agent_query_params["account__home_page"] = agent.account.homePage
 
     # Overwrite `agent` field
-    return AgentParameters(**agent_query_params)
+    return AgentParameters.construct(**agent_query_params)
 
 
 def strict_query_params(request: Request):
@@ -335,7 +335,7 @@ async def get(
     # Query Database
     try:
         query_result = DATABASE_CLIENT.query_statements(
-            StatementParameters(**{**query_params, "limit": limit})
+            RalphStatementsQuery.construct(**{**query_params, "limit": limit})
         )
     except BackendException as error:
         raise HTTPException(

--- a/src/ralph/backends/database/clickhouse.py
+++ b/src/ralph/backends/database/clickhouse.py
@@ -1,9 +1,9 @@
 """ClickHouse database backend for Ralph."""
+
 import datetime
 import json
 import logging
 import uuid
-from dataclasses import asdict
 from typing import Generator, List, Optional, TextIO, Union
 
 import clickhouse_connect
@@ -17,7 +17,7 @@ from .base import (
     BaseDatabase,
     BaseQuery,
     DatabaseStatus,
-    StatementParameters,
+    RalphStatementsQuery,
     StatementQueryResult,
     enforce_query_checks,
 )
@@ -324,12 +324,12 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
                 f"event.{target_field}.account.homePage = {{{target_field}__account__home_page:String}}"  # noqa: E501 # pylint: disable=line-too-long
             )
 
-    def query_statements(self, params: StatementParameters) -> StatementQueryResult:
+    def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
         """Returns the results of a statements query using xAPI parameters."""
         # pylint: disable=too-many-branches
         # pylint: disable=invalid-name
 
-        clickhouse_params = asdict(params)
+        clickhouse_params = params.dict(exclude_none=True)
         where_clauses = []
 
         if params.statementId:
@@ -338,7 +338,7 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
         self._add_agent_filters(
             clickhouse_params,
             where_clauses,
-            params.__dict__["agent"],
+            params.agent,
             target_field="actor",
         )
         clickhouse_params.pop("agent")
@@ -346,7 +346,7 @@ class ClickHouseDatabase(BaseDatabase):  # pylint: disable=too-many-instance-att
         self._add_agent_filters(
             clickhouse_params,
             where_clauses,
-            params.__dict__["authority"],
+            params.authority,
             target_field="authority",
         )
         clickhouse_params.pop("authority")

--- a/src/ralph/backends/database/es.py
+++ b/src/ralph/backends/database/es.py
@@ -19,7 +19,7 @@ from .base import (
     BaseDatabase,
     BaseQuery,
     DatabaseStatus,
-    StatementParameters,
+    RalphStatementsQuery,
     StatementQueryResult,
     enforce_query_checks,
 )
@@ -193,7 +193,7 @@ class ESDatabase(BaseDatabase):
                 }
             ]
 
-    def query_statements(self, params: StatementParameters) -> StatementQueryResult:
+    def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
         """Returns the results of a statements query using xAPI parameters."""
         es_query_filters = []
 

--- a/src/ralph/backends/database/mongo.py
+++ b/src/ralph/backends/database/mongo.py
@@ -19,7 +19,7 @@ from .base import (
     BaseDatabase,
     BaseQuery,
     DatabaseStatus,
-    StatementParameters,
+    RalphStatementsQuery,
     StatementQueryResult,
     enforce_query_checks,
 )
@@ -222,7 +222,7 @@ class MongoDatabase(BaseDatabase):
                 }
             )
 
-    def query_statements(self, params: StatementParameters) -> StatementQueryResult:
+    def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
         """Return the results of a statements query using xAPI parameters."""
         # pylint: disable=too-many-branches
         mongo_query_filters = {}

--- a/tests/backends/database/test_clickhouse.py
+++ b/tests/backends/database/test_clickhouse.py
@@ -9,7 +9,7 @@ import pytz
 from clickhouse_connect.driver.exceptions import ClickHouseError
 from clickhouse_connect.driver.httpclient import HttpClient
 
-from ralph.backends.database.base import DatabaseStatus, StatementParameters
+from ralph.backends.database.base import DatabaseStatus, RalphStatementsQuery
 from ralph.backends.database.clickhouse import ClickHouseDatabase, ClickHouseQuery
 from ralph.exceptions import (
     BackendException,
@@ -92,7 +92,7 @@ def test_backends_db_clickhouse_get_method_on_timestamp_boundary(clickhouse):
     backend.bulk_import(documents)
 
     # First get all 3 rows with default settings
-    results = backend.query_statements(StatementParameters())
+    results = backend.query_statements(RalphStatementsQuery.construct())
     result_statements = results.statements
     assert len(result_statements) == 3
     assert result_statements[0] == statements[0]
@@ -100,15 +100,17 @@ def test_backends_db_clickhouse_get_method_on_timestamp_boundary(clickhouse):
     assert result_statements[2] == statements[2]
 
     # Next get them one at a time, starting with the first
-    params = StatementParameters(limit=1)
+    params = RalphStatementsQuery.construct(limit=1)
     results = backend.query_statements(params)
     result_statements = results.statements
     assert len(result_statements) == 1
     assert result_statements[0] == statements[0]
 
     # Next get the second row with an appropriate search after
-    params = StatementParameters(
-        limit=1, search_after=results.search_after, pit_id=results.pit_id
+    params = RalphStatementsQuery.construct(
+        limit=1,
+        search_after=results.search_after,
+        pit_id=results.pit_id,
     )
     results = backend.query_statements(params)
     result_statements = results.statements
@@ -116,8 +118,10 @@ def test_backends_db_clickhouse_get_method_on_timestamp_boundary(clickhouse):
     assert result_statements[0] == statements[1]
 
     # And finally the third
-    params = StatementParameters(
-        limit=1, search_after=results.search_after, pit_id=results.pit_id
+    params = RalphStatementsQuery.construct(
+        limit=1,
+        search_after=results.search_after,
+        pit_id=results.pit_id,
     )
     results = backend.query_statements(params)
     result_statements = results.statements
@@ -481,7 +485,7 @@ def test_backends_db_clickhouse_query_statements_with_search_query_failure(
 
     msg = "'Failed to execute ClickHouse query', 'Something is wrong'"
     with pytest.raises(BackendException, match=msg):
-        backend.query_statements(StatementParameters())
+        backend.query_statements(RalphStatementsQuery.construct())
 
     logger_name = "ralph.backends.database.clickhouse"
     msg = "Failed to execute ClickHouse query. Something is wrong"

--- a/tests/backends/database/test_es.py
+++ b/tests/backends/database/test_es.py
@@ -17,7 +17,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.client import CatClient
 from elasticsearch.helpers import bulk
 
-from ralph.backends.database.base import DatabaseStatus, StatementParameters
+from ralph.backends.database.base import DatabaseStatus, RalphStatementsQuery
 from ralph.backends.database.es import ESDatabase, ESQuery
 from ralph.conf import ESClientOptions, settings
 from ralph.exceptions import BackendException, BackendParameterException
@@ -414,7 +414,7 @@ def test_backends_database_es_query_statements_with_pit_query_failure(
 
     msg = "'Failed to open ElasticSearch point in time', 'ES failure'"
     with pytest.raises(BackendException, match=msg):
-        database.query_statements(StatementParameters())
+        database.query_statements(RalphStatementsQuery.construct())
 
     logger_name = "ralph.backends.database.es"
     msg = "Failed to open ElasticSearch point in time. ES failure"
@@ -440,7 +440,7 @@ def test_backends_database_es_query_statements_with_search_query_failure(
 
     msg = "'Failed to execute ElasticSearch query', 'Something is wrong'"
     with pytest.raises(BackendException, match=msg):
-        database.query_statements(StatementParameters())
+        database.query_statements(RalphStatementsQuery.construct())
 
     logger_name = "ralph.backends.database.es"
     msg = "Failed to execute ElasticSearch query. ApiError(None, 'Something is wrong')"
@@ -466,7 +466,7 @@ def test_backends_database_es_query_statements_by_ids_with_search_query_failure(
 
     msg = "'Failed to execute ElasticSearch query', 'Something is wrong'"
     with pytest.raises(BackendException, match=msg):
-        database.query_statements_by_ids(StatementParameters())
+        database.query_statements_by_ids(RalphStatementsQuery())
 
     logger_name = "ralph.backends.database.es"
     msg = "Failed to execute ElasticSearch query. ApiError(None, 'Something is wrong')"

--- a/tests/backends/database/test_mongo.py
+++ b/tests/backends/database/test_mongo.py
@@ -8,7 +8,7 @@ from bson.objectid import ObjectId
 from pymongo import MongoClient
 from pymongo.errors import PyMongoError
 
-from ralph.backends.database.base import DatabaseStatus, StatementParameters
+from ralph.backends.database.base import DatabaseStatus, RalphStatementsQuery
 from ralph.backends.database.mongo import MongoDatabase, MongoQuery
 from ralph.exceptions import (
     BackendException,
@@ -411,7 +411,7 @@ def test_backends_database_mongo_query_statements_with_search_query_failure(
 
     msg = "'Failed to execute MongoDB query', 'Something is wrong'"
     with pytest.raises(BackendException, match=msg):
-        backend.query_statements(StatementParameters())
+        backend.query_statements(RalphStatementsQuery.construct())
 
     logger_name = "ralph.backends.database.mongo"
     msg = "Failed to execute MongoDB query. Something is wrong"
@@ -440,7 +440,7 @@ def test_backends_database_mongo_query_statements_by_ids_with_search_query_failu
 
     msg = "'Failed to execute MongoDB query', 'Something is wrong'"
     with pytest.raises(BackendException, match=msg):
-        backend.query_statements_by_ids(StatementParameters())
+        backend.query_statements_by_ids(RalphStatementsQuery())
 
     logger_name = "ralph.backends.database.mongo"
     msg = "Failed to execute MongoDB query. Something is wrong"


### PR DESCRIPTION
## Purpose

Until now, LRS statement query parameter used in LRS backend was typed with a dictionary. However, the LRS specification defines a precise set of parameters. 

## Proposal

To query the statements resource with the LRS backend, a Pydantic model validates the input parameter according to the official LRS spec and the query parameters defined for `ralph` LRS API makes use of this model and extra parameters but without validation, as the usage is only for `ralph` and the data is trusted.