### PR TITLE
🐛(Makefile) add missing backslash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bin/init-cluster:
 		-u $(RALPH_LRS_AUTH_USER_NAME) \
 		-p $(RALPH_LRS_AUTH_USER_PWD) \
 		-s $(RALPH_LRS_AUTH_USER_SCOPE) \
-		-M $(RALPH_LRS_AUTH_USER_AGENT_MBOX)
+		-M $(RALPH_LRS_AUTH_USER_AGENT_MBOX) \
 		-w
 
 


### PR DESCRIPTION
Missing backslash in Makefile leads to `-w` (write to disk) being ignored
when creating `auth.json`. This PR fixes this.

- [x] add missing `\`
- [x] update CHANGELOG

