### PR TITLE
🔧(project) add flake8-fixme set of rules for Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ select = [
     "D",  # pydocstyle
     "E",  # pycodestyle error
     "F",  # Pyflakes
+    "FIX",  # flake8-fixme
     "I",  # isort
     "PLC",  # Pylint Convention
     "PLE",  # Pylint Error


### PR DESCRIPTION
## Purpose

Previously, pylint was checking if any `FIXME` or `TODO` was present in the
codebase.

## Proposal

Adding `FIX` (`flake8-fixme`) set of rules to Ruff to check these.

