### PR TITLE
Cover asynchronous backends in API tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       xpack.security.enabled: "false"
     ports:
       - "9200:9200"
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
     mem_limit: 2g
     ulimits:
       memlock:
@@ -74,7 +72,3 @@ services:
   # -- tools
   dockerize:
     image: jwilder/dockerize
-
-volumes:
-  esdata:
-    driver: local

--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -165,7 +165,10 @@ class AsyncESDataBackend(BaseAsyncDataBackend):
             kwargs["q"] = query.query_string
 
         count = chunk_size
-        while limit or chunk_size == count:
+        # The first condition is set to comprise either limit as None
+        # (when the backend query does not have `size` parameter),
+        # or limit with a positive value.
+        while limit != 0 and chunk_size == count:
             kwargs["size"] = limit if limit and limit < chunk_size else chunk_size
             try:
                 documents = (await self.client.search(**kwargs))["hits"]["hits"]

--- a/src/ralph/backends/http/async_lrs.py
+++ b/src/ralph/backends/http/async_lrs.py
@@ -335,7 +335,6 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
             while True:
                 response = await client.get(target, params=query_params)
                 response.raise_for_status()
-
                 statements_response = StatementResponse.parse_obj(response.json())
                 statements = statements_response.statements
                 statements = (
@@ -370,7 +369,6 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
                     target=target, raw_output=raw_output, query_params=query_params
                 ):
                     await queue.put(statement)
-
             # Re-raising exceptions is necessary as create_task fails silently
             except Exception as exception:
                 # None signals that the queue is done

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -190,7 +190,9 @@ class Settings(BaseSettings):
     RUNSERVER_AUTH_BACKEND: AuthBackends = AuthBackends.BASIC
     RUNSERVER_AUTH_OIDC_AUDIENCE: str = None
     RUNSERVER_AUTH_OIDC_ISSUER_URI: AnyHttpUrl = None
-    RUNSERVER_BACKEND: Literal["clickhouse", "es", "mongo"] = "es"
+    RUNSERVER_BACKEND: Literal[
+        "async_es", "async_mongo", "clickhouse", "es", "mongo"
+    ] = "es"
     RUNSERVER_HOST: str = "0.0.0.0"  # nosec
     RUNSERVER_MAX_SEARCH_HITS_COUNT: int = 100
     RUNSERVER_POINT_IN_TIME_KEEP_ALIVE: str = "1m"

--- a/tests/api/test_forwarding.py
+++ b/tests/api/test_forwarding.py
@@ -1,6 +1,5 @@
 """Tests for the xAPI statements forwarding background task."""
 
-import asyncio
 import json
 import logging
 
@@ -139,7 +138,7 @@ def test_api_forwarding_get_active_xapi_forwardings_with_inactive_forwardings(
         is_active=st.just(True),
     )
 )
-def test_api_forwarding_forward_xapi_statements_with_successful_request(
+async def test_api_forwarding_forward_xapi_statements_with_successful_request(
     monkeypatch, caplog, statements, forwarding
 ):
     """Test the forward_xapi_statements function should log the forwarded statements
@@ -164,7 +163,7 @@ def test_api_forwarding_forward_xapi_statements_with_successful_request(
 
     caplog.clear()
     with caplog.at_level(logging.DEBUG):
-        asyncio.run(forward_xapi_statements(statements, method="post"))
+        await forward_xapi_statements(statements, method="post")
 
     assert [
         f"Forwarded {len(statements)} statements to {forwarding.url} with success."
@@ -185,7 +184,7 @@ def test_api_forwarding_forward_xapi_statements_with_successful_request(
         is_active=st.just(True),
     )
 )
-def test_api_forwarding_forward_xapi_statements_with_unsuccessful_request(
+async def test_api_forwarding_forward_xapi_statements_with_unsuccessful_request(
     monkeypatch, caplog, statements, forwarding
 ):
     """Test the forward_xapi_statements function should log the error if the request
@@ -211,7 +210,7 @@ def test_api_forwarding_forward_xapi_statements_with_unsuccessful_request(
 
     caplog.clear()
     with caplog.at_level(logging.ERROR):
-        asyncio.run(forward_xapi_statements(statements, method="post"))
+        await forward_xapi_statements(statements, method="post")
 
     assert ["Failed to forward xAPI statements. Failure during request."] == [
         message

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -2,56 +2,68 @@
 import logging
 
 import pytest
-from fastapi.testclient import TestClient
 
-from ralph.api import app
 from ralph.api.routers import health
 from ralph.backends.data.base import DataBackendStatus
 
 from tests.fixtures.backends import (
+    get_async_es_test_backend,
+    get_async_mongo_test_backend,
     get_clickhouse_test_backend,
     get_es_test_backend,
     get_mongo_test_backend,
 )
 
-client = TestClient(app)
 
-
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "backend",
-    [get_clickhouse_test_backend, get_es_test_backend, get_mongo_test_backend],
+    [
+        get_async_es_test_backend,
+        get_async_mongo_test_backend,
+        get_clickhouse_test_backend,
+        get_es_test_backend,
+        get_mongo_test_backend,
+    ],
 )
-def test_api_health_lbheartbeat(backend, monkeypatch):
+async def test_api_health_lbheartbeat(client, backend, monkeypatch):
     """Test the load balancer heartbeat healthcheck."""
     monkeypatch.setattr(health, "BACKEND_CLIENT", backend())
 
-    response = client.get("/__lbheartbeat__")
+    response = await client.get("/__lbheartbeat__")
     assert response.status_code == 200
     assert response.json() is None
 
 
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "backend",
-    [get_clickhouse_test_backend, get_es_test_backend, get_mongo_test_backend],
+    [
+        get_async_es_test_backend,
+        get_async_mongo_test_backend,
+        get_clickhouse_test_backend,
+        get_es_test_backend,
+        get_mongo_test_backend,
+    ],
 )
-# pylint: disable=unused-argument
-def test_api_health_heartbeat(backend, monkeypatch, clickhouse):
+async def test_api_health_heartbeat(client, backend, monkeypatch, clickhouse):
+    # pylint: disable=unused-argument
     """Test the heartbeat healthcheck."""
     monkeypatch.setattr(health, "BACKEND_CLIENT", backend())
 
-    response = client.get("/__heartbeat__")
+    response = await client.get("/__heartbeat__")
     logging.warning(response.read())
     assert response.status_code == 200
     assert response.json() == {"database": "ok"}
 
     monkeypatch.setattr(health.BACKEND_CLIENT, "status", lambda: DataBackendStatus.AWAY)
-    response = client.get("/__heartbeat__")
+    response = await client.get("/__heartbeat__")
     assert response.json() == {"database": "away"}
     assert response.status_code == 500
 
     monkeypatch.setattr(
         health.BACKEND_CLIENT, "status", lambda: DataBackendStatus.ERROR
     )
-    response = client.get("/__heartbeat__")
+    response = await client.get("/__heartbeat__")
     assert response.json() == {"database": "error"}
     assert response.status_code == 500

--- a/tests/api/test_statements.py
+++ b/tests/api/test_statements.py
@@ -4,9 +4,11 @@ from importlib import reload
 
 from ralph import conf
 from ralph.api.routers import statements
-from ralph.backends.data.clickhouse import ClickHouseDataBackend
-from ralph.backends.data.es import ESDataBackend
-from ralph.backends.data.mongo import MongoDataBackend
+from ralph.backends.lrs.async_es import AsyncESLRSBackend
+from ralph.backends.lrs.async_mongo import AsyncMongoLRSBackend
+from ralph.backends.lrs.clickhouse import ClickHouseLRSBackend
+from ralph.backends.lrs.es import ESLRSBackend
+from ralph.backends.lrs.mongo import MongoLRSBackend
 
 
 def test_api_statements_backend_instance_with_runserver_backend_env(monkeypatch):
@@ -14,19 +16,29 @@ def test_api_statements_backend_instance_with_runserver_backend_env(monkeypatch)
     instance `BACKEND_CLIENT` should be updated accordingly.
     """
     # Default backend
-    assert isinstance(statements.BACKEND_CLIENT, ESDataBackend)
+    assert isinstance(statements.BACKEND_CLIENT, ESLRSBackend)
 
     # Mongo backend
     monkeypatch.setenv("RALPH_RUNSERVER_BACKEND", "mongo")
     reload(conf)
-    assert isinstance(reload(statements).BACKEND_CLIENT, MongoDataBackend)
+    assert isinstance(reload(statements).BACKEND_CLIENT, MongoLRSBackend)
 
     # Elasticsearch backend
     monkeypatch.setenv("RALPH_RUNSERVER_BACKEND", "es")
     reload(conf)
-    assert isinstance(reload(statements).BACKEND_CLIENT, ESDataBackend)
+    assert isinstance(reload(statements).BACKEND_CLIENT, ESLRSBackend)
 
     # ClickHouse backend
     monkeypatch.setenv("RALPH_RUNSERVER_BACKEND", "clickhouse")
     reload(conf)
-    assert isinstance(reload(statements).BACKEND_CLIENT, ClickHouseDataBackend)
+    assert isinstance(reload(statements).BACKEND_CLIENT, ClickHouseLRSBackend)
+
+    # Async Elasticsearch backend
+    monkeypatch.setenv("RALPH_RUNSERVER_BACKEND", "async_es")
+    reload(conf)
+    assert isinstance(reload(statements).BACKEND_CLIENT, AsyncESLRSBackend)
+
+    # Async Mongo backend
+    monkeypatch.setenv("RALPH_RUNSERVER_BACKEND", "async_mongo")
+    reload(conf)
+    assert isinstance(reload(statements).BACKEND_CLIENT, AsyncMongoLRSBackend)

--- a/tests/backends/http/test_async_lrs.py
+++ b/tests/backends/http/test_async_lrs.py
@@ -253,20 +253,19 @@ async def test_backends_http_lrs_read_max_statements(
         json=statements,
     )
 
-    if (max_statements is None) or (max_statements > chunk_size):
-        default_params.update(dict(parse_qsl(urlparse(more_target).query)))
-        httpx_mock.add_response(
-            url=ParseResult(
-                scheme=urlparse(base_url).scheme,
-                netloc=urlparse(base_url).netloc,
-                path=urlparse(more_target).path,
-                query=urlencode(default_params).lower(),
-                params="",
-                fragment="",
-            ).geturl(),
-            method="GET",
-            json=more_statements,
-        )
+    default_params.update(dict(parse_qsl(urlparse(more_target).query)))
+    httpx_mock.add_response(
+        url=ParseResult(
+            scheme=urlparse(base_url).scheme,
+            netloc=urlparse(base_url).netloc,
+            path=urlparse(more_target).path,
+            query=urlencode(default_params).lower(),
+            params="",
+            fragment="",
+        ).geturl(),
+        method="GET",
+        json=more_statements,
+    )
 
     settings = AsyncLRSHTTPBackend.settings_class(
         BASE_URL=base_url, USERNAME="user", PASSWORD="pass"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 
 from .fixtures import hypothesis_configuration  # noqa: F401
 from .fixtures import hypothesis_strategies  # noqa: F401
+from .fixtures.api import client  # noqa: F401
 from .fixtures.auth import (  # noqa: F401
     basic_auth_credentials,
     basic_auth_test_client,

--- a/tests/fixtures/api.py
+++ b/tests/fixtures/api.py
@@ -1,0 +1,15 @@
+"""Test fixtures related to the API."""
+
+import pytest
+from httpx import AsyncClient
+
+from ralph.api import app
+
+
+@pytest.mark.anyio
+@pytest.fixture(scope="session")
+async def client():
+    """Return an AsyncClient for the FastAPI app."""
+
+    async with AsyncClient(app=app, base_url="http://test") as async_client:
+        yield async_client


### PR DESCRIPTION
## Purpose

After backends unification and integration, we are not testing the API with
async_es and async_mongo.
Covering these backends highlighted some problems:
- limit of the `read` method of `async_es` backend was not correctly used
- `runserver` could not be used with `async_es` and `async_mongo`
- volume of elasticsearch docker compose service prevented reproducibility

## Proposal

- 🐛(backends) fix limit in `read` method of `async_es` backend
- ✨(api) add ability to use async backends for `runserver` command
- 🔧(projet) remove elasticsearch volume
- ✅(api) update tests to cover async backends

