### PR TITLE
✅(api) enhance limit query parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ have an authority field matching that of the user
   control by user scopes
 - Backends: Replace reference to a JSON column in ClickHouse with 
   function calls on the String column [BC]
+- API: enhance 'limit' query parameter's validation 
 
 ### Fixed
 

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -219,6 +219,7 @@ async def get(  # noqa: PLR0913
     ),
     limit: Optional[int] = Query(
         settings.RUNSERVER_MAX_SEARCH_HITS_COUNT,
+        ge=0,
         description=(
             "Maximum number of Statements to return. "
             "0 indicates return the maximum the server will allow"

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -447,7 +447,7 @@ async def test_api_statements_get_by_activity(
     assert response.status_code == 200
     assert response.json() == {"statements": [statements[1]]}
 
-    # Check that badly formated activity returns an error
+    # Check that badly formatted activity returns an error
     response = await client.get(
         "/xAPI/statements/?activity=INVALID_IRI",
         headers={"Authorization": f"Basic {basic_auth_credentials}"},

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -733,6 +733,13 @@ async def test_api_statements_get_invalid_query_parameters(
         "detail": "The following parameter is not allowed: `mamamia`"
     }
 
+    # Check for 422 status code when a negative limit parameter is provided
+    response = await client.get(
+        "/xAPI/statements/?limit=-1",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+    assert response.status_code == 422
+
     # Check for 400 status code when both statementId and voidedStatementId are provided
     response = await client.get(
         f"/xAPI/statements/?statementId={id_1}&voidedStatementId={id_2}",


### PR DESCRIPTION
## Purpose

Adjusting response handling to return a more appropriate 422 HTTP exception
instead of a generic 500 error when the limit query parameter is strictly negative.

## Proposal

Use the arguments of the Query class. Set the greater or equal (`ge`) parameter's value to 0.

