### PR TITLE
♻️(backends) add logger property to data/lrs backends

### DIFF
--- a/src/ralph/backends/data/mixins.py
+++ b/src/ralph/backends/data/mixins.py
@@ -1,14 +1,12 @@
 """Backend mixins for Ralph."""
 
 import json
-import logging
 
+from ralph.backends.data.base import Loggable
 from ralph.conf import settings
 
-logger = logging.getLogger(__name__)
 
-
-class HistoryMixin:
+class HistoryMixin(Loggable):
     """Backend history mixin.
 
     Handle backend download history to avoid fetching same files multiple
@@ -18,7 +16,7 @@ class HistoryMixin:
     @property
     def history(self):
         """Get backend history."""
-        logger.debug("Loading history file: %s", str(settings.HISTORY_FILE))
+        self.logger.debug("Loading history file: %s", str(settings.HISTORY_FILE))
 
         if not hasattr(self, "_history"):
             try:
@@ -32,7 +30,7 @@ class HistoryMixin:
 
     def write_history(self, history):
         """Write given history as a JSON file."""
-        logger.debug("Writing history file: %s", str(settings.HISTORY_FILE))
+        self.logger.debug("Writing history file: %s", str(settings.HISTORY_FILE))
 
         if not settings.HISTORY_FILE.parent.exists():
             settings.HISTORY_FILE.parent.mkdir(parents=True)

--- a/src/ralph/backends/lrs/async_es.py
+++ b/src/ralph/backends/lrs/async_es.py
@@ -1,6 +1,5 @@
 """Asynchronous Elasticsearch LRS backend for Ralph."""
 
-import logging
 from typing import Iterator, List
 
 from ralph.backends.data.async_es import AsyncESDataBackend
@@ -11,8 +10,6 @@ from ralph.backends.lrs.base import (
 )
 from ralph.backends.lrs.es import ESLRSBackend, ESLRSBackendSettings
 from ralph.exceptions import BackendException, BackendParameterException
-
-logger = logging.getLogger(__name__)
 
 
 class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBackend):
@@ -29,7 +26,7 @@ class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBa
                 async for document in self.read(query=query, chunk_size=params.limit)
             ]
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from Elasticsearch")
+            self.logger.error("Failed to read from Elasticsearch")
             raise error
 
         return StatementQueryResult(
@@ -44,5 +41,5 @@ class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBa
             async for document in self.read(query={"query": {"terms": {"_id": ids}}}):
                 yield document["_source"]
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from Elasticsearch")
+            self.logger.error("Failed to read from Elasticsearch")
             raise error

--- a/src/ralph/backends/lrs/async_mongo.py
+++ b/src/ralph/backends/lrs/async_mongo.py
@@ -1,7 +1,5 @@
 """Async MongoDB LRS backend for Ralph."""
 
-
-import logging
 from typing import Iterator, List
 
 from ralph.backends.data.async_mongo import AsyncMongoDataBackend
@@ -12,8 +10,6 @@ from ralph.backends.lrs.base import (
 )
 from ralph.backends.lrs.mongo import MongoLRSBackend, MongoLRSBackendSettings
 from ralph.exceptions import BackendException, BackendParameterException
-
-logger = logging.getLogger(__name__)
 
 
 class AsyncMongoLRSBackend(
@@ -32,7 +28,7 @@ class AsyncMongoLRSBackend(
                 async for document in self.read(query=query, chunk_size=params.limit)
             ]
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from async MongoDB")
+            self.logger.error("Failed to read from async MongoDB")
             raise error
 
         search_after = None
@@ -53,5 +49,5 @@ class AsyncMongoLRSBackend(
             ):
                 yield document["_source"]
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from MongoDB")
+            self.logger.error("Failed to read from MongoDB")
             raise error

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -1,6 +1,5 @@
 """ClickHouse LRS backend for Ralph."""
 
-import logging
 from typing import Generator, Iterator, List
 
 from ralph.backends.data.clickhouse import (
@@ -16,8 +15,6 @@ from ralph.backends.lrs.base import (
 )
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
-
-logger = logging.getLogger(__name__)
 
 
 class ClickHouseLRSBackendSettings(
@@ -104,7 +101,7 @@ class ClickHouseLRSBackend(
                 )
             )
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from ClickHouse")
+            self.logger.error("Failed to read from ClickHouse")
             raise error
 
         new_search_after = None
@@ -147,7 +144,7 @@ class ClickHouseLRSBackend(
                 yield from (document["event"] for document in ch_response)
         except (BackendException, BackendParameterException) as error:
             msg = "Failed to read from ClickHouse"
-            logger.error(msg)
+            self.logger.error(msg)
             raise error
 
     @staticmethod

--- a/src/ralph/backends/lrs/es.py
+++ b/src/ralph/backends/lrs/es.py
@@ -1,6 +1,5 @@
 """Elasticsearch LRS backend for Ralph."""
 
-import logging
 from typing import Iterator, List
 
 from ralph.backends.data.es import (
@@ -18,8 +17,6 @@ from ralph.backends.lrs.base import (
 )
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
-
-logger = logging.getLogger(__name__)
 
 
 class ESLRSBackendSettings(BaseLRSBackendSettings, ESDataBackendSettings):
@@ -41,7 +38,7 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
             es_documents = self.read(query=query, chunk_size=params.limit)
             statements = [document["_source"] for document in es_documents]
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from Elasticsearch")
+            self.logger.error("Failed to read from Elasticsearch")
             raise error
 
         return StatementQueryResult(
@@ -56,7 +53,7 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
             es_response = self.read(query={"query": {"terms": {"_id": ids}}})
             yield from (document["_source"] for document in es_response)
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from Elasticsearch")
+            self.logger.error("Failed to read from Elasticsearch")
             raise error
 
     @staticmethod

--- a/src/ralph/backends/lrs/fs.py
+++ b/src/ralph/backends/lrs/fs.py
@@ -1,6 +1,5 @@
 """FileSystem LRS backend for Ralph."""
 
-import logging
 from datetime import datetime
 from io import IOBase
 from typing import Iterable, List, Literal, Optional, Union
@@ -16,8 +15,6 @@ from ralph.backends.lrs.base import (
     StatementQueryResult,
 )
 from ralph.conf import BaseSettingsConfig
-
-logger = logging.getLogger(__name__)
 
 
 class FSLRSBackendSettings(BaseLRSBackendSettings, FSDataBackendSettings):
@@ -324,9 +321,8 @@ class FSLRSBackend(BaseLRSBackend[FSLRSBackendSettings], FSDataBackend):
         if object_id:
             filters.append(match_related_object_id if related else match_object_id)
 
-    @staticmethod
     def _add_filter_by_timestamp_since(
-        filters: list, timestamp: Optional[datetime]
+        self, filters: list, timestamp: Optional[datetime]
     ) -> None:
         """Add the `match_since` filter if `timestamp` is set."""
         if isinstance(timestamp, str):
@@ -338,16 +334,15 @@ class FSLRSBackend(BaseLRSBackend[FSLRSBackendSettings], FSDataBackend):
                 statement_timestamp = datetime.fromisoformat(statement.get("timestamp"))
             except (TypeError, ValueError) as error:
                 msg = "Statement with id=%s contains unparsable timestamp=%s"
-                logger.debug(msg, statement.get("id"), error)
+                self.logger.debug(msg, statement.get("id"), error)
                 return False
             return statement_timestamp > timestamp
 
         if timestamp:
             filters.append(match_since)
 
-    @staticmethod
     def _add_filter_by_timestamp_until(
-        filters: list, timestamp: Optional[datetime]
+        self, filters: list, timestamp: Optional[datetime]
     ) -> None:
         """Add the `match_until` function if `timestamp` is set."""
         if isinstance(timestamp, str):
@@ -359,7 +354,7 @@ class FSLRSBackend(BaseLRSBackend[FSLRSBackendSettings], FSDataBackend):
                 statement_timestamp = datetime.fromisoformat(statement.get("timestamp"))
             except (TypeError, ValueError) as error:
                 msg = "Statement with id=%s contains unparsable timestamp=%s"
-                logger.debug(msg, statement.get("id"), error)
+                self.logger.debug(msg, statement.get("id"), error)
                 return False
             return statement_timestamp <= timestamp
 

--- a/src/ralph/backends/lrs/mongo.py
+++ b/src/ralph/backends/lrs/mongo.py
@@ -1,6 +1,5 @@
 """MongoDB LRS backend for Ralph."""
 
-import logging
 from typing import Iterator, List
 
 from bson.objectid import ObjectId
@@ -21,8 +20,6 @@ from ralph.backends.lrs.base import (
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
 
-logger = logging.getLogger(__name__)
-
 
 class MongoLRSBackendSettings(BaseLRSBackendSettings, MongoDataBackendSettings):
     """MongoDB LRS backend default configuration."""
@@ -42,7 +39,7 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
         try:
             mongo_response = list(self.read(query=query, chunk_size=params.limit))
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from MongoDB")
+            self.logger.error("Failed to read from MongoDB")
             raise error
 
         search_after = None
@@ -61,7 +58,7 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
             mongo_response = self.read(query={"filter": {"_source.id": {"$in": ids}}})
             yield from (document["_source"] for document in mongo_response)
         except (BackendException, BackendParameterException) as error:
-            logger.error("Failed to read from MongoDB")
+            self.logger.error("Failed to read from MongoDB")
             raise error
 
     @staticmethod

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -61,7 +61,7 @@ def insert_mongo_statements(mongo_client, statements):
                 data=statements,
                 ignore_errors=True,
                 operation_type=BaseOperationType.CREATE,
-                logger_class=None,
+                logger=None,
             )
         )
     )

--- a/tests/backends/data/test_async_es.py
+++ b/tests/backends/data/test_async_es.py
@@ -477,7 +477,7 @@ async def test_backends_data_async_es_read_with_query(es, async_es_backend, capl
             ]
 
     assert (
-        "ralph.backends.data.base",
+        "ralph.backends.data.async_es",
         logging.ERROR,
         "The 'query' argument is expected to be a ESQuery instance. "
         "[{'loc': ('not_query',), 'msg': 'extra fields not permitted', "

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -80,7 +80,8 @@ def test_backends_data_base_enforce_query_checks_with_invalid_input(
             MockBaseDataBackend().read(query=value)
 
     error = error.replace("\\", "")
-    assert ("ralph.backends.data.base", logging.ERROR, error) in caplog.record_tuples
+    module_name = "tests.backends.data.test_base"
+    assert (module_name, logging.ERROR, error) in caplog.record_tuples
 
 
 def test_backends_data_base_get_backend_generic_argument():

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -433,7 +433,7 @@ def test_backends_data_es_read_with_query(es, es_backend, caplog):
             list(backend.read(query={"not_query": "foo"}))
 
     assert (
-        "ralph.backends.data.base",
+        "ralph.backends.data.es",
         logging.ERROR,
         "The 'query' argument is expected to be a ESQuery instance. "
         "[{'loc': ('not_query',), 'msg': 'extra fields not permitted', "

--- a/tests/backends/data/test_mixins.py
+++ b/tests/backends/data/test_mixins.py
@@ -4,11 +4,11 @@ import json
 import os.path
 from pathlib import Path
 
-from ralph.backends.mixins import HistoryMixin
+from ralph.backends.data.mixins import HistoryMixin
 from ralph.conf import Settings, settings
 
 
-def test_backends_mixins_history_mixin_empty_history(settings_fs):
+def test_backends_data_mixins_history_mixin_empty_history(settings_fs):
     """Test the history method of the HistoryMixin when history is empty."""
 
     history = HistoryMixin()
@@ -32,7 +32,7 @@ def test_backends_mixins_history_mixin_empty_history(settings_fs):
     assert history._history == history.history
 
 
-def test_backends_mixins_history_mixin_with_history(fs, settings_fs):
+def test_backends_data_mixins_history_mixin_with_history(fs, settings_fs):
     """Test the history method of the HistoryMixin when history is filled."""
 
     history = HistoryMixin()
@@ -44,7 +44,7 @@ def test_backends_mixins_history_mixin_with_history(fs, settings_fs):
     assert history.history == events
 
 
-def test_backends_mixins_history_mixin_write_history(fs, settings_fs):
+def test_backends_data_mixins_history_mixin_write_history(fs, settings_fs):
     """Test the write_history method of the HistoryMixin."""
 
     # Force Path instantiation with fake FS
@@ -73,7 +73,7 @@ def test_backends_mixins_history_mixin_write_history(fs, settings_fs):
     assert history.history == events
 
 
-def test_backends_mixins_history_mixin_clean_history(fs, settings_fs):
+def test_backends_data_mixins_history_mixin_clean_history(fs, settings_fs):
     """Test the clean_history method of the HistoryMixin."""
 
     history = HistoryMixin()
@@ -96,7 +96,7 @@ def test_backends_mixins_history_mixin_clean_history(fs, settings_fs):
     ]
 
 
-def test_backends_mixins_history_mixin_append_to_history(fs):
+def test_backends_data_mixins_history_mixin_append_to_history(fs):
     """Test the append_to_history method of the HistoryMixin."""
 
     history = HistoryMixin()

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -471,7 +471,7 @@ def settings_fs(fs, monkeypatch):
     """Force Path instantiation with fake FS in ralph settings."""
 
     monkeypatch.setattr(
-        "ralph.backends.mixins.settings",
+        "ralph.backends.data.mixins.settings",
         Settings(HISTORY_FILE=Path(core_settings.APP_DIR / "history.json")),
     )
 


### PR DESCRIPTION
## Purpose

Currently, backends use a module-level logger instance for logging to allow filtering logs by backend.
However, when a backend inherits another backend, logs produced by the parent backend refer to the parent module (and not the current backend module).

## Proposal

- [x] make the logger an instance property of the backend class to allow a child backend to overwrite the logger of its parent
- [x] move `HistoryMixin` to the data backed module to allow its logger to be overwritten too.


**Note**: This PR depends on #510 