### PR TITLE
♻️(backends) use common utilities among backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ methods under the unified `lrs` backend interface [BC]
 have an authority field matching that of the user
 - CLI: change `push` to `write` and `fetch` to `read` [BC]
 - Upgrade `fastapi` to `0.104.1`
-- Upgrade `more-itertools` to `10.1.0`
 - Upgrade `sentry_sdk` to `1.34.0`
 - Upgrade `uvicorn` to `0.24.0.post1`
 - API: Invalid parameters now return 400 status code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ backend-ldp = [
 ]
 backend-lrs = [
     "httpx<0.25.0", # pin as `pytest-httpx<0.23.0` requires `httpx==0.24.*`
-    "more-itertools==10.1.0",
 ]
 backend-mongo = [
     "motor[srv]>=3.3.0",

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -102,9 +102,8 @@ class Writable(ABC):
             chunk_size (int or None): The number of records or bytes to write in one
                 batch, depending on whether `data` contains dictionaries or bytes.
                 If `chunk_size` is `None`, a default value is used instead.
-            ignore_errors (bool): If `True`, errors during the write operation
-                are ignored and logged. If `False` (default), a `BackendException`
-                is raised if an error occurs.
+            ignore_errors (bool): If `True`, escapable errors are ignored and logged.
+                If `False` (default), a `BackendException` is raised on any error.
             operation_type (BaseOperationType or None): The mode of the write operation.
                 If `operation_type` is `None`, the `default_operation_type` is used
                 instead. See `BaseOperationType`.
@@ -113,8 +112,8 @@ class Writable(ABC):
             int: The number of written records.
 
         Raise:
-            BackendException: If a failure during the write operation occurs and
-                `ignore_errors` is set to `False`.
+            BackendException: If any failure occurs during the write operation or
+                if an inescapable failure occurs and `ignore_errors` is set to `True`.
             BackendParameterException: If a backend argument value is not valid.
         """
 
@@ -262,17 +261,17 @@ class BaseDataBackend(Generic[Settings, Query], ABC):
                 are encoded as JSON.
                 If the records are bytes and `raw_output` is set to `False`, they are
                 decoded as JSON by line.
-            ignore_errors (bool): If `True`, errors during the read operation
-                are be ignored and logged. If `False` (default), a `BackendException`
-                is raised if an error occurs.
+            ignore_errors (bool): If `True`, encoding errors during the read operation
+                will be ignored and logged.
+                If `False` (default), a `BackendException` is raised on any error.
 
         Yield:
             dict: If `raw_output` is False.
             bytes: If `raw_output` is True.
 
         Raise:
-            BackendException: If a failure during the read operation occurs and
-                `ignore_errors` is set to `False`.
+            BackendException: If a failure during the read operation occurs or
+                during encoding records and `ignore_errors` is set to `False`.
             BackendParameterException: If a backend argument value is not valid.
         """
 
@@ -322,9 +321,8 @@ class AsyncWritable(ABC):
             chunk_size (int or None): The number of records or bytes to write in one
                 batch, depending on whether `data` contains dictionaries or bytes.
                 If `chunk_size` is `None`, a default value is used instead.
-            ignore_errors (bool): If `True`, errors during the write operation
-                are ignored and logged. If `False` (default), a `BackendException`
-                is raised if an error occurs.
+            ignore_errors (bool): If `True`, escapable errors are ignored and logged.
+                If `False` (default), a `BackendException` is raised on any error.
             operation_type (BaseOperationType or None): The mode of the write operation.
                 If `operation_type` is `None`, the `default_operation_type` is used
                 instead. See `BaseOperationType`.
@@ -333,8 +331,8 @@ class AsyncWritable(ABC):
             int: The number of written records.
 
         Raise:
-            BackendException: If a failure during the write operation occurs and
-                `ignore_errors` is set to `False`.
+            BackendException: If any failure occurs during the write operation or
+                if an inescapable failure occurs and `ignore_errors` is set to `True`.
             BackendParameterException: If a backend argument value is not valid.
         """
 
@@ -447,17 +445,17 @@ class BaseAsyncDataBackend(Generic[Settings, Query], ABC):
                 are encoded as JSON.
                 If the records are bytes and `raw_output` is set to `False`, they are
                 decoded as JSON by line.
-            ignore_errors (bool): If `True`, errors during the read operation
-                are be ignored and logged. If `False` (default), a `BackendException`
-                is raised if an error occurs.
+            ignore_errors (bool): If `True`, encoding errors during the read operation
+                will be ignored and logged.
+                If `False` (default), a `BackendException` is raised on any error.
 
         Yield:
             dict: If `raw_output` is False.
             bytes: If `raw_output` is True.
 
         Raise:
-            BackendException: If a failure during the read operation occurs and
-                `ignore_errors` is set to `False`.
+            BackendException: If a failure during the read operation occurs or
+                during encoding records and `ignore_errors` is set to `False`.
             BackendParameterException: If a backend argument value is not valid.
         """
 

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -114,11 +114,11 @@ class LDPDataBackend(
             details (bool): Get detailed archive information in addition to archive IDs.
             new (bool): Given the history, list only not already read archives.
 
-        Yields:
+        Yield:
             str: If `details` is False.
             dict: If `details` is True.
 
-        Raises:
+        Raise:
             BackendParameterException: If the `target` is `None` and no
                 `DEFAULT_STREAM_ID` is given.
             BackendException: If a failure during retrieval of archives list occurs.
@@ -167,13 +167,13 @@ class LDPDataBackend(
                 If target is `None`, the `DEFAULT_STREAM_ID` is used instead.
             chunk_size (int or None): The chunk size when reading archives by batch.
             raw_output (bool): Ignored. Always set to `True`.
-            ignore_errors (bool): Ignored.
+            ignore_errors (bool): No impact as no encoding operation is performed.
 
-        Yields:
+        Yield:
             bytes: The content of the archive matching the query.
 
-        Raises:
-            BackendException: If a failure during the read operation occurs.
+        Raise:
+            BackendException: If a failure occurs during LDP connection.
             BackendParameterException: If the `query` argument is not an archive name.
         """
         if query.query_string is None:

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -675,7 +675,7 @@ def read(  # noqa: PLR0913
             iter_over_async(statements) if isasyncgen(statements) else statements
         )
         for statement in statements:
-            click.echo(statement)
+            click.echo(statement, nl=False)
     elif isinstance(backend, BaseStreamBackend):
         backend.stream(sys.stdout.buffer)
     elif isinstance(backend, BaseHTTPBackend):

--- a/tests/backends/data/test_ldp.py
+++ b/tests/backends/data/test_ldp.py
@@ -679,7 +679,7 @@ def test_backends_data_ldp_url(monkeypatch, ldp_backend):
 
 
 def test_backends_data_ldp_close(ldp_backend, caplog):
-    """Test that the `LDPDataBackend.close` method raise an error."""
+    """Test that the `LDPDataBackend.close` method produces an info level log."""
 
     backend = ldp_backend()
 

--- a/tests/backends/http/test_async_lrs.py
+++ b/tests/backends/http/test_async_lrs.py
@@ -672,11 +672,14 @@ async def test_backends_http_async_lrs_write_without_operation(
             max_num_simultaneous=max_num_simultaneous,
         )
 
+    # If no chunk_size is provided, a default value (500) should be used.
+    if chunk_size is None:
+        chunk_size = 500
+
     assert (
         "ralph.backends.http.async_lrs",
         logging.DEBUG,
-        f"Start writing to the {base_url}{target} endpoint (chunk size: "
-        f"{chunk_size})",
+        f"Start writing to the {base_url}{target} endpoint (chunk size: {chunk_size})",
     ) in caplog.record_tuples
 
     assert (


### PR DESCRIPTION
## Purpose

During data backend unification work, some shared utilities were developed to factorize duplication:
`parse_dict_to_bytes`, `read_raw` and `iter_by_batch`.
However, some backends still used their own implementation of these utilities, leading to some minor behavioral differences among backends.

## Proposal

- [x] update backends to use common utilities.
- [x] make `parse_bytes_to_dict` more generic (`parse_to_dict`) to improve re-usability (see usage in ClickHouseDataBackend).


~**Note:** This PR depends on #501~