### PR TITLE
🔥(project) remove remaining pylint warnings escapes

### DIFF
--- a/src/ralph/backends/lrs/base.py
+++ b/src/ralph/backends/lrs/base.py
@@ -45,8 +45,6 @@ class LRSStatementsQuery(BaseQuery):
     https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md#213-get-statements
     """
 
-    # pylint: disable=too-many-instance-attributes
-
     statement_id: Optional[str] = Field(None, alias="statementId")
     voided_statement_id: Optional[str] = Field(None, alias="voidedStatementId")
     agent: Optional[Union[BaseXapiAgent, BaseXapiGroup]]

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -753,7 +753,6 @@ def write(  # noqa: PLR0913
     **options,
 ):
     """Write an archive to a configured backend."""
-    # pylint: disable=too-many-arguments
     logger.info("Writing to target %s for the configured %s backend", target, backend)
 
     logger.debug("Backend parameters: %s", options)

--- a/tests/backends/lrs/test_async_es.py
+++ b/tests/backends/lrs/test_async_es.py
@@ -17,7 +17,6 @@ from tests.fixtures.backends import ES_TEST_FORWARDING_INDEX, ES_TEST_INDEX
 
 def test_backends_lrs_async_es_lrs_backend_default_instantiation(monkeypatch, fs):
     """Test the `ESLRSBackend` default instantiation."""
-    # pylint: disable=invalid-name
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__ES__DEFAULT_INDEX", raising=False)
     backend = AsyncESLRSBackend()

--- a/tests/backends/lrs/test_async_mongo.py
+++ b/tests/backends/lrs/test_async_mongo.py
@@ -15,7 +15,6 @@ from tests.fixtures.backends import MONGO_TEST_FORWARDING_COLLECTION
 
 def test_backends_lrs_async_mongo_lrs_backend_default_instantiation(monkeypatch, fs):
     """Test the `AsyncMongoLRSBackend` default instantiation."""
-    # pylint: disable=invalid-name
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__MONGO__DEFAULT_COLLECTION", raising=False)
     backend = AsyncMongoLRSBackend()

--- a/tests/backends/lrs/test_clickhouse.py
+++ b/tests/backends/lrs/test_clickhouse.py
@@ -14,7 +14,6 @@ from ralph.exceptions import BackendException
 
 def test_backends_lrs_clickhouse_lrs_backend_default_instantiation(monkeypatch, fs):
     """Test the `ClickHouseLRSBackend` default instantiation."""
-    # pylint: disable=invalid-name
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__CLICKHOUSE__IDS_CHUNK_SIZE", raising=False)
     backend = ClickHouseLRSBackend()

--- a/tests/backends/lrs/test_es.py
+++ b/tests/backends/lrs/test_es.py
@@ -17,7 +17,6 @@ from tests.fixtures.backends import ES_TEST_FORWARDING_INDEX, ES_TEST_INDEX
 
 def test_backends_lrs_es_lrs_backend_default_instantiation(monkeypatch, fs):
     """Test the `ESLRSBackend` default instantiation."""
-    # pylint: disable=invalid-name
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__ES__DEFAULT_INDEX", raising=False)
     backend = ESLRSBackend()

--- a/tests/backends/lrs/test_fs.py
+++ b/tests/backends/lrs/test_fs.py
@@ -8,7 +8,6 @@ from ralph.backends.lrs.fs import FSLRSBackend
 
 def test_backends_lrs_fs_lrs_backend_default_instantiation(monkeypatch, fs):
     """Test the `FSLRSBackend` default instantiation."""
-    # pylint: disable=invalid-name
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__FS__DEFAULT_LRS_FILE", raising=False)
     backend = FSLRSBackend()

--- a/tests/backends/lrs/test_mongo.py
+++ b/tests/backends/lrs/test_mongo.py
@@ -15,7 +15,6 @@ from tests.fixtures.backends import MONGO_TEST_FORWARDING_COLLECTION
 
 def test_backends_lrs_mongo_lrs_backend_default_instantiation(monkeypatch, fs):
     """Test the `MongoLRSBackend` default instantiation."""
-    # pylint: disable=invalid-name
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__MONGO__DEFAULT_COLLECTION", raising=False)
     backend = MongoLRSBackend()

--- a/tests/backends/test_utils_backends/valid_backends.py
+++ b/tests/backends/test_utils_backends/valid_backends.py
@@ -1,6 +1,4 @@
 """A module containing valid Ralph Backends."""
 
-# pylint: disable=unused-import
-
 from ralph.backends.data.fs import FSDataBackend  # noqa: F401
 from ralph.backends.stream.ws import WSStreamBackend  # noqa: F401


### PR DESCRIPTION
## Purpose

Some pylint disables remain in the code, after we switched to Ruff.

## Proposal

Removing them.

