### PR TITLE
(api) Add option to enforce use of scopes (`all/read`, `all/write`, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ have an authority field matching that of the user
 - CLI: list cli usage strings in alphabetical order
 - Helm: Fix clickhouse version
 - Helm: improve volumes and ingress configurations
+- API: Add `RALPH_LRS_RESTRICT_BY_SCOPE` option enabling endpoint access
+  control by user scopes
 
 ### Fixed
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -178,7 +178,7 @@ By default, all authenticated users have full read and write access to the serve
 
 ### Filtering results by authority (multitenancy)
 
-In Ralph, all incoming statements are assigned an `authority` (or ownership) derived from the user that makes the call. You may restrict read access to users "own" statements (thus enabling multitenancy) by setting the following environment variable: 
+In Ralph LRS, all incoming statements are assigned an `authority` (or ownership) derived from the user that makes the call. You may restrict read access to users "own" statements (thus enabling multitenancy) by setting the following environment variable: 
 
 ```
 RALPH_LRS_RESTRICT_BY_AUTHORITY = True # Default: False
@@ -190,7 +190,27 @@ NB: If not using "scopes", or for users with limited "scopes", using this option
 
 #### Scopes
 
-(Work In Progress)
+In Ralph, users are assigned scopes which may be used to restrict endpoint access or 
+functionalities. You may enable this option by setting the following environment variable:
+
+```
+RALPH_LRS_RESTRICT_BY_SCOPES = True # Default: False
+```
+
+Valid scopes are a slight variation on those proposed by the
+[xAPI specification](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#details-15):
+
+
+- statements/write
+- statements/read/mine
+- statements/read
+- state/write
+- state/read
+- define
+- profile/write
+- profile/read
+- all/read
+- all
 
 ## Forwarding statements
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -142,7 +142,7 @@ match = ^(?!(setup)\.(py)$).*\.(py)$
 [isort]
 known_ralph=ralph
 sections=FUTURE,STDLIB,THIRDPARTY,RALPH,FIRSTPARTY,LOCALFOLDER
-skip_glob=venv
+skip_glob=venv,*/.conda/*
 profile=black
 
 [tool:pytest]

--- a/src/ralph/api/auth/__init__.py
+++ b/src/ralph/api/auth/__init__.py
@@ -1,12 +1,11 @@
 """Main module for Ralph's LRS API authentication."""
 
-from ralph.api.auth.basic import get_authenticated_user as get_basic_user
-from ralph.api.auth.oidc import get_authenticated_user as get_oidc_user
+from ralph.api.auth.basic import get_basic_auth_user
+from ralph.api.auth.oidc import get_oidc_user
 from ralph.conf import settings
 
 # At startup, select the authentication mode that will be used
-get_authenticated_user = (
-    get_oidc_user
-    if settings.RUNSERVER_AUTH_BACKEND == settings.AuthBackends.OIDC
-    else get_basic_user
-)
+if settings.RUNSERVER_AUTH_BACKEND == settings.AuthBackends.OIDC:
+    get_authenticated_user = get_oidc_user
+else:
+    get_authenticated_user = get_basic_auth_user

--- a/src/ralph/api/auth/user.py
+++ b/src/ralph/api/auth/user.py
@@ -1,6 +1,7 @@
 """Authenticated user for the Ralph API."""
 
-from typing import Dict, List, Literal
+from functools import lru_cache
+from typing import Dict, FrozenSet, Literal
 
 from pydantic import BaseModel
 
@@ -18,6 +19,50 @@ Scope = Literal[
 ]
 
 
+class UserScopes(FrozenSet[Scope]):
+    """Scopes available to users."""
+
+    @lru_cache(maxsize=1024)
+    def is_authorized(self, requested_scope: Scope):
+        """Check if the requested scope can be accessed based on user scopes."""
+        expanded_scopes = {
+            "statements/read": {"statements/read/mine", "statements/read"},
+            "all/read": {
+                "statements/read/mine",
+                "statements/read",
+                "state/read",
+                "profile/read",
+                "all/read",
+            },
+            "all": {
+                "statements/write",
+                "statements/read/mine",
+                "statements/read",
+                "state/read",
+                "state/write",
+                "define",
+                "profile/read",
+                "profile/write",
+                "all/read",
+                "all",
+            },
+        }
+
+        expanded_user_scopes = set()
+        for scope in self:
+            expanded_user_scopes.update(expanded_scopes.get(scope, {scope}))
+
+        return requested_scope in expanded_user_scopes
+
+    @classmethod
+    def __get_validators__(cls):  # noqa: D105
+        def validate(value: FrozenSet[Scope]):
+            """Transform value to an instance of UserScopes."""
+            return cls(value)
+
+        yield validate
+
+
 class AuthenticatedUser(BaseModel):
     """Pydantic model for user authentication.
 
@@ -27,4 +72,4 @@ class AuthenticatedUser(BaseModel):
     """
 
     agent: Dict
-    scopes: List[Scope]
+    scopes: UserScopes

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -19,7 +19,10 @@ except ImportError:
     from unittest.mock import Mock
 
     get_app_dir = Mock(return_value=".")
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, BaseSettings, Extra
+
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, BaseSettings, Extra, root_validator
+
+from ralph.exceptions import ConfigurationException
 
 from .utils import import_string
 
@@ -209,6 +212,19 @@ class Settings(BaseSettings):
     def LOCALE_ENCODING(self) -> str:  # pylint: disable=invalid-name
         """Returns Ralph's default locale encoding."""
         return self._CORE.LOCALE_ENCODING
+
+    @root_validator(allow_reuse=True)
+    @classmethod
+    def check_restriction_compatibility(cls, values):
+        """Raise an error if scopes are being used without authority restriction."""
+        if values.get("LRS_RESTRICT_BY_SCOPES") and not values.get(
+            "LRS_RESTRICT_BY_AUTHORITY"
+        ):
+            raise ConfigurationException(
+                "LRS_RESTRICT_BY_AUTHORITY must be set to True if using "
+                "LRS_RESTRICT_BY_SCOPES=True"
+            )
+        return values
 
 
 settings = Settings()

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -1,17 +1,23 @@
 """Tests for the PUT statements endpoint of the Ralph API."""
-
+from importlib import reload
 from uuid import uuid4
 
 import pytest
+import responses
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
+from ralph import api
 from ralph.api import app
+from ralph.api.auth import get_authenticated_user
+from ralph.api.auth.basic import get_basic_auth_user
+from ralph.api.auth.oidc import get_oidc_user
 from ralph.backends.lrs.es import ESLRSBackend
 from ralph.backends.lrs.mongo import MongoLRSBackend
 from ralph.conf import XapiForwardingConfigurationSettings
 from ralph.exceptions import BackendException
 
+from tests.fixtures.auth import mock_basic_auth_user, mock_oidc_user
 from tests.fixtures.backends import (
     ES_TEST_FORWARDING_INDEX,
     ES_TEST_HOSTS,
@@ -27,21 +33,23 @@ from tests.fixtures.backends import (
 
 from ..helpers import (
     assert_statement_get_responses_are_equivalent,
+    mock_agent,
     mock_statement,
     string_is_date,
 )
 
+reload(api)
 client = TestClient(app)
 
 
-def test_api_statements_put_invalid_parameters(auth_credentials):
+def test_api_statements_put_invalid_parameters(basic_auth_credentials):
     """Test that using invalid parameters returns the proper status code."""
     statement = mock_statement()
 
     # Check for 400 status code when unknown parameters are provided
     response = client.put(
         "/xAPI/statements/?mamamia=herewegoagain",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
     assert response.status_code == 400
@@ -56,7 +64,7 @@ def test_api_statements_put_invalid_parameters(auth_credentials):
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_single_statement_directly(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     """Test the put statements API route with one statement."""
     # pylint: disable=invalid-name,unused-argument
@@ -66,7 +74,7 @@ def test_api_statements_put_single_statement_directly(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -75,7 +83,8 @@ def test_api_statements_put_single_statement_directly(
     es.indices.refresh()
 
     response = client.get(
-        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
     assert response.status_code == 200
     assert_statement_get_responses_are_equivalent(
@@ -85,7 +94,7 @@ def test_api_statements_put_single_statement_directly(
 
 # pylint: disable=too-many-arguments
 def test_api_statements_put_enriching_without_existing_values(
-    monkeypatch, auth_credentials, es
+    monkeypatch, basic_auth_credentials, es
 ):
     """Test that statements are properly enriched when statement provides no values."""
     # pylint: disable=invalid-name,unused-argument
@@ -97,7 +106,7 @@ def test_api_statements_put_enriching_without_existing_values(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
     assert response.status_code == 204
@@ -105,7 +114,8 @@ def test_api_statements_put_enriching_without_existing_values(
     es.indices.refresh()
 
     response = client.get(
-        "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
 
     statement = response.json()["statements"][0]
@@ -137,7 +147,7 @@ def test_api_statements_put_enriching_without_existing_values(
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_enriching_with_existing_values(
-    field, value, status, monkeypatch, auth_credentials, es
+    field, value, status, monkeypatch, basic_auth_credentials, es
 ):
     """Test that statements are properly enriched when values are provided."""
     # pylint: disable=invalid-name,unused-argument
@@ -152,7 +162,7 @@ def test_api_statements_put_enriching_with_existing_values(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -162,7 +172,8 @@ def test_api_statements_put_enriching_with_existing_values(
     if status == 204:
         es.indices.refresh()
         response = client.get(
-            "/xAPI/statements/", headers={"Authorization": f"Basic {auth_credentials}"}
+            "/xAPI/statements/",
+            headers={"Authorization": f"Basic {basic_auth_credentials}"},
         )
         statement = response.json()["statements"][0]
 
@@ -181,7 +192,7 @@ def test_api_statements_put_enriching_with_existing_values(
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_single_statement_no_trailing_slash(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     """Test that the statements endpoint also works without the trailing slash."""
     # pylint: disable=invalid-name,unused-argument
@@ -191,7 +202,7 @@ def test_api_statements_put_single_statement_no_trailing_slash(
 
     response = client.put(
         f"/xAPI/statements?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -204,7 +215,7 @@ def test_api_statements_put_single_statement_no_trailing_slash(
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_id_mismatch(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     # pylint: disable=invalid-name,unused-argument
     """Test the put statements API route when the statementId doesn't match."""
@@ -214,7 +225,7 @@ def test_api_statements_put_id_mismatch(
     different_statement_id = str(uuid4())
     response = client.put(
         f"/xAPI/statements/?statementId={different_statement_id}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -230,7 +241,7 @@ def test_api_statements_put_id_mismatch(
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_list_of_one(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     # pylint: disable=invalid-name,unused-argument
     """Test that we fail on PUTs with a list, even if it's one statement."""
@@ -239,7 +250,7 @@ def test_api_statements_put_list_of_one(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=[statement],
     )
 
@@ -252,7 +263,7 @@ def test_api_statements_put_list_of_one(
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_duplicate_of_existing_statement(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     """Test the put statements API route, given a statement that already exist in the
     database (has the same ID), should fail.
@@ -265,7 +276,7 @@ def test_api_statements_put_duplicate_of_existing_statement(
     # Put the statement once.
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
     assert response.status_code == 204
@@ -275,7 +286,7 @@ def test_api_statements_put_duplicate_of_existing_statement(
     # Put the statement twice, trying to change the timestamp, which is not allowed
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=dict(statement, **{"timestamp": "2023-03-15T14:07:51Z"}),
     )
 
@@ -286,7 +297,7 @@ def test_api_statements_put_duplicate_of_existing_statement(
 
     response = client.get(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
     assert response.status_code == 200
     assert_statement_get_responses_are_equivalent(
@@ -299,7 +310,7 @@ def test_api_statements_put_duplicate_of_existing_statement(
     [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
 )
 def test_api_statements_put_with_failure_during_storage(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     """Test the put statements API route with a failure happening during storage."""
     # pylint: disable=invalid-name,unused-argument, too-many-arguments
@@ -315,7 +326,7 @@ def test_api_statements_put_with_failure_during_storage(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -328,7 +339,7 @@ def test_api_statements_put_with_failure_during_storage(
     [get_es_test_backend, get_clickhouse_test_backend, get_mongo_test_backend],
 )
 def test_api_statements_put_with_a_failure_during_id_query(
-    backend, monkeypatch, auth_credentials, es, mongo, clickhouse
+    backend, monkeypatch, basic_auth_credentials, es, mongo, clickhouse
 ):
     """Test the put statements API route with a failure during query execution."""
     # pylint: disable=invalid-name,unused-argument,too-many-arguments
@@ -346,7 +357,7 @@ def test_api_statements_put_with_a_failure_during_id_query(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -360,7 +371,7 @@ def test_api_statements_put_with_a_failure_during_id_query(
 )
 # pylint: disable=too-many-arguments
 def test_api_statements_put_without_forwarding(
-    backend, auth_credentials, monkeypatch, es, mongo, clickhouse
+    backend, basic_auth_credentials, monkeypatch, es, mongo, clickhouse
 ):
     """Test the put statements API route, given an empty forwarding configuration,
     should not start the forwarding background task.
@@ -386,7 +397,7 @@ def test_api_statements_put_without_forwarding(
 
     response = client.put(
         f"/xAPI/statements/?statementId={statement['id']}",
-        headers={"Authorization": f"Basic {auth_credentials}"},
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
         json=statement,
     )
 
@@ -418,7 +429,7 @@ async def test_api_statements_put_with_forwarding(
     receiving_backend,
     forwarding_backend,
     monkeypatch,
-    auth_credentials,
+    basic_auth_credentials,
     es,
     es_forwarding,
     mongo,
@@ -495,7 +506,7 @@ async def test_api_statements_put_with_forwarding(
             # The statement should be stored on the forwarding client
             response = await forwarding_client.get(
                 "/xAPI/statements/",
-                headers={"Authorization": f"Basic {auth_credentials}"},
+                headers={"Authorization": f"Basic {basic_auth_credentials}"},
             )
             assert response.status_code == 200
             assert_statement_get_responses_are_equivalent(
@@ -506,7 +517,7 @@ async def test_api_statements_put_with_forwarding(
     async with AsyncClient() as receiving_client:
         response = await receiving_client.get(
             f"http://{RUNSERVER_TEST_HOST}:{RUNSERVER_TEST_PORT}/xAPI/statements/",
-            headers={"Authorization": f"Basic {auth_credentials}"},
+            headers={"Authorization": f"Basic {basic_auth_credentials}"},
         )
         assert response.status_code == 200
         assert_statement_get_responses_are_equivalent(
@@ -515,3 +526,74 @@ async def test_api_statements_put_with_forwarding(
 
     # Stop receiving LRS client
     await lrs_context.__aexit__(None, None, None)
+
+
+@responses.activate
+@pytest.mark.parametrize("auth_method", ["basic", "oidc"])
+@pytest.mark.parametrize(
+    "scopes,is_authorized",
+    [
+        (["all"], True),
+        (["profile/read", "statements/write"], True),
+        (["all/read"], False),
+        (["statements/read/mine"], False),
+        (["profile/write"], False),
+        ([], False),
+    ],
+)
+def test_api_statements_put_scopes(
+    monkeypatch, fs, es, auth_method, scopes, is_authorized
+):
+    """Test that putting statements behaves properly according to user scopes."""
+    # pylint: disable=invalid-name,unused-argument,duplicate-code
+    monkeypatch.setattr(
+        "ralph.api.routers.statements.settings.LRS_RESTRICT_BY_SCOPES", True
+    )
+    monkeypatch.setattr("ralph.api.auth.basic.settings.LRS_RESTRICT_BY_SCOPES", True)
+
+    if auth_method == "basic":
+        agent = mock_agent("mbox", 1)
+        credentials = mock_basic_auth_user(fs, scopes=scopes, agent=agent)
+        headers = {"Authorization": f"Basic {credentials}"}
+
+        app.dependency_overrides[get_authenticated_user] = get_basic_auth_user
+        get_basic_auth_user.cache_clear()
+
+    elif auth_method == "oidc":
+        sub = "123|oidc"
+        agent = {"openid": sub}
+        oidc_token = mock_oidc_user(sub=sub, scopes=scopes)
+        headers = {"Authorization": f"Bearer {oidc_token}"}
+
+        monkeypatch.setattr(
+            "ralph.api.auth.oidc.settings.RUNSERVER_AUTH_OIDC_ISSUER_URI",
+            "http://providerHost:8080/auth/realms/real_name",
+        )
+        monkeypatch.setattr(
+            "ralph.api.auth.oidc.settings.RUNSERVER_AUTH_OIDC_AUDIENCE",
+            "http://clientHost:8100",
+        )
+
+        app.dependency_overrides[get_authenticated_user] = get_oidc_user
+
+    statement = mock_statement()
+
+    # NB: scopes are not linked to statements and backends, we therefore test with ES
+    backend_client_class_path = "ralph.api.routers.statements.BACKEND_CLIENT"
+    monkeypatch.setattr(backend_client_class_path, get_es_test_backend())
+
+    response = client.put(
+        f"/xAPI/statements/?statementId={statement['id']}",
+        headers=headers,
+        json=statement,
+    )
+
+    if is_authorized:
+        assert response.status_code == 204
+    else:
+        assert response.status_code == 401
+        assert response.json() == {
+            "detail": 'Access not authorized to scope: "statements/write".'
+        }
+
+    app.dependency_overrides.pop(get_authenticated_user, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@
 from .fixtures import hypothesis_configuration  # noqa: F401
 from .fixtures import hypothesis_strategies  # noqa: F401
 from .fixtures.auth import (  # noqa: F401
-    auth_credentials,
+    basic_auth_credentials,
     basic_auth_test_client,
     encoded_token,
     mock_discovery_response,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,7 +212,7 @@ def _assert_matching_basic_auth_credentials(
     assert "hash" in credentials
     if hash_:
         assert credentials["hash"] == hash_
-    assert credentials["scopes"] == scopes
+    assert sorted(credentials["scopes"]) == sorted(scopes)
     assert "agent" in credentials
 
     if agent_name is not None:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -7,6 +7,7 @@ import pytest
 from ralph import conf
 from ralph.backends.conf import BackendSettings
 from ralph.conf import CommaSeparatedTuple, Settings, settings
+from ralph.exceptions import ConfigurationException
 
 
 def test_conf_settings_field_value_priority(fs, monkeypatch):
@@ -73,3 +74,20 @@ def test_conf_core_settings_should_impact_settings_defaults(monkeypatch):
 
     # Defaults.
     assert str(conf.settings.AUTH_FILE) == "/foo/auth.json"
+
+
+def test_conf_forbidden_scopes_without_authority(monkeypatch):
+    """Test that using RESTRICT_BY_SCOPES without RESTRICT_BY_AUTHORITY raises an
+    error."""
+
+    monkeypatch.setenv("RALPH_LRS_RESTRICT_BY_AUTHORITY", False)
+    monkeypatch.setenv("RALPH_LRS_RESTRICT_BY_SCOPES", True)
+
+    with pytest.raises(
+        ConfigurationException,
+        match=(
+            "LRS_RESTRICT_BY_AUTHORITY must be set to True if using "
+            "LRS_RESTRICT_BY_SCOPES=True"
+        ),
+    ):
+        reload(conf)


### PR DESCRIPTION
## Purpose

The current state of Ralph allows to restrict users by authority, but does not allow 1. An admin user 2. Finer access control (read, write). This PR aims to solve this issue by implementing `scopes` (a field already present in user accounts) which can allow restricted access.

## Proposal

The scopes proposed are a slight variation on the scopes defined by the [xAPI standard](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#details-15):

```
    "statements/write",
    "statements/read/mine",
    "statements/read",
    "state/write",
    "state/read",
    "define",
    "profile/write",
    "profile/read",
    "all/read",
    "all",
```

NB: This PR also proposes some cleaning (renaming tests and factorizing code in tests).


TODO:
- [x] restrict endpoint access by scopes (`RALPH_LRS_RESTRICT_BY_SCOPE`)
- [x] deal with  `statements/read/mine` scope (`RALPH_LRS_RESTRICT_BY_AUTHORITY` must be used) (specific test !)
- [x] test restrictions for all endpoints (GET, POST, PUT) AND for both auth methods (OIDC, and basic auth)
- [x] check that `LRS_RESTRICT_BY_AUTHORITY==True` if using scopes, and test this behavior