### PR TITLE
🏗️(backends) use template method for write method in data backends

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator, Iterable, Optional, TypeVar, Union
 
 from elasticsearch import ApiError, AsyncElasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, async_streaming_bulk
+from pydantic import PositiveInt
 
 from ralph.backends.data.base import (
     AsyncListable,
@@ -114,6 +115,7 @@ class AsyncESDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
         """Read documents matching the query in the target index and yield them.
 
@@ -128,6 +130,8 @@ class AsyncESDataBackend(
             raw_output (bool): Controls whether to yield dictionaries or bytes.
             ignore_errors (bool): No impact as encoding errors are not expected in
                 Elasticsearch results.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -136,7 +140,9 @@ class AsyncESDataBackend(
         Raise:
             BackendException: If a failure occurs during Elasticsearch connection.
         """
-        statements = super().read(query, target, chunk_size, raw_output, ignore_errors)
+        statements = super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
         async for statement in statements:
             yield statement
 

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator, Iterable, Optional, TypeVar, Union
 
 from bson.errors import BSONError
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pydantic import PositiveInt
 from pymongo.errors import BulkWriteError, ConnectionFailure, InvalidName, PyMongoError
 
 from ralph.backends.data.base import BaseOperationType
@@ -122,6 +123,7 @@ class AsyncMongoDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
         """Read documents matching the `query` from `target` collection and yield them.
 
@@ -135,6 +137,8 @@ class AsyncMongoDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -145,7 +149,9 @@ class AsyncMongoDataBackend(
                 during encoding documents and `ignore_errors` is set to `False`.
             BackendParameterException: If the `target` is not a valid collection name.
         """
-        statements = super().read(query, target, chunk_size, raw_output, ignore_errors)
+        statements = super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
         async for statement in statements:
             yield statement
 

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -20,7 +20,7 @@ from uuid import UUID, uuid4
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.exceptions import ClickHouseError
-from pydantic import BaseModel, Json, ValidationError
+from pydantic import BaseModel, Json, PositiveInt, ValidationError
 
 from ralph.backends.data.base import (
     BaseDataBackend,
@@ -212,6 +212,7 @@ class ClickHouseDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read documents matching the query in the target table and yield them.
 
@@ -225,6 +226,8 @@ class ClickHouseDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -234,7 +237,9 @@ class ClickHouseDataBackend(
             BackendException: If a failure occurs during ClickHouse connection or
                 during encoding documents and `ignore_errors` is set to `False`.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -1,7 +1,6 @@
 """Elasticsearch data backend for Ralph."""
 
 from io import IOBase
-from itertools import chain
 from pathlib import Path
 from typing import Iterable, Iterator, List, Literal, Optional, TypeVar, Union
 
@@ -19,7 +18,7 @@ from ralph.backends.data.base import (
     Writable,
 )
 from ralph.conf import BaseSettingsConfig, ClientOptions, CommaSeparatedTuple
-from ralph.exceptions import BackendException, BackendParameterException
+from ralph.exceptions import BackendException
 from ralph.utils import parse_dict_to_bytes, parse_iterable_to_dict
 
 
@@ -112,6 +111,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
     """Elasticsearch data backend."""
 
     name = "es"
+    unsupported_operation_types = {BaseOperationType.APPEND}
 
     def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the Elasticsearch data backend.
@@ -314,26 +314,33 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
             BackendParameterException: If the `operation_type` is `APPEND` as it is not
                 supported.
         """
+        return super().write(data, target, chunk_size, ignore_errors, operation_type)
+
+    def _write_bytes(  # noqa: PLR0913
+        self,
+        data: Iterable[bytes],
+        target: Optional[str],
+        chunk_size: int,
+        ignore_errors: bool,
+        operation_type: BaseOperationType,
+    ) -> int:
+        """Method called by `self.write` writing bytes. See `self.write`."""
+        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
+        return self._write_dicts(
+            statements, target, chunk_size, ignore_errors, operation_type
+        )
+
+    def _write_dicts(  # noqa: PLR0913
+        self,
+        data: Iterable[dict],
+        target: Optional[str],
+        chunk_size: int,
+        ignore_errors: bool,
+        operation_type: BaseOperationType,
+    ) -> int:
+        """Method called by `self.write` writing dictionaries. See `self.write`."""
         count = 0
-        data = iter(data)
-        try:
-            first_record = next(data)
-        except StopIteration:
-            self.logger.info("Data Iterator is empty; skipping write to target.")
-            return count
-        if not operation_type:
-            operation_type = self.default_operation_type
         target = target if target else self.settings.DEFAULT_INDEX
-        chunk_size = chunk_size if chunk_size else self.settings.DEFAULT_CHUNK_SIZE
-        if operation_type == BaseOperationType.APPEND:
-            msg = "Append operation_type is not allowed."
-            self.logger.error(msg)
-            raise BackendParameterException(msg)
-
-        data = chain((first_record,), data)
-        if isinstance(first_record, bytes):
-            data = parse_iterable_to_dict(data, ignore_errors, self.logger)
-
         msg = "Start writing to the %s index (chunk size: %d)"
         self.logger.debug(msg, target, chunk_size)
         try:

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -6,7 +6,7 @@ from typing import Iterable, Iterator, List, Literal, Optional, TypeVar, Union
 
 from elasticsearch import ApiError, Elasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, streaming_bulk
-from pydantic import BaseModel
+from pydantic import BaseModel, PositiveInt
 
 from ralph.backends.data.base import (
     BaseDataBackend,
@@ -199,6 +199,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read documents matching the query in the target index and yield them.
 
@@ -213,6 +214,8 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
             raw_output (bool): Controls whether to yield dictionaries or bytes.
             ignore_errors (bool): No impact as encoding errors are not expected in
                 Elasticsearch results.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -221,7 +224,9 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
         Raise:
             BackendException: If a failure occurs during Elasticsearch connection.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Iterable, Iterator, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
+from pydantic import PositiveInt
+
 from ralph.backends.data.base import (
     BaseDataBackend,
     BaseDataBackendSettings,
@@ -152,6 +154,7 @@ class FSDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read files matching the query in the target folder and yield them.
 
@@ -167,6 +170,8 @@ class FSDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next chunk of the read files if `raw_output` is True.
@@ -176,7 +181,9 @@ class FSDataBackend(
             BackendException: If a failure during the read operation occurs or
                 during JSON encoding lines and `ignore_errors` is set to `False`.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -4,6 +4,7 @@ from typing import Iterator, Literal, Optional, Union
 
 import ovh
 import requests
+from pydantic import PositiveInt
 
 from ralph.backends.data.base import (
     BaseDataBackend,
@@ -156,6 +157,7 @@ class LDPDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = True,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read an archive matching the query in the target stream_id and yield it.
 
@@ -166,6 +168,8 @@ class LDPDataBackend(
             chunk_size (int or None): The chunk size when reading archives by batch.
             raw_output (bool): Should always be set to `True`.
             ignore_errors (bool): No impact as no encoding operation is performed.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The content of the archive matching the query.
@@ -174,7 +178,9 @@ class LDPDataBackend(
             BackendException: If a failure occurs during LDP connection.
             BackendParameterException: If the `query` argument is not an archive name.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_dicts(
         self,

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -6,7 +6,6 @@ import hashlib
 import logging
 import struct
 from io import IOBase
-from itertools import chain
 from typing import Generator, Iterable, Iterator, List, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
@@ -92,6 +91,7 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
     """MongoDB data backend."""
 
     name = "mongo"
+    unsupported_operation_types = {BaseOperationType.APPEND}
 
     def __init__(self, settings: Optional[Settings] = None):
         """Instantiate the MongoDB client.
@@ -264,32 +264,35 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
             BackendParameterException: If the `operation_type` is `APPEND` as it is not
                 supported.
         """
-        if not operation_type:
-            operation_type = self.default_operation_type
+        return super().write(data, target, chunk_size, ignore_errors, operation_type)
 
-        if operation_type == BaseOperationType.APPEND:
-            msg = "Append operation_type is not allowed."
-            self.logger.error(msg)
-            raise BackendParameterException(msg)
+    def _write_bytes(  # noqa: PLR0913
+        self,
+        data: Iterable[bytes],
+        target: Optional[str],
+        chunk_size: int,
+        ignore_errors: bool,
+        operation_type: BaseOperationType,
+    ) -> int:
+        """Method called by `self.write` writing bytes. See `self.write`."""
+        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
+        return self._write_dicts(
+            statements, target, chunk_size, ignore_errors, operation_type
+        )
 
-        if not chunk_size:
-            chunk_size = self.settings.DEFAULT_CHUNK_SIZE
-
+    def _write_dicts(  # noqa: PLR0913
+        self,
+        data: Iterable[dict],
+        target: Optional[str],
+        chunk_size: int,
+        ignore_errors: bool,
+        operation_type: BaseOperationType,
+    ) -> int:
+        """Method called by `self.write` writing dictionaries. See `self.write`."""
+        count = 0
         collection = self._get_target_collection(target)
         msg = "Start writing to the %s collection of the %s database (chunk size: %d)"
         self.logger.debug(msg, collection, self.database, chunk_size)
-
-        count = 0
-        data = iter(data)
-        try:
-            first_record = next(data)
-        except StopIteration:
-            self.logger.info("Data Iterator is empty; skipping write to target.")
-            return count
-        data = chain((first_record,), data)
-        if isinstance(first_record, bytes):
-            data = parse_iterable_to_dict(data, ignore_errors, self.logger)
-
         if operation_type == BaseOperationType.UPDATE:
             for batch in iter_by_batch(self.to_replace_one(data), chunk_size):
                 count += self._bulk_update(batch, ignore_errors, collection)

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from bson.errors import BSONError
 from bson.objectid import ObjectId
 from dateutil.parser import isoparse
-from pydantic import Json, MongoDsn, constr
+from pydantic import Json, MongoDsn, PositiveInt, constr
 from pymongo import MongoClient, ReplaceOne
 from pymongo.collection import Collection
 from pymongo.errors import (
@@ -177,6 +177,7 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read documents matching the `query` from `target` collection and yield them.
 
@@ -190,6 +191,8 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.
@@ -200,7 +203,9 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
                 during encoding documents and `ignore_errors` is set to `False`.
             BackendParameterException: If the `target` is not a valid collection name.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -14,6 +14,7 @@ from botocore.exceptions import (
     ReadTimeoutError,
     ResponseStreamingError,
 )
+from pydantic import PositiveInt
 from requests_toolbelt import StreamingIterator
 
 from ralph.backends.data.base import (
@@ -170,6 +171,7 @@ class S3DataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read an object matching the `query` in the `target` bucket and yield it.
 
@@ -182,6 +184,8 @@ class S3DataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.
@@ -192,7 +196,9 @@ class S3DataBackend(
                 during object encoding and `ignore_errors` is set to `False`.
             BackendParameterException: If a backend argument value is not valid.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -5,6 +5,7 @@ from io import IOBase
 from typing import Any, Iterable, Iterator, Optional, Tuple, Union
 from uuid import uuid4
 
+from pydantic import PositiveInt
 from swiftclient.service import ClientException, Connection
 
 from ralph.backends.data.base import (
@@ -179,6 +180,7 @@ class SwiftDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read objects matching the `query` in the `target` container and yield them.
 
@@ -196,6 +198,8 @@ class SwiftDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.
@@ -206,7 +210,9 @@ class SwiftDataBackend(
                 during encoding records and `ignore_errors` is set to `False`.
             BackendParameterException: If a backend argument value is not valid.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/tests/backends/data/test_clickhouse.py
+++ b/tests/backends/data/test_clickhouse.py
@@ -627,10 +627,8 @@ def test_backends_data_clickhouse_write_wrong_operation_type(
     ]
 
     backend = clickhouse_backend()
-    with pytest.raises(
-        BackendParameterException,
-        match=f"{BaseOperationType.APPEND.name} operation_type is not allowed.",
-    ):
+    msg = "Append operation_type is not allowed."
+    with pytest.raises(BackendParameterException, match=msg):
         backend.write(data=statements, operation_type=BaseOperationType.APPEND)
     backend.close()
 

--- a/tests/backends/data/test_s3.py
+++ b/tests/backends/data/test_s3.py
@@ -514,7 +514,7 @@ def test_backends_data_s3_write_with_append_or_delete_operation(
     backend = s3_backend()
     with pytest.raises(
         BackendParameterException,
-        match=f"{operation_type.name} operation_type is not allowed.",
+        match=f"{operation_type.value.capitalize()} operation_type is not allowed.",
     ):
         backend.write(data=[b"foo"], operation_type=operation_type)
     backend.close()

--- a/tests/backends/data/test_swift.py
+++ b/tests/backends/data/test_swift.py
@@ -608,7 +608,7 @@ def test_backends_data_swift_write_with_invalid_operation(
 
     backend = swift_backend()
 
-    msg = f"{operation_type.name} operation_type is not allowed."
+    msg = f"{operation_type.value.capitalize()} operation_type is not allowed."
     with pytest.raises(BackendParameterException, match=msg):
         backend.write(data=[b"foo"], operation_type=operation_type)
 


### PR DESCRIPTION
## Purpose

Data backends that implement the `write` method repeatedly handle some common tasks (e.g., setting a default `chunk_size`).
We want to factorize those tasks.

## Proposal

We propose to use a template pattern to factorize repeated tasks.
We move core backend write implementation to private `_write_dicts` and `_write_bytes` methods and make the public `write` method perform common tasks and call the private methods.

- [x] add private abstract `_write_dicts` and `_write_bytes` methods for writable data backends
- [x] make the `BaseDataBackend.write` method non-abstract.

**Note:** This PR depends on #515
