### PR TITLE
✅(api) fix slow tests

### DIFF
--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -716,7 +716,7 @@ async def test_api_statements_get_with_database_query_failure(
 @pytest.mark.anyio
 @pytest.mark.parametrize("id_param", ["statementId", "voidedStatementId"])
 async def test_api_statements_get_invalid_query_parameters(
-    client, basic_auth_credentials, id_param
+    client, monkeypatch, es, basic_auth_credentials, id_param
 ):
     """Test error response for invalid query parameters"""
 
@@ -757,6 +757,9 @@ async def test_api_statements_get_invalid_query_parameters(
                 "extra parameters"
             )
         }
+
+    backend_client_class_path = "ralph.api.routers.statements.BACKEND_CLIENT"
+    monkeypatch.setattr(backend_client_class_path, get_es_test_backend())
 
     # Check for NO 400 status code when statementId is passed with authorized parameters
     for valid_param, value in [("format", "ids"), ("attachments", "true")]:


### PR DESCRIPTION
## Purpose

One test seems to slow down the execution of our test set by 2 minutes **locally**
To reproduce:
`bin/pytest --durations=10 tests/api/`
```
============================================================================= slowest 10 durations ==============================================================================
60.52s call     tests/api/test_statements_get.py::test_api_statements_get_invalid_query_parameters[voidedStatementId]
60.23s call     tests/api/test_statements_get.py::test_api_statements_get_invalid_query_parameters[statementId]
3.37s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_clickhouse_test_backend]
3.11s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_async_es_test_backend]
3.09s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_es_test_backend]
3.07s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_async_mongo_test_backend]
3.05s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_mongo_test_backend]
2.25s call     tests/api/test_statements_post.py::test_api_statements_post_scopes[scopes1-True-basic]
2.17s call     tests/api/test_statements_put.py::test_api_statements_put_scopes[scopes1-True-basic]
2.14s call     tests/api/test_statements_post.py::test_api_statements_post_scopes[scopes0-True-basic]
```

## Proposal


Last part of `test_api_statements_get_invalid_query_parameters` seems to query the LRS but no backend has been set up.
It seems to use `AsyncMongoLRSBackend` and probably wait for mongo to timeout.
Fixing it by setting up the `es` backend as the `BACKEND_CLIENT`

Now if we re-execute:
`bin/pytest --durations=10 tests/api/`
```
============================================================================= slowest 10 durations ==============================================================================
3.35s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_clickhouse_test_backend]
3.10s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_async_es_test_backend]
3.09s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_es_test_backend]
3.05s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_async_mongo_test_backend]
3.05s call     tests/api/test_statements_post.py::test_api_statements_post_list_with_duplicate_of_existing_statement[get_mongo_test_backend]
2.31s call     tests/api/test_statements_put.py::test_api_statements_put_scopes[scopes0-True-basic]
2.14s call     tests/api/test_statements_post.py::test_api_statements_post_scopes[scopes1-True-basic]
2.12s call     tests/api/test_statements_post.py::test_api_statements_post_scopes[scopes0-True-basic]
2.11s call     tests/api/test_statements_put.py::test_api_statements_put_scopes[scopes1-True-basic]
1.94s call     tests/api/test_statements_put.py::test_api_statements_put_single_statement_directly[get_clickhouse_test_backend]
```

