### PR TITLE
🚚(backends) rename query_model to query_class

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -27,7 +27,7 @@ class AsyncESDataBackend(BaseAsyncDataBackend, AsyncWritable, AsyncListable):
     """Asynchronous Elasticsearch data backend."""
 
     name = "async_es"
-    query_model = ESQuery
+    query_class = ESQuery
     settings_class = ESDataBackendSettings
 
     def __init__(self, settings: Optional[ESDataBackendSettings] = None):

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -35,7 +35,7 @@ class AsyncMongoDataBackend(BaseAsyncDataBackend, AsyncWritable, AsyncListable):
     """Async MongoDB data backend."""
 
     name = "async_mongo"
-    query_model = MongoQuery
+    query_class = MongoQuery
     settings_class = MongoDataBackendSettings
 
     def __init__(self, settings: Optional[MongoDataBackendSettings] = None):

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -148,7 +148,7 @@ class BaseDataBackend(ABC):
     """Base data backend interface."""
 
     name = "base"
-    query_model = BaseQuery
+    query_class = BaseQuery
     settings_class = BaseDataBackendSettings
 
     @abstractmethod
@@ -165,26 +165,26 @@ class BaseDataBackend(ABC):
     ) -> BaseQuery:
         """Validate and transform the query."""
         if query is None:
-            query = self.query_model()
+            query = self.query_class()
 
         if isinstance(query, str):
-            query = self.query_model(query_string=query)
+            query = self.query_class(query_string=query)
 
         if isinstance(query, dict):
             try:
-                query = self.query_model(**query)
+                query = self.query_class(**query)
             except ValidationError as error:
                 msg = "The 'query' argument is expected to be a %s instance. %s"
                 errors = error.errors()
-                logger.error(msg, self.query_model.__name__, errors)
+                logger.error(msg, self.query_class.__name__, errors)
                 raise BackendParameterException(
-                    msg % (self.query_model.__name__, errors)
+                    msg % (self.query_class.__name__, errors)
                 ) from error
 
-        if not isinstance(query, self.query_model):
+        if not isinstance(query, self.query_class):
             msg = "The 'query' argument is expected to be a %s instance."
-            logger.error(msg, self.query_model.__name__)
-            raise BackendParameterException(msg % (self.query_model.__name__,))
+            logger.error(msg, self.query_class.__name__)
+            raise BackendParameterException(msg % (self.query_class.__name__,))
 
         logger.debug("Query: %s", str(query))
 
@@ -328,7 +328,7 @@ class BaseAsyncDataBackend(ABC):
     """Base async data backend interface."""
 
     name = "base"
-    query_model = BaseQuery
+    query_class = BaseQuery
     settings_class = BaseDataBackendSettings
 
     @abstractmethod
@@ -345,26 +345,26 @@ class BaseAsyncDataBackend(ABC):
     ) -> BaseQuery:
         """Validate and transform the query."""
         if query is None:
-            query = self.query_model()
+            query = self.query_class()
 
         if isinstance(query, str):
-            query = self.query_model(query_string=query)
+            query = self.query_class(query_string=query)
 
         if isinstance(query, dict):
             try:
-                query = self.query_model(**query)
+                query = self.query_class(**query)
             except ValidationError as error:
                 msg = "The 'query' argument is expected to be a %s instance. %s"
                 errors = error.errors()
-                logger.error(msg, self.query_model.__name__, errors)
+                logger.error(msg, self.query_class.__name__, errors)
                 raise BackendParameterException(
-                    msg % (self.query_model.__name__, errors)
+                    msg % (self.query_class.__name__, errors)
                 ) from error
 
-        if not isinstance(query, self.query_model):
+        if not isinstance(query, self.query_class):
             msg = "The 'query' argument is expected to be a %s instance."
-            logger.error(msg, self.query_model.__name__)
-            raise BackendParameterException(msg % (self.query_model.__name__,))
+            logger.error(msg, self.query_class.__name__)
+            raise BackendParameterException(msg % (self.query_class.__name__,))
 
         logger.debug("Query: %s", str(query))
 

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -112,7 +112,7 @@ class ClickHouseDataBackend(BaseDataBackend, Writable, Listable):
     """ClickHouse database backend."""
 
     name = "clickhouse"
-    query_model = ClickHouseQuery
+    query_class = ClickHouseQuery
     default_operation_type = BaseOperationType.CREATE
     settings_class = ClickHouseDataBackendSettings
 

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -115,7 +115,7 @@ class ESDataBackend(BaseDataBackend, Writable, Listable):
     """Elasticsearch data backend."""
 
     name = "es"
-    query_model = ESQuery
+    query_class = ESQuery
     settings_class = ESDataBackendSettings
 
     def __init__(self, settings: Optional[ESDataBackendSettings] = None):

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -94,7 +94,7 @@ class MongoDataBackend(BaseDataBackend, Writable, Listable):
     """MongoDB data backend."""
 
     name = "mongo"
-    query_model = MongoQuery
+    query_class = MongoQuery
     settings_class = MongoDataBackendSettings
 
     def __init__(self, settings: Optional[MongoDataBackendSettings] = None):

--- a/tests/backends/data/test_async_es.py
+++ b/tests/backends/data/test_async_es.py
@@ -53,7 +53,7 @@ async def test_backends_data_async_es_data_backend_default_instantiation(
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__ES__{name}", raising=False)
 
     assert AsyncESDataBackend.name == "async_es"
-    assert AsyncESDataBackend.query_model == ESQuery
+    assert AsyncESDataBackend.query_class == ESQuery
     assert AsyncESDataBackend.default_operation_type == BaseOperationType.INDEX
     assert AsyncESDataBackend.settings_class == ESDataBackendSettings
     backend = AsyncESDataBackend()

--- a/tests/backends/data/test_async_mongo.py
+++ b/tests/backends/data/test_async_mongo.py
@@ -43,7 +43,7 @@ async def test_backends_data_async_mongo_data_backend_default_instantiation(
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__MONGO__{name}", raising=False)
 
     assert AsyncMongoDataBackend.name == "async_mongo"
-    assert AsyncMongoDataBackend.query_model == MongoQuery
+    assert AsyncMongoDataBackend.query_class == MongoQuery
     assert AsyncMongoDataBackend.default_operation_type == BaseOperationType.INDEX
     assert AsyncMongoDataBackend.settings_class == MongoDataBackendSettings
     backend = AsyncMongoDataBackend()

--- a/tests/backends/data/test_clickhouse.py
+++ b/tests/backends/data/test_clickhouse.py
@@ -44,7 +44,7 @@ def test_backends_data_clickhouse_data_backend_default_instantiation(monkeypatch
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__CLICKHOUSE__{name}", raising=False)
 
     assert ClickHouseDataBackend.name == "clickhouse"
-    assert ClickHouseDataBackend.query_model == ClickHouseQuery
+    assert ClickHouseDataBackend.query_class == ClickHouseQuery
     assert ClickHouseDataBackend.default_operation_type == BaseOperationType.CREATE
     assert ClickHouseDataBackend.settings_class == ClickHouseDataBackendSettings
     backend = ClickHouseDataBackend()

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -51,7 +51,7 @@ def test_backends_data_es_data_backend_default_instantiation(monkeypatch, fs):
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__ES__{name}", raising=False)
 
     assert ESDataBackend.name == "es"
-    assert ESDataBackend.query_model == ESQuery
+    assert ESDataBackend.query_class == ESQuery
     assert ESDataBackend.default_operation_type == BaseOperationType.INDEX
     assert ESDataBackend.settings_class == ESDataBackendSettings
     backend = ESDataBackend()

--- a/tests/backends/data/test_fs.py
+++ b/tests/backends/data/test_fs.py
@@ -28,7 +28,7 @@ def test_backends_data_fs_data_backend_default_instantiation(monkeypatch, fs):
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__FS__{name}", raising=False)
 
     assert FSDataBackend.name == "fs"
-    assert FSDataBackend.query_model == BaseQuery
+    assert FSDataBackend.query_class == BaseQuery
     assert FSDataBackend.default_operation_type == BaseOperationType.CREATE
     assert FSDataBackend.settings_class == FSDataBackendSettings
     backend = FSDataBackend()

--- a/tests/backends/data/test_ldp.py
+++ b/tests/backends/data/test_ldp.py
@@ -37,7 +37,7 @@ def test_backends_data_ldp_data_backend_default_instantiation(monkeypatch, fs):
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__LDP__{name}", raising=False)
 
     assert LDPDataBackend.name == "ldp"
-    assert LDPDataBackend.query_model == BaseQuery
+    assert LDPDataBackend.query_class == BaseQuery
     backend = LDPDataBackend()
     assert isinstance(backend.client, ovh.Client)
     assert backend.service_name is None

--- a/tests/backends/data/test_mongo.py
+++ b/tests/backends/data/test_mongo.py
@@ -40,7 +40,7 @@ def test_backends_data_mongo_data_backend_default_instantiation(monkeypatch, fs)
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__MONGO__{name}", raising=False)
 
     assert MongoDataBackend.name == "mongo"
-    assert MongoDataBackend.query_model == MongoQuery
+    assert MongoDataBackend.query_class == MongoQuery
     assert MongoDataBackend.default_operation_type == BaseOperationType.INDEX
     assert MongoDataBackend.settings_class == MongoDataBackendSettings
     backend = MongoDataBackend()

--- a/tests/backends/data/test_s3.py
+++ b/tests/backends/data/test_s3.py
@@ -31,7 +31,7 @@ def test_backends_data_s3_backend_default_instantiation(monkeypatch, fs):
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__S3__{name}", raising=False)
 
     assert S3DataBackend.name == "s3"
-    assert S3DataBackend.query_model == BaseQuery
+    assert S3DataBackend.query_class == BaseQuery
     assert S3DataBackend.default_operation_type == BaseOperationType.CREATE
     assert S3DataBackend.settings_class == S3DataBackendSettings
     backend = S3DataBackend()

--- a/tests/backends/data/test_swift.py
+++ b/tests/backends/data/test_swift.py
@@ -39,7 +39,7 @@ def test_backends_data_swift_data_backend_default_instantiation(monkeypatch, fs)
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__SWIFT__{name}", raising=False)
 
     assert SwiftDataBackend.name == "swift"
-    assert SwiftDataBackend.query_model == BaseQuery
+    assert SwiftDataBackend.query_class == BaseQuery
     assert SwiftDataBackend.default_operation_type == BaseOperationType.CREATE
     assert SwiftDataBackend.settings_class == SwiftDataBackendSettings
     backend = SwiftDataBackend()


### PR DESCRIPTION
## Purpose

Data backends have two class attributes referring to pydantic model types that follow different naming conventions:
`settings_class` and `query_model`. 

## Proposal

For consistency, we propose to follow one naming convention.

- [x] rename `query_model` to `query_class`