### PR TITLE
✨(backends) generic data backends

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -3,7 +3,7 @@
 import logging
 from io import IOBase
 from itertools import chain
-from typing import Iterable, Iterator, Optional, Union
+from typing import Iterable, Iterator, Optional, TypeVar, Union
 
 from elasticsearch import ApiError, AsyncElasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, async_streaming_bulk
@@ -21,23 +21,24 @@ from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import parse_bytes_to_dict, read_raw
 
 logger = logging.getLogger(__name__)
+Settings = TypeVar("Settings", bound=ESDataBackendSettings)
 
 
-class AsyncESDataBackend(BaseAsyncDataBackend, AsyncWritable, AsyncListable):
+class AsyncESDataBackend(
+    BaseAsyncDataBackend[Settings, ESQuery], AsyncWritable, AsyncListable
+):
     """Asynchronous Elasticsearch data backend."""
 
     name = "async_es"
-    query_class = ESQuery
-    settings_class = ESDataBackendSettings
 
-    def __init__(self, settings: Optional[ESDataBackendSettings] = None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the asynchronous Elasticsearch client.
 
         Args:
             settings (ESDataBackendSettings or None): The data backend settings.
                 If `settings` is `None`, a default settings instance is used instead.
         """
-        self.settings = settings if settings else self.settings_class()
+        super().__init__(settings)
         self._client = None
 
     @property

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -4,7 +4,7 @@ import json
 import logging
 from io import IOBase
 from itertools import chain
-from typing import Any, Dict, Iterable, Iterator, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, Optional, TypeVar, Union
 
 from bson.errors import BSONError
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -29,22 +29,25 @@ from ..data.base import (
 )
 
 logger = logging.getLogger(__name__)
+Settings = TypeVar("Settings", bound=MongoDataBackendSettings)
 
 
-class AsyncMongoDataBackend(BaseAsyncDataBackend, AsyncWritable, AsyncListable):
+class AsyncMongoDataBackend(
+    BaseAsyncDataBackend[Settings, MongoQuery],
+    AsyncWritable,
+    AsyncListable,
+):
     """Async MongoDB data backend."""
 
     name = "async_mongo"
-    query_class = MongoQuery
-    settings_class = MongoDataBackendSettings
 
-    def __init__(self, settings: Optional[MongoDataBackendSettings] = None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the asynchronous MongoDB client.
 
         Args:
             settings (MongoDataBackendSettings or None): The data backend settings.
         """
-        self.settings = settings if settings else self.settings_class()
+        super().__init__(settings)
         self.client = AsyncIOMotorClient(
             self.settings.CONNECTION_URI, **self.settings.CLIENT_OPTIONS.dict()
         )

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    TypeVar,
     Union,
 )
 from uuid import UUID, uuid4
@@ -108,22 +109,27 @@ class ClickHouseQuery(BaseClickHouseQuery):
     query_string: Union[Json[BaseClickHouseQuery], None]
 
 
-class ClickHouseDataBackend(BaseDataBackend, Writable, Listable):
+Settings = TypeVar("Settings", bound=ClickHouseDataBackendSettings)
+
+
+class ClickHouseDataBackend(
+    BaseDataBackend[Settings, ClickHouseQuery],
+    Writable,
+    Listable,
+):
     """ClickHouse database backend."""
 
     name = "clickhouse"
-    query_class = ClickHouseQuery
     default_operation_type = BaseOperationType.CREATE
-    settings_class = ClickHouseDataBackendSettings
 
-    def __init__(self, settings: Optional[ClickHouseDataBackendSettings] = None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the ClickHouse configuration.
 
         Args:
             settings (ClickHouseDataBackendSettings or None): The ClickHouse
                 data backend settings.
         """
-        self.settings = settings if settings else self.settings_class()
+        super().__init__(settings)
         self.database = self.settings.DATABASE
         self.event_table_name = self.settings.EVENT_TABLE_NAME
         self.default_chunk_size = self.settings.DEFAULT_CHUNK_SIZE

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -4,7 +4,7 @@ import logging
 from io import IOBase
 from itertools import chain
 from pathlib import Path
-from typing import Iterable, Iterator, List, Literal, Optional, Union
+from typing import Iterable, Iterator, List, Literal, Optional, TypeVar, Union
 
 from elasticsearch import ApiError, Elasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, streaming_bulk
@@ -111,21 +111,22 @@ class ESQuery(BaseQuery):
     track_total_hits: Literal[False] = False
 
 
-class ESDataBackend(BaseDataBackend, Writable, Listable):
+Settings = TypeVar("Settings", bound=ESDataBackendSettings)
+
+
+class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
     """Elasticsearch data backend."""
 
     name = "es"
-    query_class = ESQuery
-    settings_class = ESDataBackendSettings
 
-    def __init__(self, settings: Optional[ESDataBackendSettings] = None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the Elasticsearch data backend.
 
         Args:
-            settings (ESDataBackendSettings or None): The data backend settings.
+            settings (Settings or None): The data backend settings.
                 If `settings` is `None`, a default settings instance is used instead.
         """
-        self.settings = settings if settings else self.settings_class()
+        super().__init__(settings)
         self._client = None
 
     @property

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from io import IOBase
 from itertools import chain
 from pathlib import Path
-from typing import IO, Iterable, Iterator, Optional, Union
+from typing import IO, Iterable, Iterator, Optional, TypeVar, Union
 from uuid import uuid4
 
 from ralph.backends.data.base import (
@@ -51,20 +51,28 @@ class FSDataBackendSettings(BaseDataBackendSettings):
     LOCALE_ENCODING: str = "utf8"
 
 
-class FSDataBackend(HistoryMixin, BaseDataBackend, Writable, Listable):
+Settings = TypeVar("Settings", bound=FSDataBackendSettings)
+
+
+class FSDataBackend(
+    BaseDataBackend[Settings, BaseQuery],
+    Writable,
+    Listable,
+    HistoryMixin,
+):
     """FileSystem data backend."""
 
     name = "fs"
     default_operation_type = BaseOperationType.CREATE
-    settings_class = FSDataBackendSettings
 
-    def __init__(self, settings: Optional[FSDataBackendSettings] = None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Create the default target directory if it does not exist.
 
         Args:
             settings (FSDataBackendSettings or None): The data backend settings.
                 If `settings` is `None`, a default settings instance is used instead.
         """
+        super().__init__(settings)
         self.settings = settings if settings else self.settings_class()
         self.default_chunk_size = self.settings.DEFAULT_CHUNK_SIZE
         self.default_directory = self.settings.DEFAULT_DIRECTORY_PATH

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -57,11 +57,14 @@ class LDPDataBackendSettings(BaseDataBackendSettings):
     SERVICE_NAME: Optional[str] = None
 
 
-class LDPDataBackend(HistoryMixin, BaseDataBackend, Listable):
+class LDPDataBackend(
+    BaseDataBackend[LDPDataBackendSettings, BaseQuery],
+    Listable,
+    HistoryMixin,
+):
     """OVH LDP (Log Data Platform) data backend."""
 
     name = "ldp"
-    settings_class = LDPDataBackendSettings
 
     def __init__(self, settings: Optional[LDPDataBackendSettings] = None):
         """Instantiate the OVH LDP client.
@@ -70,7 +73,7 @@ class LDPDataBackend(HistoryMixin, BaseDataBackend, Listable):
             settings (LDPDataBackendSettings or None): The data backend settings.
                 If `settings` is `None`, a default settings instance is used instead.
         """
-        self.settings = settings if settings else self.settings_class()
+        super().__init__(settings)
         self.service_name = self.settings.SERVICE_NAME
         self.stream_id = self.settings.DEFAULT_STREAM_ID
         self.timeout = self.settings.REQUEST_TIMEOUT

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -7,7 +7,7 @@ import logging
 import struct
 from io import IOBase
 from itertools import chain
-from typing import Generator, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Generator, Iterable, Iterator, List, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
 from bson.errors import BSONError
@@ -90,21 +90,22 @@ class MongoQuery(BaseMongoQuery):
     query_string: Union[Json[BaseMongoQuery], None]
 
 
-class MongoDataBackend(BaseDataBackend, Writable, Listable):
+Settings = TypeVar("Settings", bound=MongoDataBackendSettings)
+
+
+class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable):
     """MongoDB data backend."""
 
     name = "mongo"
-    query_class = MongoQuery
-    settings_class = MongoDataBackendSettings
 
-    def __init__(self, settings: Optional[MongoDataBackendSettings] = None):
+    def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the MongoDB client.
 
         Args:
             settings (MongoDataBackendSettings or None): The data backend settings.
                 If `settings` is `None`, a default settings instance is used instead.
         """
-        self.settings = settings if settings else self.settings_class()
+        super().__init__(settings)
         self.client = MongoClient(
             self.settings.CONNECTION_URI, **self.settings.CLIENT_OPTIONS.dict()
         )

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -67,17 +67,17 @@ class S3DataBackendSettings(BaseDataBackendSettings):
     LOCALE_ENCODING: str = "utf8"
 
 
-class S3DataBackend(HistoryMixin, BaseDataBackend, Writable, Listable):
+class S3DataBackend(
+    BaseDataBackend[S3DataBackendSettings, BaseQuery], Writable, Listable, HistoryMixin
+):
     """S3 data backend."""
 
     name = "s3"
     default_operation_type = BaseOperationType.CREATE
-    settings_class = S3DataBackendSettings
 
     def __init__(self, settings: Optional[S3DataBackendSettings] = None):
         """Instantiate the AWS S3 client."""
-        self.settings = settings if settings else self.settings_class()
-
+        super().__init__(settings)
         self.default_bucket_name = self.settings.DEFAULT_BUCKET_NAME
         self.default_chunk_size = self.settings.DEFAULT_CHUNK_SIZE
         self.locale_encoding = self.settings.LOCALE_ENCODING

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -64,17 +64,20 @@ class SwiftDataBackendSettings(BaseDataBackendSettings):
     LOCALE_ENCODING: str = "utf8"
 
 
-class SwiftDataBackend(HistoryMixin, BaseDataBackend, Writable, Listable):
+class SwiftDataBackend(
+    BaseDataBackend[SwiftDataBackendSettings, BaseQuery],
+    HistoryMixin,
+    Writable,
+    Listable,
+):
     """SWIFT data backend."""
 
     name = "swift"
     default_operation_type = BaseOperationType.CREATE
-    settings_class = SwiftDataBackendSettings
 
     def __init__(self, settings: Optional[SwiftDataBackendSettings] = None):
         """Prepares the options for the SwiftService."""
-        self.settings = settings if settings else self.settings_class()
-
+        super().__init__(settings)
         self.default_container = self.settings.DEFAULT_CONTAINER
         self.locale_encoding = self.settings.LOCALE_ENCODING
         self._connection = None

--- a/src/ralph/backends/lrs/async_es.py
+++ b/src/ralph/backends/lrs/async_es.py
@@ -9,16 +9,14 @@ from ralph.backends.lrs.base import (
     RalphStatementsQuery,
     StatementQueryResult,
 )
-from ralph.backends.lrs.es import ESLRSBackend
+from ralph.backends.lrs.es import ESLRSBackend, ESLRSBackendSettings
 from ralph.exceptions import BackendException, BackendParameterException
 
 logger = logging.getLogger(__name__)
 
 
-class AsyncESLRSBackend(BaseAsyncLRSBackend, AsyncESDataBackend):
+class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBackend):
     """Asynchronous Elasticsearch LRS backend implementation."""
-
-    settings_class = ESLRSBackend.settings_class
 
     async def query_statements(
         self, params: RalphStatementsQuery

--- a/src/ralph/backends/lrs/async_mongo.py
+++ b/src/ralph/backends/lrs/async_mongo.py
@@ -10,16 +10,16 @@ from ralph.backends.lrs.base import (
     RalphStatementsQuery,
     StatementQueryResult,
 )
-from ralph.backends.lrs.mongo import MongoLRSBackend
+from ralph.backends.lrs.mongo import MongoLRSBackend, MongoLRSBackendSettings
 from ralph.exceptions import BackendException, BackendParameterException
 
 logger = logging.getLogger(__name__)
 
 
-class AsyncMongoLRSBackend(BaseAsyncLRSBackend, AsyncMongoDataBackend):
+class AsyncMongoLRSBackend(
+    BaseAsyncLRSBackend[MongoLRSBackendSettings], AsyncMongoDataBackend
+):
     """Async MongoDB LRS backend implementation."""
-
-    settings_class = MongoLRSBackend.settings_class
 
     async def query_statements(
         self, params: RalphStatementsQuery

--- a/src/ralph/backends/lrs/base.py
+++ b/src/ralph/backends/lrs/base.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterator, List, Literal, Optional, Union
+from typing import Any, Iterator, List, Literal, Optional, TypeVar, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field, NonNegativeInt
@@ -13,8 +13,8 @@ from ralph.backends.data.base import (
     BaseDataBackend,
     BaseDataBackendSettings,
     BaseQuery,
-    BaseSettingsConfig,
 )
+from ralph.conf import BaseSettingsConfig
 from ralph.models.xapi.base.agents import BaseXapiAgent
 from ralph.models.xapi.base.common import IRI
 from ralph.models.xapi.base.groups import BaseXapiGroup
@@ -84,10 +84,11 @@ class RalphStatementsQuery(LRSStatementsQuery):
     ignore_order: Optional[bool]
 
 
-class BaseLRSBackend(BaseDataBackend):
-    """Base LRS backend interface."""
+Settings = TypeVar("Settings", bound=BaseLRSBackendSettings)
 
-    settings_class = BaseLRSBackendSettings
+
+class BaseLRSBackend(BaseDataBackend[Settings, Any]):
+    """Base LRS backend interface."""
 
     @abstractmethod
     def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
@@ -98,10 +99,8 @@ class BaseLRSBackend(BaseDataBackend):
         """Yield statements with matching ids from the backend."""
 
 
-class BaseAsyncLRSBackend(BaseAsyncDataBackend):
+class BaseAsyncLRSBackend(BaseAsyncDataBackend[Settings, Any]):
     """Base async LRS backend interface."""
-
-    settings_class = BaseLRSBackendSettings
 
     @abstractmethod
     async def query_statements(

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Generator, Iterator, List
 
-from ralph.backends.data.base import BaseSettingsConfig
 from ralph.backends.data.clickhouse import (
     ClickHouseDataBackend,
     ClickHouseDataBackendSettings,
@@ -15,6 +14,7 @@ from ralph.backends.lrs.base import (
     RalphStatementsQuery,
     StatementQueryResult,
 )
+from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
 
 logger = logging.getLogger(__name__)
@@ -37,10 +37,10 @@ class ClickHouseLRSBackendSettings(
     IDS_CHUNK_SIZE: int = 10000
 
 
-class ClickHouseLRSBackend(BaseLRSBackend, ClickHouseDataBackend):
+class ClickHouseLRSBackend(
+    BaseLRSBackend[ClickHouseLRSBackendSettings], ClickHouseDataBackend
+):
     """ClickHouse LRS backend implementation."""
-
-    settings_class = ClickHouseLRSBackendSettings
 
     def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""

--- a/src/ralph/backends/lrs/es.py
+++ b/src/ralph/backends/lrs/es.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Iterator, List
 
-from ralph.backends.data.base import BaseSettingsConfig
 from ralph.backends.data.es import (
     ESDataBackend,
     ESDataBackendSettings,
@@ -17,6 +16,7 @@ from ralph.backends.lrs.base import (
     RalphStatementsQuery,
     StatementQueryResult,
 )
+from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
 
 logger = logging.getLogger(__name__)
@@ -31,10 +31,8 @@ class ESLRSBackendSettings(BaseLRSBackendSettings, ESDataBackendSettings):
         env_prefix = "RALPH_BACKENDS__LRS__ES__"
 
 
-class ESLRSBackend(BaseLRSBackend, ESDataBackend):
+class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
     """Elasticsearch LRS backend implementation."""
-
-    settings_class = ESLRSBackendSettings
 
     def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""

--- a/src/ralph/backends/lrs/fs.py
+++ b/src/ralph/backends/lrs/fs.py
@@ -6,7 +6,7 @@ from io import IOBase
 from typing import Iterable, List, Literal, Optional, Union
 from uuid import UUID
 
-from ralph.backends.data.base import BaseOperationType, BaseSettingsConfig
+from ralph.backends.data.base import BaseOperationType
 from ralph.backends.data.fs import FSDataBackend, FSDataBackendSettings
 from ralph.backends.lrs.base import (
     AgentParameters,
@@ -15,6 +15,7 @@ from ralph.backends.lrs.base import (
     RalphStatementsQuery,
     StatementQueryResult,
 )
+from ralph.conf import BaseSettingsConfig
 
 logger = logging.getLogger(__name__)
 
@@ -34,10 +35,8 @@ class FSLRSBackendSettings(BaseLRSBackendSettings, FSDataBackendSettings):
     DEFAULT_LRS_FILE: str = "fs_lrs.jsonl"
 
 
-class FSLRSBackend(BaseLRSBackend, FSDataBackend):
+class FSLRSBackend(BaseLRSBackend[FSLRSBackendSettings], FSDataBackend):
     """FileSystem LRS Backend."""
-
-    settings_class = FSLRSBackendSettings
 
     def write(  # noqa: PLR0913
         self,

--- a/src/ralph/backends/lrs/mongo.py
+++ b/src/ralph/backends/lrs/mongo.py
@@ -6,7 +6,6 @@ from typing import Iterator, List
 from bson.objectid import ObjectId
 from pymongo import ASCENDING, DESCENDING
 
-from ralph.backends.data.base import BaseSettingsConfig
 from ralph.backends.data.mongo import (
     MongoDataBackend,
     MongoDataBackendSettings,
@@ -19,6 +18,7 @@ from ralph.backends.lrs.base import (
     RalphStatementsQuery,
     StatementQueryResult,
 )
+from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
 
 logger = logging.getLogger(__name__)
@@ -33,10 +33,8 @@ class MongoLRSBackendSettings(BaseLRSBackendSettings, MongoDataBackendSettings):
         env_prefix = "RALPH_BACKENDS__LRS__MONGO__"
 
 
-class MongoLRSBackend(BaseLRSBackend, MongoDataBackend):
+class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend):
     """MongoDB LRS backend."""
-
-    settings_class = MongoLRSBackendSettings
 
     def query_statements(self, params: RalphStatementsQuery) -> StatementQueryResult:
         """Return the results of a statements query using xAPI parameters."""


### PR DESCRIPTION
## Purpose

When data backends inherit from `BaseDataBackend`, they alter (specialize) the `__init__` and `read` method signatures with their proper `settings_class` and `query_class` types.
This is intended; however, this leaves a lot of freedom for data backend implementations - (for example, setting the type of `settings_class` to an `int`)

## Proposal

We propose to improve data backend typing using generic types.

- [x] use generic base backend classes.

