### PR TITLE
🔧(helm) improve ingress's host management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Implement Pydantic model for LRS Statements resource query parameters
 - Implement xAPI LMS Profile statements validation
 - `EdX` to `xAPI` converters for enrollment events
+- Helm: Add variable ``ingress.hosts``
 
 ### Changed
 
@@ -55,6 +56,7 @@ have an authority field matching that of the user
 
 - `school`, `course`, `module` context extensions in Edx to xAPI base converter
 - `name` field in `VideoActivity` xAPI model mistakenly used in `video` profile
+- Helm: remove variable ``ingress.hostname`` and ``ingress.tls``
 
 ## [3.9.0] - 2023-07-21
 

--- a/src/helm/ralph/templates/ingress.yaml
+++ b/src/helm/ralph/templates/ingress.yaml
@@ -12,25 +12,33 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
+
+  {{- $tls := (list) }}
   rules:
-    - host: {{ .Values.ingress.hostname | quote }}
+    {{- $outer := . }}
+    {{- range .Values.ingress.hosts }}
+    {{- if .tls }}
+      {{- $tls = (concat $tls (list .) ) }}
+    {{- end }}
+    {{- range .domains }}
+    - host: {{ . | quote}}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ include "ralph.fullname" . }}
+                name: {{ template "ralph.fullname" $outer }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $outer.Values.service.port }}
+    {{- end }}
+    {{- end }}
+  tls:
+    {{- range $tls }}
+    - hosts:
+      {{- range .domains }}
+        - {{ .| quote }}
+      {{- end }}
+      secretName: {{ .tls.secretName }}
+    {{- end }}
 {{- end }}

--- a/src/helm/ralph/values.yaml
+++ b/src/helm/ralph/values.yaml
@@ -27,12 +27,12 @@ service:
 ingress:
   enabled: false
   ingressClassName: ""
-  hostname: "ralph.example.com"
+  hosts:
+    - domains:
+        - ralph.example.com
+      tls:
+        secretName: "ralph-example-com-tls"
   annotations: {}
-  tls:
-    - hosts:
-        - "ralph.example.com"
-      secretName: "ralph-example-com-tls"
 
 affinity:
   podAntiAffinity:


### PR DESCRIPTION
The PR #471 add the possibility to add more certificate to the Ralph's Ingress. But doesn't allow to use it.

This PR the delete Helm's values ``ingress.tls`` and ``ingress.hostname`` and create a new one.

``` yaml 
ingress:
  hosts:
    - domains:
      - ralph.example.com
      - ralph2.example.com
      tls:
        secretName: "ralph-example-com-tls" # This secret is a wildcard certificate for example.com
    - domains:
      - ralph.other-example.com
      tls:
        secretName: "ralph-other-example-com-tls"
```

Result
``` yaml
# Source: ralph/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-ralph
  labels:
    helm.sh/chart: ralph-0.1.0
    app.kubernetes.io/name: ralph
    app.kubernetes.io/instance: release-name
    app: ralph
    service: app
    app.kubernetes.io/version: "3.9.0"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: ""
  rules:
    - host: "ralph.example.com"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: release-name-ralph
                port:
                  number: 8080
    - host: "ralph2.example.com"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: release-name-ralph
                port:
                  number: 8080
    - host: "ralph.other-example.com"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: release-name-ralph
                port:
                  number: 8080
  tls:
    - hosts:
        - "ralph.example.com"
        - "ralph2.example.com"
      secretName: ralph-example-com-tls
    - hosts:
        - "ralph.other-example.com"
      secretName: ralph-other-example-com-tls
```
