### PR TITLE
🐛(helm) fix clickhouse Helm's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ have an authority field matching that of the user
 - API: Add `RALPH_LRS_RESTRICT_BY_AUTHORITY` option making `?mine=True`
   implicit
 - CLI: list cli usage strings in alphabetical order
+- Helm: Fix clickhouse version
 
 ### Fixed
 

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: mongodb.enabled
   - name: clickhouse
-    version: 23.x.x
+    version: 4.x.x
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: clickhouse.enabled


### PR DESCRIPTION
The version 23.x for clickhouse is the docker image version. 

The last major version for the clickhouse's helm chart is 4.


