### PR TITLE
📝(docs) add useful commands to "contributing" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,39 @@ We try to raise our code quality standards and expect contributors to follow
 the recommendations from our
 [handbook](https://handbook.openfun.fr).
 
+### Useful commands
+
+Bootstrap the project:
+
+```
+$ make bootstrap
+```
+
+Run tests:
+
+```
+$ make test
+```
+
+Run all linters:
+
+```
+$ make lint
+```
+
+If you add new dependencies to the project, you will have to rebuild the Docker
+image (and the development environment):
+
+```
+$ make down && make bootstrap
+```
+
+You can explore all available rules using:
+
+```
+$ make help
+```
+
 ## License
 
 This work is released under the MIT License (see [LICENSE](./LICENSE.md)).


### PR DESCRIPTION
## Purpose

As a new developper on Ralph, it is not obvious what commands are useful and where to find them. This commit (inspired by the [doc of OBC](https://github.com/openfun/open-badges-client#hack-on-the-project)) adds info on testing, linting, and updating dependancies to README in the contributing section.


## Proposal

- [x] update README

