### PR TITLE
🎨(tests) standardize naming for backend tests

### DIFF
--- a/tests/backends/data/test_async_es.py
+++ b/tests/backends/data/test_async_es.py
@@ -31,9 +31,7 @@ from tests.fixtures.backends import (
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_default_instantiation(
-    monkeypatch, fs
-):
+async def test_backends_data_async_es_default_instantiation(monkeypatch, fs):
     """Test the `AsyncESDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -82,7 +80,7 @@ async def test_backends_data_async_es_data_backend_default_instantiation(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_instantiation_with_settings():
+async def test_backends_data_async_es_instantiation_with_settings():
     """Test the `AsyncESDataBackend` instantiation with settings."""
     # Not testing `ca_certs` and `verify_certs` as elasticsearch aiohttp
     # node transport checks that file exists
@@ -120,9 +118,7 @@ async def test_backends_data_async_es_data_backend_instantiation_with_settings()
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_status_method(
-    monkeypatch, async_es_backend, caplog
-):
+async def test_backends_data_async_es_status(monkeypatch, async_es_backend, caplog):
     """Test the `AsyncESDataBackend.status` method."""
 
     async def mock_info():
@@ -196,7 +192,7 @@ async def test_backends_data_async_es_data_backend_status_method(
     ],
 )
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_list_method_with_failure(
+async def test_backends_data_async_es_list_with_failure(
     exception, error, caplog, monkeypatch, async_es_backend
 ):
     """Test the `AsyncESDataBackend.list` method given a failed Elasticsearch connection
@@ -225,7 +221,7 @@ async def test_backends_data_async_es_data_backend_list_method_with_failure(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_list_method_without_history(
+async def test_backends_data_async_es_list_without_history(
     async_es_backend, monkeypatch
 ):
     """Test the `AsyncESDataBackend.list` method without history."""
@@ -247,33 +243,7 @@ async def test_backends_data_async_es_data_backend_list_method_without_history(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_list_method_with_details(
-    async_es_backend, monkeypatch
-):
-    """Test the `AsyncESDataBackend.list` method with `details` set to `True`."""
-    indices = {"index_1": {"info_1": "foo"}, "index_2": {"info_2": "baz"}}
-
-    async def mock_get(index):
-        """Mocks the AsyncES.client.indices.get method returning a dictionary."""
-        assert index == "target_index*"
-        return indices
-
-    backend = async_es_backend()
-    monkeypatch.setattr(backend.client.indices, "get", mock_get)
-    result = [
-        statement async for statement in backend.list("target_index*", details=True)
-    ]
-    assert isinstance(result, Iterable)
-    assert list(result) == [
-        {"index_1": {"info_1": "foo"}},
-        {"index_2": {"info_2": "baz"}},
-    ]
-
-    await backend.close()
-
-
-@pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_list_method_with_history(
+async def test_backends_data_async_es_list_with_history(
     async_es_backend, caplog, monkeypatch
 ):
     """Test the `AsyncESDataBackend.list` method given `new` argument set to True,
@@ -298,6 +268,30 @@ async def test_backends_data_async_es_data_backend_list_method_with_history(
     await backend.close()
 
 
+@pytest.mark.anyio
+async def test_backends_data_async_es_list_with_details(async_es_backend, monkeypatch):
+    """Test the `AsyncESDataBackend.list` method with `details` set to `True`."""
+    indices = {"index_1": {"info_1": "foo"}, "index_2": {"info_2": "baz"}}
+
+    async def mock_get(index):
+        """Mocks the AsyncES.client.indices.get method returning a dictionary."""
+        assert index == "target_index*"
+        return indices
+
+    backend = async_es_backend()
+    monkeypatch.setattr(backend.client.indices, "get", mock_get)
+    result = [
+        statement async for statement in backend.list("target_index*", details=True)
+    ]
+    assert isinstance(result, Iterable)
+    assert list(result) == [
+        {"index_1": {"info_1": "foo"}},
+        {"index_2": {"info_2": "baz"}},
+    ]
+
+    await backend.close()
+
+
 @pytest.mark.parametrize(
     "exception, error",
     [
@@ -306,7 +300,7 @@ async def test_backends_data_async_es_data_backend_list_method_with_history(
     ],
 )
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_read_method_with_failure(  # noqa: PLR0913
+async def test_backends_data_async_es_read_with_failure(  # noqa: PLR0913
     exception, error, es, async_es_backend, caplog, monkeypatch
 ):
     """Test the `AsyncESDataBackend.read` method, given a request failure, should
@@ -358,7 +352,7 @@ async def test_backends_data_async_es_data_backend_read_method_with_failure(  # 
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_read_method_with_ignore_errors(
+async def test_backends_data_async_es_read_with_ignore_errors(
     es, async_es_backend, monkeypatch, caplog
 ):
     """Test the `AsyncESDataBackend.read` method, given `ignore_errors` set to `True`,
@@ -384,9 +378,7 @@ async def test_backends_data_async_es_data_backend_read_method_with_ignore_error
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_read_method_with_raw_ouput(
-    es, async_es_backend
-):
+async def test_backends_data_async_es_read_with_raw_ouput(es, async_es_backend):
     """Test the `AsyncESDataBackend.read` method with `raw_output` set to `True`."""
 
     backend = async_es_backend()
@@ -401,9 +393,7 @@ async def test_backends_data_async_es_data_backend_read_method_with_raw_ouput(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_read_method_without_raw_ouput(
-    es, async_es_backend
-):
+async def test_backends_data_async_es_read_without_raw_ouput(es, async_es_backend):
     """Test the `AsyncESDataBackend.read` method with `raw_output` set to `False`."""
 
     backend = async_es_backend()
@@ -418,9 +408,7 @@ async def test_backends_data_async_es_data_backend_read_method_without_raw_ouput
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_read_method_with_query(
-    es, async_es_backend, caplog
-):
+async def test_backends_data_async_es_read_with_query(es, async_es_backend, caplog):
     """Test the `AsyncESDataBackend.read` method with a query."""
 
     backend = async_es_backend()
@@ -484,7 +472,7 @@ async def test_backends_data_async_es_data_backend_read_method_with_query(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_create_operation(
+async def test_backends_data_async_es_write_with_create_operation(
     es, async_es_backend, caplog
 ):
     """Test the `AsyncESDataBackend.write` method, given an `CREATE` `operation_type`,
@@ -535,7 +523,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_create_oper
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_delete_operation(
+async def test_backends_data_async_es_write_with_delete_operation(
     es,
     async_es_backend,
 ):
@@ -564,7 +552,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_delete_oper
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_update_operation(
+async def test_backends_data_async_es_write_with_update_operation(
     es,
     async_es_backend,
 ):
@@ -611,7 +599,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_update_oper
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_append_operation(
+async def test_backends_data_async_es_write_with_append_operation(
     async_es_backend, caplog
 ):
     """Test the `AsyncESDataBackend.write` method, given an `APPEND` `operation_type`,
@@ -633,9 +621,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_append_oper
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_target(
-    es, async_es_backend
-):
+async def test_backends_data_async_es_write_with_target(es, async_es_backend):
     """Test the `AsyncESDataBackend.write` method, given a target index, should insert
     documents to the corresponding index.
     """
@@ -681,7 +667,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_target(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_without_ignore_errors(
+async def test_backends_data_async_es_write_without_ignore_errors(
     es, async_es_backend, caplog
 ):
     """Test the `AsyncESDataBackend.write` method with `ignore_errors` set to `False`,
@@ -752,7 +738,7 @@ async def test_backends_data_async_es_data_backend_write_method_without_ignore_e
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_ignore_errors(
+async def test_backends_data_async_es_write_with_ignore_errors(
     es, async_es_backend, caplog
 ):
     """Test the `AsyncESDataBackend.write` method with `ignore_errors` set to `True`,
@@ -804,7 +790,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_ignore_erro
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_data_backend_write_method_with_datastream(
+async def test_backends_data_async_es_write_with_datastream(
     es_data_stream, async_es_backend
 ):
     """Test the `AsyncESDataBackend.write` method using a configured data stream."""
@@ -825,9 +811,7 @@ async def test_backends_data_async_es_data_backend_write_method_with_datastream(
 
 
 @pytest.mark.anyio
-async def test_backends_data_es_data_backend_close_method_with_failure(
-    async_es_backend, monkeypatch
-):
+async def test_backends_data_es_close_with_failure(async_es_backend, monkeypatch):
     """Test the `AsyncESDataBackend.close` method."""
 
     backend = async_es_backend()
@@ -843,7 +827,7 @@ async def test_backends_data_es_data_backend_close_method_with_failure(
 
 
 @pytest.mark.anyio
-async def test_backends_data_es_data_backend_close_method(async_es_backend, caplog):
+async def test_backends_data_es_close(async_es_backend, caplog):
     """Test the `AsyncESDataBackend.close` method."""
 
     # No client instantiated

--- a/tests/backends/data/test_async_mongo.py
+++ b/tests/backends/data/test_async_mongo.py
@@ -25,9 +25,7 @@ from tests.fixtures.backends import (
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_default_instantiation(
-    monkeypatch, fs
-):
+async def test_backends_data_async_mongo_default_instantiation(monkeypatch, fs):
     """Test the `AsyncMongoDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -63,7 +61,7 @@ async def test_backends_data_async_mongo_data_backend_default_instantiation(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_instantiation_with_settings(
+async def test_backends_data_async_mongo_instantiation_with_settings(
     async_mongo_backend,
 ):
     """Test the `AsyncMongoDataBackend` instantiation with settings."""
@@ -77,7 +75,7 @@ async def test_backends_data_async_mongo_data_backend_instantiation_with_setting
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_status_with_connection_failure(
+async def test_backends_data_async_mongo_status_with_connection_failure(
     async_mongo_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoDataBackend.status` method, given a connection failure,
@@ -111,7 +109,7 @@ async def test_backends_data_async_mongo_data_backend_status_with_connection_fai
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_status_with_error_status(
+async def test_backends_data_async_mongo_status_with_error_status(
     async_mongo_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoDataBackend.status` method, given a failed serverStatus
@@ -174,7 +172,7 @@ async def test_backends_data_async_mongo_data_backend_status_with_error_status(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_status_with_ok_status(
+async def test_backends_data_async_mongo_status_with_ok_status(
     async_mongo_backend, monkeypatch
 ):
     """Test the `AsyncMongoDataBackend.status` method, given a successful connection
@@ -202,7 +200,7 @@ async def test_backends_data_async_mongo_data_backend_status_with_ok_status(
 
 @pytest.mark.parametrize("invalid_character", [" ", ".", "/", '"'])
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_list_method_with_invalid_target(
+async def test_backends_data_async_mongo_list_with_invalid_target(
     invalid_character, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.list` method given an invalid `target` argument,
@@ -227,7 +225,7 @@ async def test_backends_data_async_mongo_data_backend_list_method_with_invalid_t
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_list_method_with_failure(
+async def test_backends_data_async_mongo_list_with_failure(
     async_mongo_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoDataBackend.list` method given a failure while retrieving
@@ -254,7 +252,7 @@ async def test_backends_data_async_mongo_data_backend_list_method_with_failure(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_list_method_without_history(
+async def test_backends_data_async_mongo_list_without_history(
     mongo, async_mongo_backend, monkeypatch
 ):
     """Test the `AsyncMongoDataBackend.list` method without history."""
@@ -290,7 +288,7 @@ async def test_backends_data_async_mongo_data_backend_list_method_without_histor
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_list_method_with_history(
+async def test_backends_data_async_mongo_list_with_history(
     mongo, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.list` method given `new` argument set to
@@ -312,7 +310,7 @@ async def test_backends_data_async_mongo_data_backend_list_method_with_history(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_with_raw_output(
+async def test_backends_data_async_mongo_read_with_raw_output(
     mongo,
     async_mongo_backend,
 ):
@@ -349,7 +347,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_with_raw_outpu
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_without_raw_output(
+async def test_backends_data_async_mongo_read_without_raw_output(
     mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.read` method with `raw_output` set to
@@ -388,7 +386,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_without_raw_ou
     ],
 )
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_with_invalid_target(
+async def test_backends_data_async_mongo_read_with_invalid_target(
     invalid_target,
     error,
     async_mongo_backend,
@@ -415,7 +413,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_with_invalid_t
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_with_failure(
+async def test_backends_data_async_mongo_read_with_failure(
     async_mongo_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoDataBackend.read` method given an AsyncIOMotorClient failure,
@@ -444,7 +442,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_with_failure(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_with_ignore_errors(
+async def test_backends_data_async_mongo_read_with_ignore_errors(
     mongo, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.read` method with `ignore_errors` set to `True`,
@@ -486,7 +484,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_with_ignore_er
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_without_ignore_errors(
+async def test_backends_data_async_mongo_read_without_ignore_errors(
     mongo, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.read` method with `ignore_errors` set to `False`,
@@ -558,7 +556,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_without_ignore
     ],
 )
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_read_method_with_query(
+async def test_backends_data_async_mongo_read_with_query(
     query, mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.read` method given a query argument."""
@@ -586,7 +584,7 @@ async def test_backends_data_async_mongo_data_backend_read_method_with_query(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_target(
+async def test_backends_data_async_mongo_write_with_target(
     mongo,
     async_mongo_backend,
 ):
@@ -616,7 +614,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_target(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_without_target(
+async def test_backends_data_async_mongo_write_without_target(
     mongo,
     async_mongo_backend,
 ):
@@ -640,7 +638,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_without_targe
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_duplicated_key_error(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_duplicated_key_error(
     mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.write` method, given documents with duplicated
@@ -686,7 +684,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_duplicat
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_delete_operation(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_delete_operation(
     mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.write` method, given a `DELETE` `operation_type`,
@@ -719,7 +717,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_delete_o
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_delete_operation_failure(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_delete_operation_failure(
     mongo, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.write` method with the `DELETE` `operation_type`,
@@ -754,7 +752,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_delete_o
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_update_operation(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_update_operation(
     mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.write` method, given an `UPDATE`
@@ -794,7 +792,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_update_o
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_update_operation_failure(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_update_operation_failure(
     mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.write` method with the `UPDATE` `operation_type`,
@@ -851,7 +849,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_update_o
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_append_operation(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_append_operation(
     async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.write` method, given an `APPEND`
@@ -871,7 +869,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_append_o
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_create_operation(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_create_operation(
     mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.write` method, given an `CREATE`
@@ -901,7 +899,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_create_o
     ],
 )
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_invalid_documents(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_invalid_documents(
     document, error, mongo, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.write` method, given invalid documents, should
@@ -929,7 +927,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_invalid_
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_unparsable_documents(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_unparsable_documents(
     async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.write` method, given unparsable raw documents,
@@ -957,7 +955,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_unparsab
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_no_data(
+async def test_backends_data_async_mongo_write_with_no_data(
     async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.write` method, given no documents, should return
@@ -976,7 +974,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_no_data(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_write_method_with_custom_chunk_size(  # noqa: E501
+async def test_backends_data_async_mongo_write_with_custom_chunk_size(
     mongo, async_mongo_backend, caplog
 ):
     """Test the `AsyncMongoDataBackend.write` method, given a custom chunk_size, should
@@ -1052,7 +1050,7 @@ async def test_backends_data_async_mongo_data_backend_write_method_with_custom_c
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_close_method_with_failure(
+async def test_backends_data_async_mongo_close_with_failure(
     async_mongo_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoDataBackend.close` method, given a failed close,
@@ -1083,7 +1081,7 @@ async def test_backends_data_async_mongo_data_backend_close_method_with_failure(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_mongo_data_backend_close_method(async_mongo_backend):
+async def test_backends_data_async_mongo_close(async_mongo_backend):
     """Test the `AsyncMongoDataBackend.close` method."""
 
     backend = async_mongo_backend()

--- a/tests/backends/data/test_clickhouse.py
+++ b/tests/backends/data/test_clickhouse.py
@@ -26,7 +26,7 @@ from tests.fixtures.backends import (
 )
 
 
-def test_backends_data_clickhouse_data_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_clickhouse_default_instantiation(monkeypatch, fs):
     """Test the `ClickHouseDataBackend` default instantiation."""
     fs.create_file(".env")
     backend_settings_names = [
@@ -64,7 +64,7 @@ def test_backends_data_clickhouse_data_backend_default_instantiation(monkeypatch
     )
 
 
-def test_backends_data_clickhouse_data_backend_instantiation_with_settings():
+def test_backends_data_clickhouse_instantiation_with_settings():
     """Test the `ClickHouseDataBackend` instantiation."""
     settings = ClickHouseDataBackendSettings(
         HOST=CLICKHOUSE_TEST_HOST,
@@ -88,9 +88,7 @@ def test_backends_data_clickhouse_data_backend_instantiation_with_settings():
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_status(
-    clickhouse, clickhouse_backend, monkeypatch
-):
+def test_backends_data_clickhouse_status(clickhouse, clickhouse_backend, monkeypatch):
     """Test the `ClickHouseDataBackend.status` method."""
 
     backend = clickhouse_backend()
@@ -106,9 +104,7 @@ def test_backends_data_clickhouse_data_backend_status(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_read_method_with_raw_output(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_read_with_raw_output(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.read` method."""
 
     # Create records
@@ -144,7 +140,7 @@ def test_backends_data_clickhouse_data_backend_read_method_with_raw_output(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_read_method_with_a_custom_query(
+def test_backends_data_clickhouse_read_with_a_custom_query(
     clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.read` method with a custom query."""
@@ -221,7 +217,7 @@ def test_backends_data_clickhouse_data_backend_read_method_with_a_custom_query(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_read_method_with_failures(
+def test_backends_data_clickhouse_read_with_failures(
     monkeypatch, caplog, clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.read` method with failures."""
@@ -295,9 +291,7 @@ def test_backends_data_clickhouse_data_backend_read_method_with_failures(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_list_method(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_list(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.list` method."""
 
     backend = clickhouse_backend()
@@ -307,7 +301,7 @@ def test_backends_data_clickhouse_data_backend_list_method(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_list_method_with_failure(
+def test_backends_data_clickhouse_list_with_failure(
     monkeypatch, caplog, clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.list` method with a failure."""
@@ -336,7 +330,7 @@ def test_backends_data_clickhouse_data_backend_list_method_with_failure(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_with_invalid_timestamp(
+def test_backends_data_clickhouse_write_with_invalid_timestamp(
     clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.write` method with an invalid timestamp."""
@@ -365,9 +359,7 @@ def test_backends_data_clickhouse_data_backend_write_method_with_invalid_timesta
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_no_timestamp(
-    caplog, clickhouse_backend
-):
+def test_backends_data_clickhouse_write_no_timestamp(caplog, clickhouse_backend):
     """Test the `ClickHouseDataBackend.write` method when a statement has no
     timestamp.
     """
@@ -411,7 +403,7 @@ def test_backends_data_clickhouse_data_backend_write_method_no_timestamp(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_with_duplicated_key(
+def test_backends_data_clickhouse_write_with_duplicated_key(
     clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.write` method with duplicated key
@@ -436,9 +428,7 @@ def test_backends_data_clickhouse_data_backend_write_method_with_duplicated_key(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_chunks_on_error(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_write_chunks_on_error(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.write` method imports partial chunks
     while raising BulkWriteError and ignoring errors.
     """
@@ -460,9 +450,7 @@ def test_backends_data_clickhouse_data_backend_write_method_chunks_on_error(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_write(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.write` method."""
 
     sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
@@ -502,9 +490,7 @@ def test_backends_data_clickhouse_data_backend_write_method(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_bytes(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_write_bytes(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.write` method."""
 
     sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
@@ -549,9 +535,7 @@ def test_backends_data_clickhouse_data_backend_write_method_bytes(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_bytes_failed(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_write_bytes_failed(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.write` method."""
 
     sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
@@ -581,9 +565,7 @@ def test_backends_data_clickhouse_data_backend_write_method_bytes_failed(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_empty(
-    clickhouse, clickhouse_backend
-):
+def test_backends_data_clickhouse_write_empty(clickhouse, clickhouse_backend):
     """Test the `ClickHouseDataBackend.write` method."""
 
     sql = f"""SELECT count(*) FROM {CLICKHOUSE_TEST_TABLE_NAME}"""
@@ -600,7 +582,7 @@ def test_backends_data_clickhouse_data_backend_write_method_empty(
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_wrong_operation_type(
+def test_backends_data_clickhouse_write_wrong_operation_type(
     clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.write` method."""
@@ -627,7 +609,7 @@ def test_backends_data_clickhouse_data_backend_write_method_wrong_operation_type
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_write_method_with_custom_chunk_size(
+def test_backends_data_clickhouse_write_with_custom_chunk_size(
     clickhouse, clickhouse_backend
 ):
     """Test the `ClickHouseDataBackend.write` method with a custom chunk_size."""
@@ -669,9 +651,7 @@ def test_backends_data_clickhouse_data_backend_write_method_with_custom_chunk_si
     backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_close_method_with_failure(
-    clickhouse_backend, monkeypatch
-):
+def test_backends_data_clickhouse_close_with_failure(clickhouse_backend, monkeypatch):
     """Test the `ClickHouseDataBackend.close` method with failure."""
 
     backend = clickhouse_backend()
@@ -686,7 +666,7 @@ def test_backends_data_clickhouse_data_backend_close_method_with_failure(
         backend.close()
 
 
-def test_backends_data_clickhouse_data_backend_close_method(clickhouse_backend, caplog):
+def test_backends_data_clickhouse_close(clickhouse_backend, caplog):
     """Test the `ClickHouseDataBackend.close` method."""
 
     backend = clickhouse_backend()

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -31,7 +31,7 @@ from tests.fixtures.backends import (
 )
 
 
-def test_backends_data_es_data_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_es_default_instantiation(monkeypatch, fs):
     """Test the `ESDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -79,7 +79,7 @@ def test_backends_data_es_data_backend_default_instantiation(monkeypatch, fs):
     assert backend.settings.CLIENT_OPTIONS == ESClientOptions(verify_certs=True)
 
 
-def test_backends_data_es_data_backend_instantiation_with_settings():
+def test_backends_data_es_instantiation_with_settings():
     """Test the `ESDataBackend` instantiation with settings."""
     settings = ESDataBackendSettings(
         ALLOW_YELLOW_STATUS=True,
@@ -118,7 +118,7 @@ def test_backends_data_es_data_backend_instantiation_with_settings():
     backend.close()
 
 
-def test_backends_data_es_data_backend_status_method(monkeypatch, es_backend, caplog):
+def test_backends_data_es_status(monkeypatch, es_backend, caplog):
     """Test the `ESDataBackend.status` method."""
     backend = es_backend()
     with monkeypatch.context() as elasticsearch_patch:
@@ -176,7 +176,7 @@ def test_backends_data_es_data_backend_status_method(monkeypatch, es_backend, ca
         (ESConnectionError(""), "Connection error"),
     ],
 )
-def test_backends_data_es_data_backend_list_method_with_failure(
+def test_backends_data_es_list_with_failure(
     exception, error, caplog, monkeypatch, es_backend
 ):
     """Test the `ESDataBackend.list` method given an failed Elasticsearch connection
@@ -203,9 +203,7 @@ def test_backends_data_es_data_backend_list_method_with_failure(
     backend.close()
 
 
-def test_backends_data_es_data_backend_list_method_without_history(
-    es_backend, monkeypatch
-):
+def test_backends_data_es_list_without_history(es_backend, monkeypatch):
     """Test the `ESDataBackend.list` method without history."""
 
     indices = {"index_1": {"info_1": "foo"}, "index_2": {"info_2": "baz"}}
@@ -224,9 +222,7 @@ def test_backends_data_es_data_backend_list_method_without_history(
     backend.close()
 
 
-def test_backends_data_es_data_backend_list_method_with_details(
-    es_backend, monkeypatch
-):
+def test_backends_data_es_list_with_details(es_backend, monkeypatch):
     """Test the `ESDataBackend.list` method with `details` set to `True`."""
     indices = {"index_1": {"info_1": "foo"}, "index_2": {"info_2": "baz"}}
 
@@ -247,9 +243,7 @@ def test_backends_data_es_data_backend_list_method_with_details(
     backend.close()
 
 
-def test_backends_data_es_data_backend_list_method_with_history(
-    es_backend, caplog, monkeypatch
-):
+def test_backends_data_es_list_with_history(es_backend, caplog, monkeypatch):
     """Test the `ESDataBackend.list` method given `new` argument set to True, should log
     a warning message.
     """
@@ -274,7 +268,7 @@ def test_backends_data_es_data_backend_list_method_with_history(
         (ESConnectionError(""), "Connection error"),
     ],
 )
-def test_backends_data_es_data_backend_read_method_with_failure(  # noqa: PLR0913
+def test_backends_data_es_read_with_failure(  # noqa: PLR0913
     exception, error, es, es_backend, caplog, monkeypatch
 ):
     """Test the `ESDataBackend.read` method, given a request failure, should raise a
@@ -321,9 +315,7 @@ def test_backends_data_es_data_backend_read_method_with_failure(  # noqa: PLR091
     backend.close()
 
 
-def test_backends_data_es_data_backend_read_method_with_ignore_errors(
-    es, es_backend, monkeypatch, caplog
-):
+def test_backends_data_es_read_with_ignore_errors(es, es_backend, monkeypatch, caplog):
     """Test the `ESDataBackend.read` method, given `ignore_errors` set to `True`,
     should log a warning message.
     """
@@ -342,7 +334,7 @@ def test_backends_data_es_data_backend_read_method_with_ignore_errors(
     backend.close()
 
 
-def test_backends_data_es_data_backend_read_method_with_raw_ouput(es, es_backend):
+def test_backends_data_es_read_with_raw_ouput(es, es_backend):
     """Test the `ESDataBackend.read` method with `raw_output` set to `True`."""
 
     backend = es_backend()
@@ -356,7 +348,7 @@ def test_backends_data_es_data_backend_read_method_with_raw_ouput(es, es_backend
     backend.close()
 
 
-def test_backends_data_es_data_backend_read_method_without_raw_ouput(es, es_backend):
+def test_backends_data_es_read_without_raw_ouput(es, es_backend):
     """Test the `ESDataBackend.read` method with `raw_output` set to `False`."""
 
     backend = es_backend()
@@ -370,7 +362,7 @@ def test_backends_data_es_data_backend_read_method_without_raw_ouput(es, es_back
     backend.close()
 
 
-def test_backends_data_es_data_backend_read_method_with_query(es, es_backend, caplog):
+def test_backends_data_es_read_with_query(es, es_backend, caplog):
     """Test the `ESDataBackend.read` method with a query."""
 
     backend = es_backend()
@@ -431,9 +423,7 @@ def test_backends_data_es_data_backend_read_method_with_query(es, es_backend, ca
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_create_operation(
-    es, es_backend, caplog
-):
+def test_backends_data_es_write_with_create_operation(es, es_backend, caplog):
     """Test the `ESDataBackend.write` method, given an `CREATE` `operation_type`,
     should insert the target documents with the provided data.
     """
@@ -479,7 +469,7 @@ def test_backends_data_es_data_backend_write_method_with_create_operation(
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_delete_operation(
+def test_backends_data_es_write_with_delete_operation(
     es,
     es_backend,
 ):
@@ -505,7 +495,7 @@ def test_backends_data_es_data_backend_write_method_with_delete_operation(
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_update_operation(
+def test_backends_data_es_write_with_update_operation(
     es,
     es_backend,
 ):
@@ -550,9 +540,7 @@ def test_backends_data_es_data_backend_write_method_with_update_operation(
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_append_operation(
-    es_backend, caplog
-):
+def test_backends_data_es_write_with_append_operation(es_backend, caplog):
     """Test the `ESDataBackend.write` method, given an `APPEND` `operation_type`,
     should raise a `BackendParameterException`.
     """
@@ -571,7 +559,7 @@ def test_backends_data_es_data_backend_write_method_with_append_operation(
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_target(es, es_backend):
+def test_backends_data_es_write_with_target(es, es_backend):
     """Test the `ESDataBackend.write` method, given a target index, should insert
     documents to the corresponding index.
     """
@@ -605,9 +593,7 @@ def test_backends_data_es_data_backend_write_method_with_target(es, es_backend):
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_without_ignore_errors(
-    es, es_backend, caplog
-):
+def test_backends_data_es_write_without_ignore_errors(es, es_backend, caplog):
     """Test the `ESDataBackend.write` method with `ignore_errors` set to `False`, given
     badly formatted data, should raise a `BackendException`.
     """
@@ -675,7 +661,7 @@ def test_backends_data_es_data_backend_write_method_without_ignore_errors(
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_ignore_errors(es, es_backend):
+def test_backends_data_es_write_with_ignore_errors(es, es_backend):
     """Test the `ESDataBackend.write` method with `ignore_errors` set to `True`, given
     badly formatted data, should should skip the invalid data.
     """
@@ -713,9 +699,7 @@ def test_backends_data_es_data_backend_write_method_with_ignore_errors(es, es_ba
     backend.close()
 
 
-def test_backends_data_es_data_backend_write_method_with_datastream(
-    es_data_stream, es_backend
-):
+def test_backends_data_es_write_with_datastream(es_data_stream, es_backend):
     """Test the `ESDataBackend.write` method using a configured data stream."""
 
     data = [{"id": idx, "@timestamp": datetime.now().isoformat()} for idx in range(10)]
@@ -732,9 +716,7 @@ def test_backends_data_es_data_backend_write_method_with_datastream(
     backend.close()
 
 
-def test_backends_data_es_data_backend_close_method_with_failure(
-    es_backend, monkeypatch
-):
+def test_backends_data_es_close_with_failure(es_backend, monkeypatch):
     """Test the `ESDataBackend.close` method."""
 
     backend = es_backend()
@@ -749,7 +731,7 @@ def test_backends_data_es_data_backend_close_method_with_failure(
         backend.close()
 
 
-def test_backends_data_es_data_backend_close_method(es_backend, caplog):
+def test_backends_data_es_close(es_backend, caplog):
     """Test the `ESDataBackend.close` method."""
 
     backend = es_backend()

--- a/tests/backends/data/test_fs.py
+++ b/tests/backends/data/test_fs.py
@@ -14,7 +14,7 @@ from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import now
 
 
-def test_backends_data_fs_data_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_fs_default_instantiation(monkeypatch, fs):
     """Test the `FSDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -43,7 +43,7 @@ def test_backends_data_fs_data_backend_default_instantiation(monkeypatch, fs):
     assert backend.default_chunk_size == 1
 
 
-def test_backends_data_fs_data_backend_instantiation_with_settings(fs):
+def test_backends_data_fs_instantiation_with_settings(fs):
     """Test the `FSDataBackend` instantiation with settings."""
 
     deep_path = "deep/directories/path"
@@ -72,9 +72,7 @@ def test_backends_data_fs_data_backend_instantiation_with_settings(fs):
     "mode",
     [0o007, 0o100, 0o200, 0o300, 0o400, 0o500, 0o600],
 )
-def test_backends_data_fs_data_backend_status_method_with_error_status(
-    mode, fs_backend, caplog
-):
+def test_backends_data_fs_status_with_error_status(mode, fs_backend, caplog):
     """Test the `FSDataBackend.status` method, given a directory with wrong
     permissions, should return `DataBackendStatus.ERROR`.
     """
@@ -91,7 +89,7 @@ def test_backends_data_fs_data_backend_status_method_with_error_status(
 
 
 @pytest.mark.parametrize("mode", [0o700])
-def test_backends_data_fs_data_backend_status_method_with_ok_status(mode, fs_backend):
+def test_backends_data_fs_status_with_ok_status(mode, fs_backend):
     """Test the `FSDataBackend.status` method, given a directory with right
     permissions, should return `DataBackendStatus.OK`.
     """
@@ -110,7 +108,7 @@ def test_backends_data_fs_data_backend_status_method_with_ok_status(mode, fs_bac
         (["foo/file_1"], "bar", "Invalid target argument', 'No such file or directory"),
     ],
 )
-def test_backends_data_fs_data_backend_list_method_with_invalid_target(
+def test_backends_data_fs_list_with_invalid_target(
     files, target, error, fs_backend, fs
 ):
     """Test the `FSDataBackend.list` method given an invalid `target` argument should
@@ -144,9 +142,7 @@ def test_backends_data_fs_data_backend_list_method_with_invalid_target(
         (["bar/file_1", "bar/file_2"], "/bar", ["/bar/file_1", "/bar/file_2"]),
     ],
 )
-def test_backends_data_fs_data_backend_list_method_without_history(
-    files, target, expected, fs_backend, fs
-):
+def test_backends_data_fs_list_without_history(files, target, expected, fs_backend, fs):
     """Test the `FSDataBackend.list` method without history."""
 
     for file in files:
@@ -177,9 +173,7 @@ def test_backends_data_fs_data_backend_list_method_without_history(
         (["bar/file_1", "bar/file_2"], "/bar", ["/bar/file_1", "/bar/file_2"]),
     ],
 )
-def test_backends_data_fs_data_backend_list_method_with_details(
-    files, target, expected, fs_backend, fs
-):
+def test_backends_data_fs_list_with_details(files, target, expected, fs_backend, fs):
     """Test the `FSDataBackend.list` method with `details` set to `True`."""
 
     for file in files:
@@ -195,7 +189,7 @@ def test_backends_data_fs_data_backend_list_method_with_details(
     ]
 
 
-def test_backends_data_fs_data_backend_list_method_with_history(fs_backend, fs):
+def test_backends_data_fs_list_with_history(fs_backend, fs):
     """Test the `FSDataBackend.list` method with history."""
 
     # Create 3 files in the default directory.
@@ -270,9 +264,7 @@ def test_backends_data_fs_data_backend_list_method_with_history(fs_backend, fs):
     assert sorted(result) == expected
 
 
-def test_backends_data_fs_data_backend_list_method_with_history_and_details(
-    fs_backend, fs
-):
+def test_backends_data_fs_list_with_history_and_details(fs_backend, fs):
     """Test the `FSDataBackend.list` method with an history and detailed output."""
 
     # Create 3 files in the default directory.
@@ -361,9 +353,7 @@ def test_backends_data_fs_data_backend_list_method_with_history_and_details(
     assert sorted(result, key=itemgetter("path")) == expected
 
 
-def test_backends_data_fs_data_backend_read_method_with_raw_ouput(
-    fs_backend, fs, monkeypatch
-):
+def test_backends_data_fs_read_with_raw_ouput(fs_backend, fs, monkeypatch):
     """Test the `FSDataBackend.read` method with `raw_output` set to `True`."""
 
     # Create files in absolute path directory.
@@ -475,9 +465,7 @@ def test_backends_data_fs_data_backend_read_method_with_raw_ouput(
     ]
 
 
-def test_backends_data_fs_data_backend_read_method_without_raw_output(
-    fs_backend, fs, monkeypatch
-):
+def test_backends_data_fs_read_without_raw_output(fs_backend, fs, monkeypatch):
     """Test the `FSDataBackend.read` method with `raw_output` set to `False`."""
 
     # File contents.
@@ -558,7 +546,7 @@ def test_backends_data_fs_data_backend_read_method_without_raw_output(
     ]
 
 
-def test_backends_data_fs_data_backend_read_method_with_ignore_errors(fs_backend, fs):
+def test_backends_data_fs_read_with_ignore_errors(fs_backend, fs):
     """Test the `FSDataBackend.read` method with `ignore_errors` set to `True`, given
     a file containing invalid JSON lines, should skip the invalid lines.
     """
@@ -600,9 +588,7 @@ def test_backends_data_fs_data_backend_read_method_with_ignore_errors(fs_backend
     assert list(result) == [valid_dictionary]
 
 
-def test_backends_data_fs_data_backend_read_method_without_ignore_errors(
-    fs_backend, fs, monkeypatch
-):
+def test_backends_data_fs_read_without_ignore_errors(fs_backend, fs, monkeypatch):
     """Test the `FSDataBackend.read` method with `ignore_errors` set to `False`, given
     a file containing invalid JSON lines, should raise a `BackendException`.
     """
@@ -683,7 +669,7 @@ def test_backends_data_fs_data_backend_read_method_without_ignore_errors(
     assert len(backend.history) == 1
 
 
-def test_backends_data_fs_data_backend_read_method_with_query(fs_backend, fs):
+def test_backends_data_fs_read_with_query(fs_backend, fs):
     """Test the `FSDataBackend.read` method, given a query argument."""
 
     # File contents.
@@ -737,9 +723,7 @@ def test_backends_data_fs_data_backend_read_method_with_query(fs_backend, fs):
 @pytest.mark.parametrize(
     "operation_type", [None, BaseOperationType.CREATE, BaseOperationType.INDEX]
 )
-def test_backends_data_fs_data_backend_write_method_with_file_exists_error(
-    operation_type, fs_backend, fs
-):
+def test_backends_data_fs_write_with_file_exists_error(operation_type, fs_backend, fs):
     """Test the `FSDataBackend.write` method, given a target matching an
     existing file and a `CREATE` or `INDEX` `operation_type`, should raise a
     `BackendException`.
@@ -761,7 +745,7 @@ def test_backends_data_fs_data_backend_write_method_with_file_exists_error(
     assert not sorted(backend.history, key=itemgetter("id"))
 
 
-def test_backends_data_fs_data_backend_write_method_with_delete_operation(
+def test_backends_data_fs_write_with_delete_operation(
     fs_backend,
 ):
     """Test the `FSDataBackend.write` method, given a `DELETE` `operation_type`, should
@@ -778,9 +762,7 @@ def test_backends_data_fs_data_backend_write_method_with_delete_operation(
     assert not sorted(backend.history, key=itemgetter("id"))
 
 
-def test_backends_data_fs_data_backend_write_method_with_update_operation(
-    fs_backend, fs, monkeypatch
-):
+def test_backends_data_fs_write_with_update_operation(fs_backend, fs, monkeypatch):
     """Test the `FSDataBackend.write` method, given an `UPDATE` `operation_type`,
     should overwrite the target file content with the provided data.
     """
@@ -885,7 +867,7 @@ def test_backends_data_fs_data_backend_write_method_with_update_operation(
         ),
     ],
 )
-def test_backends_data_fs_data_backend_write_method_with_append_operation(
+def test_backends_data_fs_write_with_append_operation(
     data, expected, fs_backend, fs, monkeypatch
 ):
     """Test the `FSDataBackend.write` method, given an `APPEND` `operation_type`,
@@ -937,7 +919,7 @@ def test_backends_data_fs_data_backend_write_method_with_append_operation(
     ]
 
 
-def test_backends_data_fs_data_backend_write_method_with_no_data(fs_backend, caplog):
+def test_backends_data_fs_write_with_no_data(fs_backend, caplog):
     """Test the `FSDataBackend.write` method, given no data, should return 0."""
     backend = fs_backend()
     with caplog.at_level(logging.INFO):
@@ -947,9 +929,7 @@ def test_backends_data_fs_data_backend_write_method_with_no_data(fs_backend, cap
     assert ("ralph.backends.data.fs", logging.INFO, msg) in caplog.record_tuples
 
 
-def test_backends_data_fs_data_backend_write_method_without_target(
-    fs_backend, monkeypatch
-):
+def test_backends_data_fs_write_without_target(fs_backend, monkeypatch):
     """Test the `FSDataBackend.write` method, given no `target` argument,
     should create a new random file and write the provided data into it.
     """
@@ -992,7 +972,7 @@ def test_backends_data_fs_data_backend_write_method_without_target(
     ]
 
 
-def test_backends_data_fs_data_backend_close_method(fs_backend):
+def test_backends_data_fs_close(fs_backend):
     """Test that the `FSDataBackend.close` method raise an error."""
 
     backend = fs_backend()

--- a/tests/backends/data/test_ldp.py
+++ b/tests/backends/data/test_ldp.py
@@ -20,7 +20,7 @@ from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import now
 
 
-def test_backends_data_ldp_data_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_ldp_default_instantiation(monkeypatch, fs):
     """Test the `LDPDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -50,7 +50,7 @@ def test_backends_data_ldp_data_backend_default_instantiation(monkeypatch, fs):
     assert backend.service_name == "foo"
 
 
-def test_backends_data_ldp_data_backend_instantiation_with_settings(ldp_backend):
+def test_backends_data_ldp_instantiation_with_settings(ldp_backend):
     """Test the `LDPDataBackend` instantiation with settings."""
     backend = ldp_backend()
     assert isinstance(backend.client, ovh.Client)
@@ -67,7 +67,7 @@ def test_backends_data_ldp_data_backend_instantiation_with_settings(ldp_backend)
     "exception_class",
     [ovh.exceptions.HTTPError, ovh.exceptions.InvalidResponse],
 )
-def test_backends_data_ldp_data_backend_status_method_with_error_status(
+def test_backends_data_ldp_status_with_error_status(
     exception_class, ldp_backend, monkeypatch
 ):
     """Test the `LDPDataBackend.status` method, given a failed request to OVH's archive
@@ -89,9 +89,7 @@ def test_backends_data_ldp_data_backend_status_method_with_error_status(
     assert backend.status() == DataBackendStatus.ERROR
 
 
-def test_backends_data_ldp_data_backend_status_method_with_ok_status(
-    ldp_backend, monkeypatch
-):
+def test_backends_data_ldp_status_with_ok_status(ldp_backend, monkeypatch):
     """Test the `LDPDataBackend.status` method, given a successful request to OVH's
     archive endpoint, the `status` method should return `DataBackendStatus.OK`.
     """
@@ -105,7 +103,7 @@ def test_backends_data_ldp_data_backend_status_method_with_ok_status(
     assert backend.status() == DataBackendStatus.OK
 
 
-def test_backends_data_ldp_data_backend_list_method_with_invalid_target(ldp_backend):
+def test_backends_data_ldp_list_with_invalid_target(ldp_backend):
     """Test the `LDPDataBackend.list` method given no default `stream_id` and no target
     argument should raise a `BackendParameterException`.
     """
@@ -120,9 +118,7 @@ def test_backends_data_ldp_data_backend_list_method_with_invalid_target(ldp_back
     "exception_class",
     [ovh.exceptions.HTTPError, ovh.exceptions.InvalidResponse],
 )
-def test_backends_data_ldp_data_backend_list_method_failure(
-    exception_class, ldp_backend, monkeypatch
-):
+def test_backends_data_ldp_list_failure(exception_class, ldp_backend, monkeypatch):
     """Test the `LDPDataBackend.list` method, given a failed OVH API request should
     raise a `BackendException`.
     """
@@ -155,7 +151,7 @@ def test_backends_data_ldp_data_backend_list_method_failure(
         (["achive_1", "achive_2"], None, "bar"),
     ],
 )
-def test_backends_data_ldp_data_backend_list_method_without_history(
+def test_backends_data_ldp_list_without_history(
     archives, target, expected_stream_id, ldp_backend, monkeypatch
 ):
     """Test the `LDPDataBackend.list` method without history."""
@@ -189,7 +185,7 @@ def test_backends_data_ldp_data_backend_list_method_without_history(
         (["achive_1", "achive_2"], None, "bar"),
     ],
 )
-def test_backends_data_ldp_data_backend_list_method_with_details(
+def test_backends_data_ldp_list_with_details(
     archives, target, expected_stream_id, ldp_backend, monkeypatch
 ):
     """Test the `LDPDataBackend.list` method with `details` set to `True`."""
@@ -227,7 +223,7 @@ def test_backends_data_ldp_data_backend_list_method_with_details(
 
 
 @pytest.mark.parametrize("target,expected_stream_id", [(None, "bar"), ("baz", "baz")])
-def test_backends_data_ldp_data_backend_list_method_with_history(
+def test_backends_data_ldp_list_with_history(
     target, expected_stream_id, ldp_backend, monkeypatch, settings_fs
 ):
     """Test the `LDPDataBackend.list` method with history."""
@@ -306,7 +302,7 @@ def test_backends_data_ldp_data_backend_list_method_with_history(
 
 
 @pytest.mark.parametrize("target,expected_stream_id", [(None, "bar"), ("baz", "baz")])
-def test_backends_data_ldp_data_backend_list_method_with_history_and_details(
+def test_backends_data_ldp_list_with_history_and_details(
     target, expected_stream_id, ldp_backend, monkeypatch, settings_fs
 ):
     """Test the `LDPDataBackend.list` method with a history and detailed output."""
@@ -431,9 +427,7 @@ def test_backends_data_ldp_data_backend_list_method_with_history_and_details(
     assert list(result) == expected
 
 
-def test_backends_data_ldp_data_backend_read_method_without_raw_ouput(
-    ldp_backend, caplog, monkeypatch
-):
+def test_backends_data_ldp_read_without_raw_ouput(ldp_backend, caplog, monkeypatch):
     """Test the `LDPDataBackend.read method, given `raw_output` set to `False`, should
     log a warning message.
     """
@@ -459,9 +453,7 @@ def test_backends_data_ldp_data_backend_read_method_without_raw_ouput(
     ) in caplog.record_tuples
 
 
-def test_backends_data_ldp_data_backend_read_method_without_ignore_errors(
-    ldp_backend, caplog, monkeypatch
-):
+def test_backends_data_ldp_read_without_ignore_errors(ldp_backend, caplog, monkeypatch):
     """Test the `LDPDataBackend.read` method, given `ignore_errors` set to `False`,
     should log a warning message.
     """
@@ -489,7 +481,7 @@ def test_backends_data_ldp_data_backend_read_method_without_ignore_errors(
     ) in caplog.record_tuples
 
 
-def test_backends_data_ldp_data_backend_read_method_with_invalid_query(ldp_backend):
+def test_backends_data_ldp_read_with_invalid_query(ldp_backend):
     """Test the `LDPDataBackend.read` method given an invalid `query` argument should
     raise a `BackendParameterException`.
     """
@@ -500,9 +492,7 @@ def test_backends_data_ldp_data_backend_read_method_with_invalid_query(ldp_backe
         list(backend.read())
 
 
-def test_backends_data_ldp_data_backend_read_method_with_failure(
-    ldp_backend, monkeypatch
-):
+def test_backends_data_ldp_read_with_failure(ldp_backend, monkeypatch):
     """Test the `LDPDataBackend.read` method, given a request failure, should raise a
     `BackendException`.
     """
@@ -554,9 +544,7 @@ def test_backends_data_ldp_data_backend_read_method_with_failure(
         next(backend.read(query="foo"))
 
 
-def test_backends_data_ldp_data_backend_read_method_with_query(
-    ldp_backend, monkeypatch, fs
-):
+def test_backends_data_ldp_read_with_query(ldp_backend, monkeypatch, fs):
     """Test the `LDPDataBackend.read` method, given a query argument."""
 
     # Create fake archive to stream.
@@ -630,7 +618,7 @@ def test_backends_data_ldp_data_backend_read_method_with_query(
         (["baz"], "/dbaas/logs/foo/output/graylog/stream/baz/archive"),
     ],
 )
-def test_backends_data_ldp_data_backend_get_archive_endpoint_method_with_valid_input(
+def test_backends_data_ldp_get_archive_endpoint_with_valid_input(
     ldp_backend, args, expected
 ):
     """Test the `LDPDataBackend.get_archive_endpoint` method, given valid input, should
@@ -643,7 +631,7 @@ def test_backends_data_ldp_data_backend_get_archive_endpoint_method_with_valid_i
 @pytest.mark.parametrize(
     "service_name,stream_id", [(None, "bar"), ("foo", None), (None, None)]
 )
-def test_backends_data_ldp_data_backend_get_archive_endpoint_method_with_invalid_input(
+def test_backends_data_ldp_get_archive_endpoint_with_invalid_input(
     ldp_backend, service_name, stream_id
 ):
     """Test the `LDPDataBackend.get_archive_endpoint` method, given invalid input
@@ -667,7 +655,7 @@ def test_backends_data_ldp_data_backend_get_archive_endpoint_method_with_invalid
         )
 
 
-def test_backends_data_ldp_data_backend_url_method(monkeypatch, ldp_backend):
+def test_backends_data_ldp_url(monkeypatch, ldp_backend):
     """Test the `LDPDataBackend.url` method."""
 
     archive_name = "5d49d1b3-a3eb-498c-9039-6a482166f888"
@@ -690,7 +678,7 @@ def test_backends_data_ldp_data_backend_url_method(monkeypatch, ldp_backend):
     assert backend._url(archive_name) == archive_url
 
 
-def test_backends_data_ldp_data_backend_close_method(ldp_backend, caplog):
+def test_backends_data_ldp_close(ldp_backend, caplog):
     """Test that the `LDPDataBackend.close` method raise an error."""
 
     backend = ldp_backend()

--- a/tests/backends/data/test_mongo.py
+++ b/tests/backends/data/test_mongo.py
@@ -24,7 +24,7 @@ from tests.fixtures.backends import (
 )
 
 
-def test_backends_data_mongo_data_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_mongo_default_instantiation(monkeypatch, fs):
     """Test the `MongoDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -59,7 +59,7 @@ def test_backends_data_mongo_data_backend_default_instantiation(monkeypatch, fs)
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_instantiation_with_settings():
+def test_backends_data_mongo_instantiation_with_settings():
     """Test the `MongoDataBackend` instantiation with settings."""
     settings = MongoDataBackend.settings_class(
         CONNECTION_URI=MONGO_TEST_CONNECTION_URI,
@@ -84,7 +84,7 @@ def test_backends_data_mongo_data_backend_instantiation_with_settings():
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_status_with_connection_failure(
+def test_backends_data_mongo_status_with_connection_failure(
     mongo_backend, monkeypatch, caplog
 ):
     """Test the `MongoDataBackend.status` method, given a connection failure, should
@@ -117,7 +117,7 @@ def test_backends_data_mongo_data_backend_status_with_connection_failure(
     ) in caplog.record_tuples
 
 
-def test_backends_data_mongo_data_backend_status_with_error_status(
+def test_backends_data_mongo_status_with_error_status(
     mongo_backend, monkeypatch, caplog
 ):
     """Test the `MongoDataBackend.status` method, given a failed serverStatus command,
@@ -164,7 +164,7 @@ def test_backends_data_mongo_data_backend_status_with_error_status(
     ) in caplog.record_tuples
 
 
-def test_backends_data_mongo_data_backend_status_with_ok_status(mongo_backend):
+def test_backends_data_mongo_status_with_ok_status(mongo_backend):
     """Test the `MongoDataBackend.status` method, given a successful connection and
     serverStatus command, should return `DataBackendStatus.OK`.
     """
@@ -174,7 +174,7 @@ def test_backends_data_mongo_data_backend_status_with_ok_status(mongo_backend):
 
 
 @pytest.mark.parametrize("invalid_character", [" ", ".", "/", '"'])
-def test_backends_data_mongo_data_backend_list_method_with_invalid_target(
+def test_backends_data_mongo_list_with_invalid_target(
     invalid_character, mongo_backend, caplog
 ):
     """Test the `MongoDataBackend.list` method given an invalid `target` argument,
@@ -193,9 +193,7 @@ def test_backends_data_mongo_data_backend_list_method_with_invalid_target(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_list_method_with_failure(
-    mongo_backend, monkeypatch, caplog
-):
+def test_backends_data_mongo_list_with_failure(mongo_backend, monkeypatch, caplog):
     """Test the `MongoDataBackend.list` method given a failure while retrieving MongoDB
     collections, should raise a `BackendException`.
     """
@@ -215,9 +213,7 @@ def test_backends_data_mongo_data_backend_list_method_with_failure(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_list_method_without_history(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_list_without_history(mongo, mongo_backend):
     """Test the `MongoDataBackend.list` method without history."""
 
     backend = mongo_backend()
@@ -234,9 +230,7 @@ def test_backends_data_mongo_data_backend_list_method_without_history(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_list_method_with_history(
-    mongo_backend, caplog
-):
+def test_backends_data_mongo_list_with_history(mongo_backend, caplog):
     """Test the `MongoDataBackend.list` method given `new` argument set to `True`,
     should log a warning message.
     """
@@ -252,9 +246,7 @@ def test_backends_data_mongo_data_backend_list_method_with_history(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_read_method_with_raw_output(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_read_with_raw_output(mongo, mongo_backend):
     """Test the `MongoDataBackend.read` method with `raw_output` set to `True`."""
 
     backend = mongo_backend()
@@ -277,9 +269,7 @@ def test_backends_data_mongo_data_backend_read_method_with_raw_output(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_read_method_without_raw_output(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_read_without_raw_output(mongo, mongo_backend):
     """Test the `MongoDataBackend.read` method with `raw_output` set to `False`."""
 
     backend = mongo_backend()
@@ -311,7 +301,7 @@ def test_backends_data_mongo_data_backend_read_method_without_raw_output(
         ("foo..bar", "cannot be empty"),
     ],
 )
-def test_backends_data_mongo_data_backend_read_method_with_invalid_target(
+def test_backends_data_mongo_read_with_invalid_target(
     invalid_target, error, mongo_backend, caplog
 ):
     """Test the `MongoDataBackend.read` method given an invalid `target` argument,
@@ -330,9 +320,7 @@ def test_backends_data_mongo_data_backend_read_method_with_invalid_target(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_read_method_with_failure(
-    mongo_backend, monkeypatch, caplog
-):
+def test_backends_data_mongo_read_with_failure(mongo_backend, monkeypatch, caplog):
     """Test the `MongoDataBackend.read` method given a MongoClient failure,
     should raise a `BackendException`.
     """
@@ -354,9 +342,7 @@ def test_backends_data_mongo_data_backend_read_method_with_failure(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_read_method_with_ignore_errors(
-    mongo, mongo_backend, caplog
-):
+def test_backends_data_mongo_read_with_ignore_errors(mongo, mongo_backend, caplog):
     """Test the `MongoDataBackend.read` method with `ignore_errors` set to `True`, given
     a collection containing unparsable documents, should skip the invalid documents.
     """
@@ -389,9 +375,7 @@ def test_backends_data_mongo_data_backend_read_method_with_ignore_errors(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_read_method_without_ignore_errors(
-    mongo, mongo_backend, caplog
-):
+def test_backends_data_mongo_read_without_ignore_errors(mongo, mongo_backend, caplog):
     """Test the `MongoDataBackend.read` method with `ignore_errors` set to `False`,
     given a collection containing unparsable documents, should raise a
     `BackendException`.
@@ -452,9 +436,7 @@ def test_backends_data_mongo_data_backend_read_method_without_ignore_errors(
         MongoQuery(filter={"id": {"$eq": "bar"}}, projection={"id": 1}),
     ],
 )
-def test_backends_data_mongo_data_backend_read_method_with_query(
-    query, mongo, mongo_backend
-):
+def test_backends_data_mongo_read_with_query(query, mongo, mongo_backend):
     """Test the `MongoDataBackend.read` method given a query argument."""
 
     # Create records
@@ -475,9 +457,7 @@ def test_backends_data_mongo_data_backend_read_method_with_query(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_target(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_write_with_target(mongo, mongo_backend):
     """Test the `MongoDataBackend.write` method, given a valid `target` argument, should
     write documents to the target collection.
     """
@@ -502,9 +482,7 @@ def test_backends_data_mongo_data_backend_write_method_with_target(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_without_target(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_write_without_target(mongo, mongo_backend):
     """Test the `MongoDataBackend.write` method, given a no `target` argument, should
     write documents to the default collection.
     """
@@ -525,7 +503,7 @@ def test_backends_data_mongo_data_backend_write_method_without_target(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_duplicated_key_error(
+def test_backends_data_mongo_write_with_duplicated_key_error(
     mongo, mongo_backend, caplog
 ):
     """Test the `MongoDataBackend.write` method, given documents with duplicated ids,
@@ -579,9 +557,7 @@ def test_backends_data_mongo_data_backend_write_method_with_duplicated_key_error
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_delete_operation(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_write_with_delete_operation(mongo, mongo_backend):
     """Test the `MongoDataBackend.write` method, given a `DELETE` `operation_type`,
     should delete the provided documents from the MongoDB collection.
     """
@@ -607,7 +583,7 @@ def test_backends_data_mongo_data_backend_write_method_with_delete_operation(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_delete_operation_failure(
+def test_backends_data_mongo_write_with_delete_operation_failure(
     mongo, mongo_backend, caplog
 ):
     """Test the `MongoDataBackend.write` method with the `DELETE` `operation_type`,
@@ -641,9 +617,7 @@ def test_backends_data_mongo_data_backend_write_method_with_delete_operation_fai
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_update_operation(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_write_with_update_operation(mongo, mongo_backend):
     """Test the `MongoDataBackend.write` method, given an `UPDATE` `operation_type`,
     should update the provided documents from the MongoDB collection.
     """
@@ -678,7 +652,7 @@ def test_backends_data_mongo_data_backend_write_method_with_update_operation(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_update_operation_failure(
+def test_backends_data_mongo_write_with_update_operation_failure(
     mongo, mongo_backend, caplog
 ):
     """Test the `MongoDataBackend.write` method with the `UPDATE` `operation_type`,
@@ -736,9 +710,7 @@ def test_backends_data_mongo_data_backend_write_method_with_update_operation_fai
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_append_operation(
-    mongo_backend, caplog
-):
+def test_backends_data_mongo_write_with_append_operation(mongo_backend, caplog):
     """Test the `MongoDataBackend.write` method, given an `APPEND` `operation_type`,
     should raise a `BackendParameterException`.
     """
@@ -752,9 +724,7 @@ def test_backends_data_mongo_data_backend_write_method_with_append_operation(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_create_operation(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_write_with_create_operation(mongo, mongo_backend):
     """Test the `MongoDataBackend.write` method, given an `CREATE` `operation_type`,
     should insert the provided documents to the MongoDB collection.
     """
@@ -782,7 +752,7 @@ def test_backends_data_mongo_data_backend_write_method_with_create_operation(
         ),
     ],
 )
-def test_backends_data_mongo_data_backend_write_method_with_invalid_documents(
+def test_backends_data_mongo_write_with_invalid_documents(
     document, error, mongo, mongo_backend, caplog
 ):
     """Test the `MongoDataBackend.write` method, given invalid documents, should raise a
@@ -808,9 +778,7 @@ def test_backends_data_mongo_data_backend_write_method_with_invalid_documents(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_unparsable_documents(
-    mongo_backend, caplog
-):
+def test_backends_data_mongo_write_with_unparsable_documents(mongo_backend, caplog):
     """Test the `MongoDataBackend.write` method, given unparsable raw documents, should
     raise a `BackendException`.
     """
@@ -833,9 +801,7 @@ def test_backends_data_mongo_data_backend_write_method_with_unparsable_documents
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_no_data(
-    mongo_backend, caplog
-):
+def test_backends_data_mongo_write_with_no_data(mongo_backend, caplog):
     """Test the `MongoDataBackend.write` method, given no documents, should return 0."""
     backend = mongo_backend()
     with caplog.at_level(logging.INFO):
@@ -846,9 +812,7 @@ def test_backends_data_mongo_data_backend_write_method_with_no_data(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_write_method_with_custom_chunk_size(
-    mongo, mongo_backend
-):
+def test_backends_data_mongo_write_with_custom_chunk_size(mongo, mongo_backend):
     """Test the `MongoDataBackend.write` method, given a custom chunk_size, should
     insert the provided documents to target collection by batches of size `chunk_size`.
     """
@@ -904,9 +868,7 @@ def test_backends_data_mongo_data_backend_write_method_with_custom_chunk_size(
     backend.close()
 
 
-def test_backends_data_mongo_data_backend_close_method_with_failure(
-    mongo_backend, monkeypatch
-):
+def test_backends_data_mongo_close_with_failure(mongo_backend, monkeypatch):
     """Test the `MongoDataBackend.close` method."""
 
     backend = mongo_backend()
@@ -921,7 +883,7 @@ def test_backends_data_mongo_data_backend_close_method_with_failure(
         backend.close()
 
 
-def test_backends_data_mongo_data_backend_close_method(mongo_backend):
+def test_backends_data_mongo_close(mongo_backend):
     """Test the `MongoDataBackend.close` method."""
 
     backend = mongo_backend()

--- a/tests/backends/data/test_s3.py
+++ b/tests/backends/data/test_s3.py
@@ -14,7 +14,7 @@ from ralph.backends.data.s3 import S3DataBackend, S3DataBackendSettings
 from ralph.exceptions import BackendException, BackendParameterException
 
 
-def test_backends_data_s3_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_s3_default_instantiation(monkeypatch, fs):
     """Test the `S3DataBackend` default instantiation."""
     fs.create_file(".env")
     backend_settings_names = [
@@ -45,7 +45,7 @@ def test_backends_data_s3_backend_default_instantiation(monkeypatch, fs):
     assert backend.default_chunk_size == 1
 
 
-def test_backends_data_s3_data_backend_instantiation_with_settings():
+def test_backends_data_s3_instantiation_with_settings():
     """Test the `S3DataBackend` instantiation with settings."""
     settings_ = S3DataBackend.settings_class(
         ACCESS_KEY_ID="access_key",
@@ -69,7 +69,7 @@ def test_backends_data_s3_data_backend_instantiation_with_settings():
 
 
 @mock_s3
-def test_backends_data_s3_data_backend_status_method(s3_backend):
+def test_backends_data_s3_status(s3_backend):
     """Test the `S3DataBackend.status` method."""
 
     # Regions outside of us-east-1 require the appropriate LocationConstraint
@@ -88,7 +88,7 @@ def test_backends_data_s3_data_backend_status_method(s3_backend):
 
 
 @mock_s3
-def test_backends_data_s3_data_backend_list_should_yield_archive_names(
+def test_backends_data_s3_list_should_yield_archive_names(
     s3_backend,
 ):
     """Test that given `S3DataBackend.list` method successfully connects to the S3
@@ -449,7 +449,7 @@ def test_backends_data_s3_read_with_iter_error_should_log_the_error(
     [None, BaseOperationType.CREATE, BaseOperationType.INDEX],
 )
 @mock_s3
-def test_backends_data_s3_write_method_with_parameter_error(
+def test_backends_data_s3_write_with_parameter_error(
     operation_type, s3_backend, caplog
 ):
     """Test the `S3DataBackend.write` method, given a target matching an
@@ -495,7 +495,7 @@ def test_backends_data_s3_write_method_with_parameter_error(
     "operation_type",
     [BaseOperationType.APPEND, BaseOperationType.DELETE],
 )
-def test_backends_data_s3_data_backend_write_method_with_append_or_delete_operation(
+def test_backends_data_s3_write_with_append_or_delete_operation(
     s3_backend, operation_type
 ):
     """Test the `S3DataBackend.write` method, given an `APPEND`
@@ -516,7 +516,7 @@ def test_backends_data_s3_data_backend_write_method_with_append_or_delete_operat
     [BaseOperationType.CREATE, BaseOperationType.INDEX],
 )
 @mock_s3
-def test_backends_data_s3_write_method_with_create_index_operation(
+def test_backends_data_s3_write_with_create_index_operation(
     operation_type, s3_backend, monkeypatch, caplog
 ):
     """Test the `S3DataBackend.write` method, given a target matching an
@@ -620,7 +620,7 @@ def test_backends_data_s3_write_method_with_create_index_operation(
 
 
 @mock_s3
-def test_backends_data_s3_write_method_with_no_data_should_skip(
+def test_backends_data_s3_write_with_no_data_should_skip(
     s3_backend,
 ):
     """Test the `S3DataBackend.write` method, given no data to write,
@@ -645,7 +645,7 @@ def test_backends_data_s3_write_method_with_no_data_should_skip(
 
 
 @mock_s3
-def test_backends_data_s3_write_method_with_failure_should_log_the_error(
+def test_backends_data_s3_write_with_failure_should_log_the_error(
     s3_backend,
 ):
     """Test the `S3DataBackend.write` method, given a connection failure,
@@ -676,9 +676,7 @@ def test_backends_data_s3_write_method_with_failure_should_log_the_error(
     backend.close()
 
 
-def test_backends_data_s3_data_backend_close_method_with_failure(
-    s3_backend, monkeypatch
-):
+def test_backends_data_s3_close_with_failure(s3_backend, monkeypatch):
     """Test the `S3DataBackend.close` method."""
 
     backend = s3_backend()
@@ -694,7 +692,7 @@ def test_backends_data_s3_data_backend_close_method_with_failure(
 
 
 @mock_s3
-def test_backends_data_s3_data_backend_close_method(s3_backend, caplog):
+def test_backends_data_s3_close(s3_backend, caplog):
     """Test the `S3DataBackend.close` method."""
 
     # No client instantiated

--- a/tests/backends/data/test_swift.py
+++ b/tests/backends/data/test_swift.py
@@ -17,7 +17,7 @@ from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import now
 
 
-def test_backends_data_swift_data_backend_default_instantiation(monkeypatch, fs):
+def test_backends_data_swift_default_instantiation(monkeypatch, fs):
     """Test the `SwiftDataBackend` default instantiation."""
 
     fs.create_file(".env")
@@ -59,7 +59,7 @@ def test_backends_data_swift_data_backend_default_instantiation(monkeypatch, fs)
     backend.close()
 
 
-def test_backends_data_swift_data_backend_instantiation_with_settings(fs):
+def test_backends_data_swift_instantiation_with_settings(fs):
     """Test the `SwiftDataBackend` instantiation with settings."""
 
     fs.create_file(".env")
@@ -94,7 +94,7 @@ def test_backends_data_swift_data_backend_instantiation_with_settings(fs):
     backend.close()
 
 
-def test_backends_data_swift_data_backend_status_method_with_error_status(
+def test_backends_data_swift_status_with_error_status(
     monkeypatch, swift_backend, caplog
 ):
     """Test the `SwiftDataBackend.status` method, given a failed connection,
@@ -121,9 +121,7 @@ def test_backends_data_swift_data_backend_status_method_with_error_status(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_status_method_with_ok_status(
-    monkeypatch, swift_backend, caplog
-):
+def test_backends_data_swift_status_with_ok_status(monkeypatch, swift_backend, caplog):
     """Test the `SwiftDataBackend.status` method, given a directory with wrong
     permissions, should return `DataBackendStatus.OK`.
     """
@@ -143,9 +141,7 @@ def test_backends_data_swift_data_backend_status_method_with_ok_status(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_list_method(
-    swift_backend, monkeypatch, fs, settings_fs
-):
+def test_backends_data_swift_list(swift_backend, monkeypatch, fs, settings_fs):
     """Test that the `SwiftDataBackend.list` method argument should list
     the default container.
     """
@@ -201,7 +197,7 @@ def test_backends_data_swift_data_backend_list_method(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_list_with_failed_details(
+def test_backends_data_swift_list_with_failed_details(
     swift_backend, monkeypatch, fs, caplog, settings_fs
 ):
     """Test that the `SwiftDataBackend.list` method with a failed connection
@@ -240,7 +236,7 @@ def test_backends_data_swift_data_backend_list_with_failed_details(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_list_with_failed_connection(
+def test_backends_data_swift_list_with_failed_connection(
     swift_backend, monkeypatch, fs, caplog, settings_fs
 ):
     """Test that the `SwiftDataBackend.list` method with a failed connection
@@ -269,7 +265,7 @@ def test_backends_data_swift_data_backend_list_with_failed_connection(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_read_method_with_raw_output(
+def test_backends_data_swift_read_with_raw_output(
     swift_backend, monkeypatch, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.read` method with `raw_output` set to `True`."""
@@ -330,7 +326,7 @@ def test_backends_data_swift_data_backend_read_method_with_raw_output(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_read_method_without_raw_output(
+def test_backends_data_swift_read_without_raw_output(
     swift_backend, monkeypatch, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.read` method with `raw_output` set to `False`."""
@@ -369,7 +365,7 @@ def test_backends_data_swift_data_backend_read_method_without_raw_output(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_read_method_with_invalid_query(swift_backend):
+def test_backends_data_swift_read_with_invalid_query(swift_backend):
     """Test the `SwiftDataBackend.read` method given an invalid `query` argument should
     raise a `BackendParameterException`.
     """
@@ -381,7 +377,7 @@ def test_backends_data_swift_data_backend_read_method_with_invalid_query(swift_b
     backend.close()
 
 
-def test_backends_data_swift_data_backend_read_method_with_ignore_errors(
+def test_backends_data_swift_read_with_ignore_errors(
     monkeypatch, swift_backend, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.read` method with `ignore_errors` set to `True`,
@@ -427,7 +423,7 @@ def test_backends_data_swift_data_backend_read_method_with_ignore_errors(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_read_method_without_ignore_errors(
+def test_backends_data_swift_read_without_ignore_errors(
     monkeypatch, swift_backend, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.read` method with `ignore_errors` set to `False`,
@@ -483,7 +479,7 @@ def test_backends_data_swift_data_backend_read_method_without_ignore_errors(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_read_method_with_failed_connection(
+def test_backends_data_swift_read_with_failed_connection(
     caplog, monkeypatch, swift_backend
 ):
     """Test the `SwiftDataBackend.read` method, given a `ClientException` raised by
@@ -510,7 +506,7 @@ def test_backends_data_swift_data_backend_read_method_with_failed_connection(
 @pytest.mark.parametrize(
     "operation_type", [None, BaseOperationType.CREATE, BaseOperationType.INDEX]
 )
-def test_backends_data_swift_data_backend_write_method_with_file_exists_error(
+def test_backends_data_swift_write_with_file_exists_error(
     operation_type, swift_backend, monkeypatch, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.write` method, given a target matching an
@@ -541,7 +537,7 @@ def test_backends_data_swift_data_backend_write_method_with_file_exists_error(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_write_method_with_failed_connection(
+def test_backends_data_swift_write_with_failed_connection(
     monkeypatch, swift_backend, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.write` method, given a failed connection, should
@@ -581,7 +577,7 @@ def test_backends_data_swift_data_backend_write_method_with_failed_connection(
         BaseOperationType.UPDATE,
     ],
 )
-def test_backends_data_swift_data_backend_write_method_with_invalid_operation(
+def test_backends_data_swift_write_with_invalid_operation(
     operation_type,
     swift_backend,
     fs,
@@ -601,7 +597,7 @@ def test_backends_data_swift_data_backend_write_method_with_invalid_operation(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_write_method_without_target(
+def test_backends_data_swift_write_without_target(
     swift_backend, monkeypatch, fs, settings_fs
 ):
     """Test the `SwiftDataBackend.write` method, given no target, should write
@@ -657,9 +653,7 @@ def test_backends_data_swift_data_backend_write_method_without_target(
     backend.close()
 
 
-def test_backends_data_swift_data_backend_close_method_with_failure(
-    swift_backend, monkeypatch
-):
+def test_backends_data_swift_close_with_failure(swift_backend, monkeypatch):
     """Test the `SwiftDataBackend.close` method."""
 
     backend = swift_backend()
@@ -674,7 +668,7 @@ def test_backends_data_swift_data_backend_close_method_with_failure(
         backend.close()
 
 
-def test_backends_data_swift_data_backend_close_method(swift_backend, caplog):
+def test_backends_data_swift_close(swift_backend, caplog):
     """Test the `SwiftDataBackend.close` method."""
 
     backend = swift_backend()

--- a/tests/backends/http/test_async_lrs.py
+++ b/tests/backends/http/test_async_lrs.py
@@ -34,7 +34,7 @@ async def _unpack_async_generator(async_gen):
     return result
 
 
-def test_backend_http_lrs_default_instantiation(monkeypatch, fs):
+def test_backends_http_async_lrs_default_instantiation(monkeypatch, fs):
     """Test the `LRSHTTPBackend` default instantiation."""
     fs.create_file(".env")
     backend_settings_names = [
@@ -64,7 +64,7 @@ def test_backend_http_lrs_default_instantiation(monkeypatch, fs):
     assert backend.auth == ("foo", "secret")
 
 
-def test_backends_http_lrs_http_instantiation():
+def test_backends_http_async_lrs_instantiation():
     """Test the LRS backend default instantiation."""
 
     headers = LRSHeaders(
@@ -92,7 +92,7 @@ def test_backends_http_lrs_http_instantiation():
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_status_with_successful_request(
+async def test_backends_http_async_lrs_status_with_successful_request(
     httpx_mock: HTTPXMock,
 ):
     """Test the LRS backend status method returns `OK` when the request is
@@ -119,7 +119,7 @@ async def test_backends_http_lrs_status_with_successful_request(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_status_with_request_error(
+async def test_backends_http_async_lrs_status_with_request_error(
     httpx_mock: HTTPXMock, caplog
 ):
     """Test the LRS backend status method returns `AWAY` when a `RequestError`
@@ -151,7 +151,7 @@ async def test_backends_http_lrs_status_with_request_error(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_status_with_http_status_error(
+async def test_backends_http_async_lrs_status_with_http_status_error(
     httpx_mock: HTTPXMock, caplog
 ):
     """Test the LRS backend status method returns `ERROR` when an `HTTPStatusError`
@@ -185,7 +185,7 @@ async def test_backends_http_lrs_status_with_http_status_error(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_list(caplog):
+async def test_backends_http_async_lrs_list(caplog):
     """Test the LRS backend `list` method raises a `NotImplementedError`."""
 
     base_url = "http://fake-lrs.com"
@@ -218,7 +218,7 @@ async def test_backends_http_lrs_list(caplog):
 
 @pytest.mark.parametrize("max_statements", [None, 2, 4, 8])
 @pytest.mark.anyio
-async def test_backends_http_lrs_read_max_statements(
+async def test_backends_http_async_lrs_read_max_statements(
     httpx_mock: HTTPXMock, max_statements: int
 ):
     """Test the LRS backend `read` method `max_statements` property."""
@@ -291,7 +291,7 @@ async def test_backends_http_lrs_read_max_statements(
 
 @pytest.mark.parametrize("greedy", [False, True])
 @pytest.mark.anyio
-async def test_backends_http_lrs_read_without_target(
+async def test_backends_http_async_lrs_read_without_target(
     httpx_mock: HTTPXMock, greedy: bool
 ):
     """Test that the LRS backend `read` method without target parameter value fetches
@@ -333,7 +333,7 @@ async def test_backends_http_lrs_read_without_target(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("greedy", [False, True])
-async def test_backends_http_lrs_read_backend_error(
+async def test_backends_http_async_lrs_read_backend_error(
     httpx_mock: HTTPXMock, caplog, greedy: bool
 ):
     """Test the LRS backend `read` method raises a `BackendException` when the server
@@ -380,7 +380,7 @@ async def test_backends_http_lrs_read_backend_error(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("greedy", [False, True])
-async def test_backends_http_lrs_read_without_pagination(
+async def test_backends_http_async_lrs_read_without_pagination(
     httpx_mock: HTTPXMock, greedy: bool
 ):
     """Test the LRS backend `read` method when the request on the target endpoint
@@ -479,7 +479,7 @@ async def test_backends_http_lrs_read_without_pagination(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_read_with_pagination(httpx_mock: HTTPXMock):
+async def test_backends_http_async_lrs_read_with_pagination(httpx_mock: HTTPXMock):
     """Test the LRS backend `read` method when the request on the target endpoint
     returns statements with pagination."""
 
@@ -641,7 +641,7 @@ async def test_backends_http_lrs_read_with_pagination(httpx_mock: HTTPXMock):
         (2, True, None),
     ],
 )
-async def test_backends_http_lrs_write_without_operation(
+async def test_backends_http_async_lrs_write_without_operation(
     httpx_mock: HTTPXMock, caplog, chunk_size, simultaneous, max_num_simultaneous
 ):
     """Test the LRS backend `write` method, given no operation_type should POST to
@@ -689,7 +689,7 @@ async def test_backends_http_lrs_write_without_operation(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_without_data(caplog):
+async def test_backends_http_async_lrs_write_without_data(caplog):
     """Test the LRS backend `write` method returns null when no data to write
     in the target endpoint are given.
     """
@@ -725,7 +725,7 @@ async def test_backends_http_lrs_write_without_data(caplog):
     ],
 )
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_with_unsupported_operation(
+async def test_backends_http_async_lrs_write_with_unsupported_operation(
     operation_type, caplog, error_msg
 ):
     """Test the LRS backend `write` method, given an unsupported` `operation_type`,
@@ -763,7 +763,7 @@ async def test_backends_http_lrs_write_with_unsupported_operation(
     ],
 )
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_with_invalid_parameters(
+async def test_backends_https_async_lrs_write_with_invalid_parameters(
     caplog, simultaneous, max_num_simultaneous, error_msg
 ):
     """Test the LRS backend `write` method, given invalid_parameters
@@ -797,7 +797,9 @@ async def test_backends_http_lrs_write_with_invalid_parameters(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_without_target(httpx_mock: HTTPXMock, caplog):
+async def test_backends_https_async_lrs_write_without_target(
+    httpx_mock: HTTPXMock, caplog
+):
     """Test the LRS backend `write` method without target parameter value writes
     statements to '/xAPI/statements' default endpoint.
     """
@@ -834,7 +836,7 @@ async def test_backends_http_lrs_write_without_target(httpx_mock: HTTPXMock, cap
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_with_create_or_index_operation(
+async def test_backends_https_async_lrs_write_with_create_or_index_operation(
     httpx_mock: HTTPXMock, caplog
 ):
     """Test the `LRSHTTP.write` method with `CREATE` or `INDEX` operation_type writes
@@ -870,7 +872,7 @@ async def test_backends_http_lrs_write_with_create_or_index_operation(
 
 
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_backend_exception(
+async def test_backends_https_async_lrs_write_backend_exception(
     httpx_mock: HTTPXMock,
     caplog,
 ):
@@ -909,7 +911,7 @@ async def test_backends_http_lrs_write_backend_exception(
 @pytest.mark.parametrize(
     "num_pages,chunk_size,network_latency_time", [(3, 3, 0.2), (10, 3, 0.2)]
 )
-async def test_backends_http_lrs_read_concurrency(
+async def test_backends_https_async_lrs_read_concurrency(
     httpx_mock: HTTPXMock, num_pages, chunk_size, network_latency_time
 ):
     """Test concurrency performances in `read`, for development use.
@@ -1004,7 +1006,7 @@ async def test_backends_http_lrs_read_concurrency(
 
 @pytest.mark.skip(reason="Timing based tests are too unstable to run in CI")
 @pytest.mark.anyio
-async def test_backends_http_lrs_write_concurrency(
+async def test_backends_https_async_lrs_write_concurrency(
     httpx_mock: HTTPXMock,
 ):
     """Test concurrency performances in `write`, for development use."""

--- a/tests/backends/http/test_lrs.py
+++ b/tests/backends/http/test_lrs.py
@@ -19,7 +19,7 @@ from ralph.backends.lrs.base import LRSStatementsQuery
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("method", ["status", "list", "write", "read"])
-async def test_backend_http_lrs_in_async_setting(monkeypatch, method):
+async def test_backends_http_lrs_in_async_setting(monkeypatch, method):
     """Test that backend returns the proper error when run in async function."""
 
     # Define mock responses
@@ -59,7 +59,7 @@ async def test_backend_http_lrs_in_async_setting(monkeypatch, method):
 
 
 @pytest.mark.anyio
-def test_backend_http_lrs_default_instantiation(monkeypatch, fs):
+def test_backends_http_lrs_default_instantiation(monkeypatch, fs):
     """Test the `LRSHTTPBackend` default instantiation."""
     fs.create_file(".env")
     backend_settings_names = [
@@ -89,7 +89,7 @@ def test_backend_http_lrs_default_instantiation(monkeypatch, fs):
     assert backend.auth == ("foo", "secret")
 
 
-def test_backends_http_lrs_http_instantiation():
+def test_backends_http_lrs_instantiation_with_settings():
     """Test the LRS backend default instantiation."""
 
     headers = LRSHeaders(

--- a/tests/backends/lrs/test_async_es.py
+++ b/tests/backends/lrs/test_async_es.py
@@ -15,7 +15,7 @@ from ralph.exceptions import BackendException
 from tests.fixtures.backends import ES_TEST_FORWARDING_INDEX, ES_TEST_INDEX
 
 
-def test_backends_lrs_async_es_lrs_backend_default_instantiation(monkeypatch, fs):
+def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
     """Test the `ESLRSBackend` default instantiation."""
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__ES__DEFAULT_INDEX", raising=False)
@@ -267,7 +267,7 @@ def test_backends_lrs_async_es_lrs_backend_default_instantiation(monkeypatch, fs
     ],
 )
 @pytest.mark.anyio
-async def test_backends_lrs_async_es_lrs_backend_query_statements_query(
+async def test_backends_lrs_async_es_query_statements_query(
     params, expected_query, async_es_lrs_backend, monkeypatch
 ):
     """Test the `AsyncESLRSBackend.query_statements` method, given valid statement
@@ -293,9 +293,7 @@ async def test_backends_lrs_async_es_lrs_backend_query_statements_query(
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_async_es_lrs_backend_query_statements(
-    es, async_es_lrs_backend
-):
+async def test_backends_lrs_async_es_query_statements(es, async_es_lrs_backend):
     """Test the `AsyncESLRSBackend.query_statements` method, given a query,
     should return matching statements.
     """
@@ -315,7 +313,7 @@ async def test_backends_lrs_async_es_lrs_backend_query_statements(
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_async_es_lrs_backend_query_statements_pit_query_failure(
+async def test_backends_lrs_async_es_query_statements_pit_query_failure(
     es, async_es_lrs_backend, monkeypatch, caplog
 ):
     """Test the `AsyncESLRSBackend.query_statements` method, given a point in time
@@ -345,7 +343,7 @@ async def test_backends_lrs_async_es_lrs_backend_query_statements_pit_query_fail
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_es_lrs_backend_query_statements_by_ids_search_query_failure(
+async def test_backends_lrs_es_query_statements_by_ids_search_query_failure(
     es, async_es_lrs_backend, monkeypatch, caplog
 ):
     """Test the `AsyncESLRSBackend.query_statements_by_ids` method, given a search
@@ -379,7 +377,7 @@ async def test_backends_lrs_es_lrs_backend_query_statements_by_ids_search_query_
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_async_es_lrs_backend_query_statements_by_ids_many_indexes(
+async def test_backends_lrs_async_es_query_statements_by_ids_many_indexes(
     es, es_forwarding, async_es_lrs_backend
 ):
     """Test the `AsyncESLRSBackend.query_statements_by_ids` method, given a valid

--- a/tests/backends/lrs/test_async_mongo.py
+++ b/tests/backends/lrs/test_async_mongo.py
@@ -13,7 +13,7 @@ from ralph.exceptions import BackendException
 from tests.fixtures.backends import MONGO_TEST_FORWARDING_COLLECTION
 
 
-def test_backends_lrs_async_mongo_lrs_backend_default_instantiation(monkeypatch, fs):
+def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
     """Test the `AsyncMongoLRSBackend` default instantiation."""
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__MONGO__DEFAULT_COLLECTION", raising=False)
@@ -237,7 +237,7 @@ def test_backends_lrs_async_mongo_lrs_backend_default_instantiation(monkeypatch,
     ],
 )
 @pytest.mark.anyio
-async def test_backends_lrs_async_mongo_lrs_backend_query_statements_query(
+async def test_backends_lrs_async_mongo_query_statements_query(
     params, expected_query, async_mongo_lrs_backend, monkeypatch
 ):
     """Test the `AsyncMongoLRSBackend.query_statements` method, given valid statement
@@ -261,7 +261,7 @@ async def test_backends_lrs_async_mongo_lrs_backend_query_statements_query(
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_async_mongo_lrs_backend_query_statements_with_success(
+async def test_backends_lrs_async_mongo_query_statements_with_success(
     mongo, async_mongo_lrs_backend
 ):
     """Test the `AsyncMongoLRSBackend.query_statements` method, given a valid search
@@ -305,7 +305,7 @@ async def test_backends_lrs_async_mongo_lrs_backend_query_statements_with_succes
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_async_mongo_lrs_backend_query_statements_with_query_failure(
+async def test_backends_lrs_async_mongo_query_statements_with_query_failure(
     async_mongo_lrs_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoLRSBackend.query_statements` method, given a search query
@@ -334,7 +334,7 @@ async def test_backends_lrs_async_mongo_lrs_backend_query_statements_with_query_
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_query_failure(
+async def test_backends_lrs_mongo_query_statements_by_ids_query_failure(
     async_mongo_lrs_backend, monkeypatch, caplog
 ):
     """Test the `AsyncMongoLRSBackend.query_statements_by_ids` method, given a search
@@ -368,7 +368,7 @@ async def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_query_fail
 
 
 @pytest.mark.anyio
-async def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_two_collections(
+async def test_backends_lrs_mongo_query_statements_by_ids_two_collections(
     mongo, mongo_forwarding, async_mongo_lrs_backend
 ):
     """Test the `AsyncMongoLRSBackend.query_statements_by_ids` method, given a valid

--- a/tests/backends/lrs/test_clickhouse.py
+++ b/tests/backends/lrs/test_clickhouse.py
@@ -12,7 +12,7 @@ from ralph.backends.lrs.clickhouse import ClickHouseLRSBackend
 from ralph.exceptions import BackendException
 
 
-def test_backends_lrs_clickhouse_lrs_backend_default_instantiation(monkeypatch, fs):
+def test_backends_lrs_clickhouse_default_instantiation(monkeypatch, fs):
     """Test the `ClickHouseLRSBackend` default instantiation."""
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__CLICKHOUSE__IDS_CHUNK_SIZE", raising=False)
@@ -289,9 +289,7 @@ def test_backends_database_clickhouse_query_statements_query(
     backend.close()
 
 
-def test_backends_lrs_clickhouse_lrs_backend_query_statements(
-    clickhouse, clickhouse_lrs_backend
-):
+def test_backends_lrs_clickhouse_query_statements(clickhouse, clickhouse_lrs_backend):
     """Test the `ClickHouseLRSBackend.query_statements` method, given a query,
     should return matching statements.
     """
@@ -323,7 +321,7 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements(
     backend.close()
 
 
-def test_backends_lrs_clickhouse_lrs_backend__find(clickhouse, clickhouse_lrs_backend):
+def test_backends_lrs_clickhouse__find(clickhouse, clickhouse_lrs_backend):
     """Test the `ClickHouseLRSBackend._find` method, given a query,
     should return matching statements.
     """
@@ -352,7 +350,7 @@ def test_backends_lrs_clickhouse_lrs_backend__find(clickhouse, clickhouse_lrs_ba
     backend.close()
 
 
-def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids(
+def test_backends_lrs_clickhouse_query_statements_by_ids(
     clickhouse, clickhouse_lrs_backend
 ):
     """Test the `ClickHouseLRSBackend.query_statements_by_ids` method, given
@@ -384,7 +382,7 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids(
     backend.close()
 
 
-def test_backends_lrs_clickhouse_lrs_backend_query_statements_client_failure(
+def test_backends_lrs_clickhouse_query_statements_client_failure(
     clickhouse, clickhouse_lrs_backend, monkeypatch, caplog
 ):
     """Test the `ClickHouseLRSBackend.query_statements`, given a client query
@@ -412,7 +410,7 @@ def test_backends_lrs_clickhouse_lrs_backend_query_statements_client_failure(
     backend.close()
 
 
-def test_backends_lrs_clickhouse_lrs_backend_query_statements_by_ids_client_failure(
+def test_backends_lrs_clickhouse_query_statements_by_ids_client_failure(
     clickhouse, clickhouse_lrs_backend, monkeypatch, caplog
 ):
     """Test the `ClickHouseLRSBackend.query_statements_by_ids`, given a client

--- a/tests/backends/lrs/test_es.py
+++ b/tests/backends/lrs/test_es.py
@@ -15,7 +15,7 @@ from ralph.exceptions import BackendException
 from tests.fixtures.backends import ES_TEST_FORWARDING_INDEX, ES_TEST_INDEX
 
 
-def test_backends_lrs_es_lrs_backend_default_instantiation(monkeypatch, fs):
+def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
     """Test the `ESLRSBackend` default instantiation."""
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__ES__DEFAULT_INDEX", raising=False)
@@ -266,7 +266,7 @@ def test_backends_lrs_es_lrs_backend_default_instantiation(monkeypatch, fs):
         ),
     ],
 )
-def test_backends_lrs_es_lrs_backend_query_statements_query(
+def test_backends_lrs_es_query_statements_query(
     params, expected_query, es_lrs_backend, monkeypatch
 ):
     """Test the `ESLRSBackend.query_statements` method, given valid statement
@@ -291,7 +291,7 @@ def test_backends_lrs_es_lrs_backend_query_statements_query(
     backend.close()
 
 
-def test_backends_lrs_es_lrs_backend_query_statements(es, es_lrs_backend):
+def test_backends_lrs_es_query_statements(es, es_lrs_backend):
     """Test the `ESLRSBackend.query_statements` method, given a query,
     should return matching statements.
     """
@@ -310,7 +310,7 @@ def test_backends_lrs_es_lrs_backend_query_statements(es, es_lrs_backend):
     backend.close()
 
 
-def test_backends_lrs_es_lrs_backend_query_statements_with_search_query_failure(
+def test_backends_lrs_es_query_statements_with_search_query_failure(
     es, es_lrs_backend, monkeypatch, caplog
 ):
     """Test the `ESLRSBackend.query_statements`, given a search query failure, should
@@ -338,7 +338,7 @@ def test_backends_lrs_es_lrs_backend_query_statements_with_search_query_failure(
     backend.close()
 
 
-def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_search_query_failure(
+def test_backends_lrs_es_query_statements_by_ids_with_search_query_failure(
     es, es_lrs_backend, monkeypatch, caplog
 ):
     """Test the `ESLRSBackend.query_statements_by_ids` method, given a search query
@@ -366,7 +366,7 @@ def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_search_query_f
     backend.close()
 
 
-def test_backends_lrs_es_lrs_backend_query_statements_by_ids_with_multiple_indexes(
+def test_backends_lrs_es_query_statements_by_ids_with_multiple_indexes(
     es, es_forwarding, es_lrs_backend
 ):
     """Test the `ESLRSBackend.query_statements_by_ids` method, given a valid search

--- a/tests/backends/lrs/test_fs.py
+++ b/tests/backends/lrs/test_fs.py
@@ -6,7 +6,7 @@ from ralph.backends.lrs.base import RalphStatementsQuery
 from ralph.backends.lrs.fs import FSLRSBackend
 
 
-def test_backends_lrs_fs_lrs_backend_default_instantiation(monkeypatch, fs):
+def test_backends_lrs_fs_default_instantiation(monkeypatch, fs):
     """Test the `FSLRSBackend` default instantiation."""
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__FS__DEFAULT_LRS_FILE", raising=False)
@@ -153,7 +153,7 @@ def test_backends_lrs_fs_lrs_backend_default_instantiation(monkeypatch, fs):
         ),
     ],
 )
-def test_backends_lrs_fs_lrs_backend_query_statements_query(
+def test_backends_lrs_fs_query_statements_query(
     params, expected_statement_ids, fs_lrs_backend
 ):
     """Test the `FSLRSBackend.query_statements` method, given valid statement
@@ -278,7 +278,7 @@ def test_backends_lrs_fs_lrs_backend_query_statements_query(
     assert ids == expected_statement_ids
 
 
-def test_backends_lrs_fs_lrs_backend_query_statements_by_ids(fs_lrs_backend):
+def test_backends_lrs_fs_query_statements_by_ids(fs_lrs_backend):
     """Test the `FSLRSBackend.query_statements_by_ids` method, given a valid search
     query, should return the expected results.
     """

--- a/tests/backends/lrs/test_mongo.py
+++ b/tests/backends/lrs/test_mongo.py
@@ -13,7 +13,7 @@ from ralph.exceptions import BackendException
 from tests.fixtures.backends import MONGO_TEST_FORWARDING_COLLECTION
 
 
-def test_backends_lrs_mongo_lrs_backend_default_instantiation(monkeypatch, fs):
+def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
     """Test the `MongoLRSBackend` default instantiation."""
     fs.create_file(".env")
     monkeypatch.delenv("RALPH_BACKENDS__LRS__MONGO__DEFAULT_COLLECTION", raising=False)
@@ -236,7 +236,7 @@ def test_backends_lrs_mongo_lrs_backend_default_instantiation(monkeypatch, fs):
         ),
     ],
 )
-def test_backends_lrs_mongo_lrs_backend_query_statements_query(
+def test_backends_lrs_mongo_query_statements_query(
     params, expected_query, mongo_lrs_backend, monkeypatch
 ):
     """Test the `MongoLRSBackend.query_statements` method, given valid statement
@@ -258,9 +258,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_query(
     backend.close()
 
 
-def test_backends_lrs_mongo_lrs_backend_query_statements_with_success(
-    mongo, mongo_lrs_backend
-):
+def test_backends_lrs_mongo_query_statements_with_success(mongo, mongo_lrs_backend):
     """Test the `MongoLRSBackend.query_statements` method, given a valid search query,
     should return the expected statements.
     """
@@ -302,7 +300,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_with_success(
     backend.close()
 
 
-def test_backends_lrs_mongo_lrs_backend_query_statements_with_query_failure(
+def test_backends_lrs_mongo_query_statements_with_query_failure(
     mongo_lrs_backend, monkeypatch, caplog
 ):
     """Test the `MongoLRSBackend.query_statements` method, given a search query failure,
@@ -331,7 +329,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_with_query_failure(
     backend.close()
 
 
-def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_query_failure(
+def test_backends_lrs_mongo_query_statements_by_ids_with_query_failure(
     mongo_lrs_backend, monkeypatch, caplog
 ):
     """Test the `MongoLRSBackend.query_statements_by_ids` method, given a search query
@@ -360,7 +358,7 @@ def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_query_failu
     backend.close()
 
 
-def test_backends_lrs_mongo_lrs_backend_query_statements_by_ids_with_two_collections(
+def test_backends_lrs_mongo_query_statements_by_ids_with_two_collections(
     mongo, mongo_forwarding, mongo_lrs_backend
 ):
     """Test the `MongoLRSBackend.query_statements_by_ids` method, given a valid search

--- a/tests/backends/stream/test_ws.py
+++ b/tests/backends/stream/test_ws.py
@@ -10,7 +10,7 @@ from ralph.backends.stream.ws import WSStreamBackend, WSStreamBackendSettings
 from tests.fixtures.backends import WS_TEST_HOST, WS_TEST_PORT
 
 
-def test_backends_stream_ws_stream_default_instantiation(monkeypatch, fs):
+def test_backends_stream_ws_default_instantiation(monkeypatch, fs):
     """Test the `WSStreamBackend` instantiation."""
 
     fs.create_file(".env")
@@ -28,7 +28,7 @@ def test_backends_stream_ws_stream_default_instantiation(monkeypatch, fs):
     assert backend.settings.URI == uri
 
 
-def test_backends_stream_ws_stream_stream(ws, monkeypatch, events):
+def test_backends_stream_ws_stream(ws, monkeypatch, events):
     """Test the `WSStreamBackend` stream method."""
 
     settings = WSStreamBackendSettings(URI=f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}")
@@ -53,7 +53,7 @@ def test_backends_stream_ws_stream_stream(ws, monkeypatch, events):
     assert streamed_events == events
 
 
-def test_backends_stream_ws_stream_stream_when_server_stops(ws, monkeypatch, events):
+def test_backends_stream_ws_stream_when_server_stops(ws, monkeypatch, events):
     """Test the WSStreamBackend stream method when the websocket server stops."""
 
     settings = WSStreamBackendSettings(URI=f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}")


### PR DESCRIPTION
## Purpose

Having developed the unification of backends separately, this has led to a de-unification of test naming.

## Proposal

To align with the clean-up in the naming of API method tests, the names of backend tests have been shortened.

The suffix with the backend type(`data_backend`, `lrs_backend`) is unnecessary as the information is contained at the beginning of the test name.


