### PR TITLE
Setting up docs versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,8 +670,8 @@ workflows:
               only: /^v.*/
 
       # Publish the documentation website to GitHub Pages.
-      # Only do it for master as tagged releases are supposed to tag their own version of the
-      # documentation in the release commit on master before they go out.
+      # Only do it for master and for tagged releases with a tag starting with
+      # the letter v.
       - deploy-docs:
           requires:
             - tray

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,8 +495,17 @@ jobs:
           command: |
             git config --global user.email "funmoocbot@users.noreply.github.com"
             git config --global user.name "FUN MOOC Bot"
-            ~/.local/bin/mkdocs gh-deploy
-
+            # Deploy docs with either:
+            # - DOCS_VERSION: 1.1 (for git tag v1.1.2)
+            # - DOCS_ALIAS: latest
+            # or
+            # - DOCS_VERSION: dev (for master branch)
+            # - No DOCS_ALIAS
+            DOCS_VERSION=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v\([0-9]\.[0-9]*\)\..*/\1/')
+            DOCS_ALIAS=$([[ -z "$CIRCLE_TAG" ]] && echo "" || echo "latest")
+            echo "DOCS_VERSION: ${DOCS_VERSION}"
+            echo "DOCS_ALIAS: ${DOCS_ALIAS}"
+            ~/.local/bin/mike deploy --push --update-aliases ${DOCS_VERSION} ${DOCS_ALIAS}
   # Make a new github release
   release:
     docker:
@@ -680,7 +689,7 @@ workflows:
             branches:
               only: master
             tags:
-              only: /.*/
+              only: /^v.*/
 
       # Release
       - release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; \
         rm -rf /var/lib/apt/lists/*; \
     fi;
 
+# Install git for documentation deployment
+RUN apt-get update && \
+    apt-get install -y \
+        git && \
+    rm -rf /var/lib/apt/lists/*;
+
 # Uninstall ralph and re-install it in editable mode along with development
 # dependencies
 RUN pip uninstall -y ralph-malph

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,14 @@ COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_TEST_RUN     = $(COMPOSE_RUN)
 COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app
-MKDOCS               = $(COMPOSE_RUN) --no-deps --publish "8000:8000" app mkdocs
+COMPOSE_RUN_DOCS     = $(COMPOSE_RUN) --no-deps --publish "8000:8000" app
+
+
+# -- Documentation
+DOCS_COMMITTER_NAME  = "FUN MOOC Bot"
+DOCS_COMMITTER_EMAIL = funmoocbot@users.noreply.github.com
+MKDOCS               = $(COMPOSE_RUN_DOCS) mkdocs
+MIKE                 = GIT_COMMITTER_NAME=$(DOCS_COMMITTER_NAME) GIT_COMMITTER_EMAIL=$(DOCS_COMMITTER_EMAIL) $(COMPOSE_RUN_DOCS) mike
 
 # -- Elasticsearch
 ES_PROTOCOL = http
@@ -140,11 +147,14 @@ docs-build: ## build documentation site
 .PHONY: docs-build
 
 docs-deploy: ## deploy documentation site
-	@$(MKDOCS) gh-deploy
+# Using env variables GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL will work with mike 2.0
+# Until that you need to set local git config user.name and user.email manually
+	@echo "Deploying docs with version dev"
+	@${MIKE} deploy dev
 .PHONY: docs-deploy
 
-docs-serve: ## run mkdocs live server
-	@$(MKDOCS) serve --dev-addr 0.0.0.0:8000
+docs-serve: ## run mike live server
+	@$(MIKE) serve --dev-addr 0.0.0.0:8000
 .PHONY: docs-serve
 
 down: ## stop and remove backend containers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,3 +43,10 @@ nav:
 plugins:
     - search
     - mkdocstrings
+    - mike:
+        canonical_version: latest
+        version_selector: true
+
+extra:
+    version:
+        provider: mike

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ dev =
     hypothesis==6.88.1
     isort==5.12.0
     logging-gelf==0.0.31
+    mike==1.1.2
     mkdocs==1.5.3
     mkdocs-click==0.8.1
     mkdocs-material==9.4.6


### PR DESCRIPTION
## Purpose

Documentation under https://openfun.github.io/ralph/ lacks a version and is always following `master`, which can be confusing for the Ralph python package users.

## Proposal

- [x] 🔧(docs) add mike tools for docs versioning
- [x] 💚(docs) add docs versioning in CI
