### PR TITLE
✨(backends) add max_statements option to data backends

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator, Iterable, Optional, TypeVar, Union
 
 from elasticsearch import ApiError, AsyncElasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, async_streaming_bulk
+from pydantic import PositiveInt
 
 from ralph.backends.data.base import (
     AsyncListable,
@@ -114,6 +115,7 @@ class AsyncESDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
         """Read documents matching the query in the target index and yield them.
 
@@ -128,6 +130,8 @@ class AsyncESDataBackend(
             raw_output (bool): Controls whether to yield dictionaries or bytes.
             ignore_errors (bool): No impact as encoding errors are not expected in
                 Elasticsearch results.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -136,7 +140,9 @@ class AsyncESDataBackend(
         Raise:
             BackendException: If a failure occurs during Elasticsearch connection.
         """
-        statements = super().read(query, target, chunk_size, raw_output, ignore_errors)
+        statements = super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
         async for statement in statements:
             yield statement
 

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator, Iterable, Optional, TypeVar, Union
 
 from bson.errors import BSONError
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pydantic import PositiveInt
 from pymongo.errors import BulkWriteError, ConnectionFailure, InvalidName, PyMongoError
 
 from ralph.backends.data.base import BaseOperationType
@@ -122,6 +123,7 @@ class AsyncMongoDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
         """Read documents matching the `query` from `target` collection and yield them.
 
@@ -135,6 +137,8 @@ class AsyncMongoDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -145,7 +149,9 @@ class AsyncMongoDataBackend(
                 during encoding documents and `ignore_errors` is set to `False`.
             BackendParameterException: If the `target` is not a valid collection name.
         """
-        statements = super().read(query, target, chunk_size, raw_output, ignore_errors)
+        statements = super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
         async for statement in statements:
             yield statement
 

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -20,7 +20,7 @@ from uuid import UUID, uuid4
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.exceptions import ClickHouseError
-from pydantic import BaseModel, Json, ValidationError
+from pydantic import BaseModel, Json, PositiveInt, ValidationError
 
 from ralph.backends.data.base import (
     BaseDataBackend,
@@ -212,6 +212,7 @@ class ClickHouseDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read documents matching the query in the target table and yield them.
 
@@ -225,6 +226,8 @@ class ClickHouseDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -234,7 +237,9 @@ class ClickHouseDataBackend(
             BackendException: If a failure occurs during ClickHouse connection or
                 during encoding documents and `ignore_errors` is set to `False`.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -6,7 +6,7 @@ from typing import Iterable, Iterator, List, Literal, Optional, TypeVar, Union
 
 from elasticsearch import ApiError, Elasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, streaming_bulk
-from pydantic import BaseModel
+from pydantic import BaseModel, PositiveInt
 
 from ralph.backends.data.base import (
     BaseDataBackend,
@@ -199,6 +199,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read documents matching the query in the target index and yield them.
 
@@ -213,6 +214,8 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
             raw_output (bool): Controls whether to yield dictionaries or bytes.
             ignore_errors (bool): No impact as encoding errors are not expected in
                 Elasticsearch results.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -221,7 +224,9 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
         Raise:
             BackendException: If a failure occurs during Elasticsearch connection.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Iterable, Iterator, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
+from pydantic import PositiveInt
+
 from ralph.backends.data.base import (
     BaseDataBackend,
     BaseDataBackendSettings,
@@ -152,6 +154,7 @@ class FSDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read files matching the query in the target folder and yield them.
 
@@ -167,6 +170,8 @@ class FSDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The next chunk of the read files if `raw_output` is True.
@@ -176,7 +181,9 @@ class FSDataBackend(
             BackendException: If a failure during the read operation occurs or
                 during JSON encoding lines and `ignore_errors` is set to `False`.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -4,6 +4,7 @@ from typing import Iterator, Literal, Optional, Union
 
 import ovh
 import requests
+from pydantic import PositiveInt
 
 from ralph.backends.data.base import (
     BaseDataBackend,
@@ -156,6 +157,7 @@ class LDPDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = True,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read an archive matching the query in the target stream_id and yield it.
 
@@ -166,6 +168,8 @@ class LDPDataBackend(
             chunk_size (int or None): The chunk size when reading archives by batch.
             raw_output (bool): Should always be set to `True`.
             ignore_errors (bool): No impact as no encoding operation is performed.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             bytes: The content of the archive matching the query.
@@ -174,7 +178,9 @@ class LDPDataBackend(
             BackendException: If a failure occurs during LDP connection.
             BackendParameterException: If the `query` argument is not an archive name.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_dicts(
         self,

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from bson.errors import BSONError
 from bson.objectid import ObjectId
 from dateutil.parser import isoparse
-from pydantic import Json, MongoDsn, constr
+from pydantic import Json, MongoDsn, PositiveInt, constr
 from pymongo import MongoClient, ReplaceOne
 from pymongo.collection import Collection
 from pymongo.errors import (
@@ -177,6 +177,7 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read documents matching the `query` from `target` collection and yield them.
 
@@ -190,6 +191,8 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.
@@ -200,7 +203,9 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
                 during encoding documents and `ignore_errors` is set to `False`.
             BackendParameterException: If the `target` is not a valid collection name.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -14,6 +14,7 @@ from botocore.exceptions import (
     ReadTimeoutError,
     ResponseStreamingError,
 )
+from pydantic import PositiveInt
 from requests_toolbelt import StreamingIterator
 
 from ralph.backends.data.base import (
@@ -170,6 +171,7 @@ class S3DataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read an object matching the `query` in the `target` bucket and yield it.
 
@@ -182,6 +184,8 @@ class S3DataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.
@@ -192,7 +196,9 @@ class S3DataBackend(
                 during object encoding and `ignore_errors` is set to `False`.
             BackendParameterException: If a backend argument value is not valid.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -5,6 +5,7 @@ from io import IOBase
 from typing import Any, Iterable, Iterator, Optional, Tuple, Union
 from uuid import uuid4
 
+from pydantic import PositiveInt
 from swiftclient.service import ClientException, Connection
 
 from ralph.backends.data.base import (
@@ -179,6 +180,7 @@ class SwiftDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        max_statements: Optional[PositiveInt] = None,
     ) -> Union[Iterator[bytes], Iterator[dict]]:
         """Read objects matching the `query` in the `target` container and yield them.
 
@@ -196,6 +198,8 @@ class SwiftDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            max_statements (int): The maximum number of statements to yield.
+                If `None` (default), there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.
@@ -206,7 +210,9 @@ class SwiftDataBackend(
                 during encoding records and `ignore_errors` is set to `False`.
             BackendParameterException: If a backend argument value is not valid.
         """
-        yield from super().read(query, target, chunk_size, raw_output, ignore_errors)
+        yield from super().read(
+            query, target, chunk_size, raw_output, ignore_errors, max_statements
+        )
 
     def _read_bytes(
         self,


### PR DESCRIPTION
## Purpose

To align `data` backends with `http` backends, we add the `max_statements` option to the `read` method, allowing users to specify the maximum number of yielded statements.

## Proposal

- [x] add `max_statements` option to data backend `read` method

**Note:** This PR depends on #517

