### PR TITLE
✨(backends) add simultaneous option for AsyncWritable data backends

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -217,6 +217,7 @@ class AsyncESDataBackend(
         chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
         operation_type: Optional[BaseOperationType] = None,
+        concurrency: Optional[PositiveInt] = None,
     ) -> int:
         """Write data documents to the target index and return their count.
 
@@ -232,6 +233,8 @@ class AsyncESDataBackend(
             operation_type (BaseOperationType or None): The mode of the write operation.
                 If `operation_type` is `None`, the `default_operation_type` is used
                 instead. See `BaseOperationType`.
+            concurrency (int): The number of chunks to write concurrently.
+                If `None` it defaults to `1`.
 
         Return:
             int: The number of documents written.
@@ -243,7 +246,7 @@ class AsyncESDataBackend(
                 supported.
         """
         return await super().write(
-            data, target, chunk_size, ignore_errors, operation_type
+            data, target, chunk_size, ignore_errors, operation_type, concurrency
         )
 
     async def _write_bytes(  # noqa: PLR0913

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -196,6 +196,7 @@ class AsyncMongoDataBackend(
         chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
         operation_type: Optional[BaseOperationType] = None,
+        concurrency: Optional[PositiveInt] = None,
     ) -> int:
         """Write data documents to the target collection and return their count.
 
@@ -210,6 +211,8 @@ class AsyncMongoDataBackend(
             operation_type (BaseOperationType or None): The mode of the write operation.
                 If `operation_type` is `None`, the `default_operation_type` is used
                     instead. See `BaseOperationType`.
+            concurrency (int): The number of chunks to write concurrently.
+                If `None` it defaults to `1`.
 
         Return:
             int: The number of documents written.
@@ -221,7 +224,7 @@ class AsyncMongoDataBackend(
                 supported.
         """
         return await super().write(
-            data, target, chunk_size, ignore_errors, operation_type
+            data, target, chunk_size, ignore_errors, operation_type, concurrency
         )
 
     async def _write_bytes(  # noqa: PLR0913

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, BaseSettings, PositiveInt, ValidationError
 
 from ralph.conf import BaseSettingsConfig, core_settings
 from ralph.exceptions import BackendParameterException
+from ralph.utils import gather_with_limited_concurrency, iter_by_batch
 
 
 class BaseDataBackendSettings(BaseSettings):
@@ -131,7 +132,7 @@ class Writable(Loggable, ABC):
             operation_type = self.default_operation_type
 
         if operation_type in self.unsupported_operation_types:
-            msg = f"{operation_type.value.capitalize()} operation_type is not allowed."
+            msg = f"{operation_type.value.capitalize()} operation_type is not allowed"
             self.logger.error(msg)
             raise BackendParameterException(msg)
 
@@ -139,7 +140,7 @@ class Writable(Loggable, ABC):
         try:
             first_record = next(data)
         except StopIteration:
-            self.logger.info("Data Iterator is empty; skipping write to target.")
+            self.logger.info("Data Iterator is empty; skipping write to target")
             return 0
         data = chain((first_record,), data)
 
@@ -356,6 +357,7 @@ class AsyncWritable(Loggable, ABC):
         chunk_size: Optional[int] = None,
         ignore_errors: bool = False,
         operation_type: Optional[BaseOperationType] = None,
+        concurrency: Optional[PositiveInt] = None,
     ) -> int:
         """Write `data` records to the `target` container and return their count.
 
@@ -371,6 +373,8 @@ class AsyncWritable(Loggable, ABC):
             operation_type (BaseOperationType or None): The mode of the write operation.
                 If `operation_type` is `None`, the `default_operation_type` is used
                 instead. See `BaseOperationType`.
+            concurrency (int): The number of chunks to write concurrently.
+                If `None` it defaults to `1`.
 
         Return:
             int: The number of written records.
@@ -384,7 +388,7 @@ class AsyncWritable(Loggable, ABC):
             operation_type = self.default_operation_type
 
         if operation_type in self.unsupported_operation_types:
-            msg = f"{operation_type.value.capitalize()} operation_type is not allowed."
+            msg = f"{operation_type.value.capitalize()} operation_type is not allowed"
             self.logger.error(msg)
             raise BackendParameterException(msg)
 
@@ -392,14 +396,32 @@ class AsyncWritable(Loggable, ABC):
         try:
             first_record = next(data)
         except StopIteration:
-            self.logger.info("Data Iterator is empty; skipping write to target.")
+            self.logger.info("Data Iterator is empty; skipping write to target")
             return 0
         data = chain((first_record,), data)
 
         chunk_size = chunk_size if chunk_size else self.settings.WRITE_CHUNK_SIZE
         is_bytes = isinstance(first_record, bytes)
         writer = self._write_bytes if is_bytes else self._write_dicts
-        return await writer(data, target, chunk_size, ignore_errors, operation_type)
+
+        concurrency = concurrency if concurrency else 1
+        if concurrency == 1:
+            return await writer(data, target, chunk_size, ignore_errors, operation_type)
+
+        if concurrency < 1:
+            msg = "concurrency must be a strictly positive integer"
+            self.logger.error(msg)
+            raise BackendParameterException(msg)
+
+        count = 0
+        for batch in iter_by_batch(iter_by_batch(data, chunk_size), concurrency):
+            tasks = set()
+            for chunk in batch:
+                task = writer(chunk, target, chunk_size, ignore_errors, operation_type)
+                tasks.add(task)
+            result = await gather_with_limited_concurrency(concurrency, *tasks)
+            count += sum(result)
+        return count
 
     @abstractmethod
     async def _write_bytes(  # noqa: PLR0913

--- a/src/ralph/backends/http/async_lrs.py
+++ b/src/ralph/backends/http/async_lrs.py
@@ -238,7 +238,7 @@ class AsyncLRSHTTPBackend(BaseHTTPBackend):
         try:
             first_record = next(data)
         except StopIteration:
-            logger.info("Data Iterator is empty; skipping write to target.")
+            logger.info("Data Iterator is empty; skipping write to target")
             return 0
 
         if not operation_type:

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -6,13 +6,17 @@ from typing import Any, Union
 import pytest
 
 from ralph.backends.data.base import (
+    AsyncWritable,
     BaseAsyncDataBackend,
     BaseDataBackend,
     BaseDataBackendSettings,
+    BaseOperationType,
     BaseQuery,
+    Writable,
     get_backend_generic_argument,
 )
 from ralph.exceptions import BackendParameterException
+from ralph.utils import gather_with_limited_concurrency
 
 
 @pytest.mark.parametrize(
@@ -171,10 +175,10 @@ async def test_backends_data_base_async_read_with_max_statements():
             for _ in range(3):
                 yield b""
 
-        def status(self):
+        async def status(self):
             pass
 
-        def close(self):
+        async def close(self):
             pass
 
     backend = MockAsyncBaseDataBackend()
@@ -197,3 +201,222 @@ async def test_backends_data_base_async_read_with_max_statements():
 
     assert not [_ async for _ in backend.read(max_statements=0)]
     assert not [_ async for _ in backend.read(max_statements=0, raw_output=True)]
+
+
+@pytest.mark.parametrize(
+    "chunk_size,concurrency,expected_item_count,expected_write_calls",
+    [
+        # Given a chunk size equal to the size of the data, only one write call should
+        # be performed, regardless of how many concurrent requests are allowed.
+        (4, None, {4}, 1),
+        (4, 1, {4}, 1),
+        (4, 20, {4}, 1),
+        # Given a chunk size equal to half (or a bit more) of the data, two write
+        # calls should be performed.
+        (2, 2, {2}, 2),
+        (2, 20, {2}, 2),
+        (3, 2, {1, 3}, 2),
+        (3, 20, {1, 3}, 2),
+        # However, given a limit of one concurrent request, only one write call is
+        # allowed.
+        (2, 1, {4}, 1),
+        (3, 1, {4}, 1),
+        # Given a chunk size equal to one, up to four concurrent write calls can be
+        # performed.
+        (1, 1, {4}, 1),
+        (1, 2, {1}, 4),
+        (1, 20, {1}, 4),
+    ],
+)
+@pytest.mark.anyio
+async def test_backends_data_base_async_write_with_concurrency(
+    chunk_size, concurrency, expected_item_count, expected_write_calls, monkeypatch
+):
+    """Test the async `AsyncWritable.write` method with `concurrency` argument."""
+
+    write_calls = {"count": 0}
+    gather_calls = {"count": 0}
+    data = (i for i in range(4))
+    expected_data = {0, 1, 2, 3}
+    expected_concurrency = concurrency if concurrency else 1
+
+    class MockAsyncBaseDataBackend(
+        BaseAsyncDataBackend[BaseDataBackendSettings, BaseQuery], AsyncWritable
+    ):
+        """A class mocking the base database class."""
+
+        async def _read_dicts(self, *args):
+            pass
+
+        async def _read_bytes(self, *args):
+            pass
+
+        async def _write_bytes(self, data, *args):
+            pass
+
+        async def _write_dicts(self, data, *args):
+            write_calls["count"] += 1
+            item_count = 0
+            for item in data:
+                expected_data.remove(item)
+                item_count += 1
+
+            assert item_count in expected_item_count
+            return item_count
+
+        async def status(self):
+            pass
+
+        async def close(self):
+            pass
+
+    async def mock_gather_with_limited_concurrency(num_tasks, *tasks):
+        """Mock the gather_with_limited_concurrency method."""
+        assert len(tasks) <= expected_concurrency
+        assert num_tasks == expected_concurrency
+        gather_calls["count"] += 1
+        return await gather_with_limited_concurrency(num_tasks, *tasks)
+
+    backend = MockAsyncBaseDataBackend()
+    monkeypatch.setattr(
+        "ralph.backends.data.base.gather_with_limited_concurrency",
+        mock_gather_with_limited_concurrency,
+    )
+
+    assert (
+        await backend.write(data, chunk_size=chunk_size, concurrency=concurrency) == 4
+    )
+    # All data should be consumed.
+    assert not expected_data
+    assert write_calls["count"] == expected_write_calls
+
+    if expected_concurrency == 1:
+        assert not gather_calls["count"]
+    else:
+        assert gather_calls["count"] == max(
+            1, int(4 / chunk_size / expected_concurrency)
+        )
+
+
+@pytest.mark.anyio
+async def test_backends_data_base_write_with_invalid_parameters(caplog):
+    """Test the Writable backend `write` method, given invalid parameters."""
+
+    class MockBaseDataBackend(
+        BaseDataBackend[BaseDataBackendSettings, BaseQuery], Writable
+    ):
+        """A class mocking the base database class."""
+
+        unsupported_operation_types = {BaseOperationType.DELETE}
+
+        def _read_dicts(self, *args):
+            pass
+
+        def _read_bytes(self, *args):
+            pass
+
+        def _write_bytes(self, *args):
+            pass
+
+        def _write_dicts(self, *args):
+            return 1
+
+        def status(self):
+            pass
+
+        def close(self):
+            pass
+
+    backend = MockBaseDataBackend()
+    # Given an unsupported `operation_type`, the write method should raise a
+    # `BackendParameterException` and log an error.
+    msg = "Delete operation_type is not allowed"
+    with pytest.raises(BackendParameterException, match=msg):
+        with caplog.at_level(logging.ERROR):
+            assert backend.write([{}], operation_type=BaseOperationType.DELETE)
+
+    assert (
+        "tests.backends.data.test_base",
+        logging.ERROR,
+        msg,
+    ) in caplog.record_tuples
+
+    # Given an empty data iterator, the write method should log an info and return 0.
+    msg = "Data Iterator is empty; skipping write to target"
+    with caplog.at_level(logging.INFO):
+        assert backend.write([]) == 0
+
+    assert (
+        "tests.backends.data.test_base",
+        logging.INFO,
+        msg,
+    ) in caplog.record_tuples
+
+
+@pytest.mark.anyio
+async def test_backends_data_base_async_write_with_invalid_parameters(caplog):
+    """Test the AsyncWritable backend `write` method, given invalid parameters."""
+
+    class MockAsyncBaseDataBackend(
+        BaseAsyncDataBackend[BaseDataBackendSettings, BaseQuery], AsyncWritable
+    ):
+        """A class mocking the base database class."""
+
+        unsupported_operation_types = {BaseOperationType.DELETE}
+
+        async def _read_dicts(self, *args):
+            pass
+
+        async def _read_bytes(self, *args):
+            pass
+
+        async def _write_bytes(self, *args):
+            pass
+
+        async def _write_dicts(self, *args):
+            return 1
+
+        async def status(self):
+            pass
+
+        async def close(self):
+            pass
+
+    backend = MockAsyncBaseDataBackend()
+
+    # Given `concurrency` is set to a negative value, the write method should raise a
+    # `BackendParameterException` and produce an error log.
+    msg = "concurrency must be a strictly positive integer"
+    with pytest.raises(BackendParameterException, match=msg):
+        with caplog.at_level(logging.ERROR):
+            assert await backend.write([{}], concurrency=-1)
+
+    assert (
+        "tests.backends.data.test_base",
+        logging.ERROR,
+        msg,
+    ) in caplog.record_tuples
+
+    # Given an unsupported `operation_type`, the write method should raise a
+    # `BackendParameterException` and log an error.
+    msg = "Delete operation_type is not allowed"
+    with pytest.raises(BackendParameterException, match=msg):
+        with caplog.at_level(logging.ERROR):
+            assert await backend.write([{}], operation_type=BaseOperationType.DELETE)
+
+    assert (
+        "tests.backends.data.test_base",
+        logging.ERROR,
+        msg,
+    ) in caplog.record_tuples
+
+    # Given an empty data iterator, the write method should log an info and return 0.
+    msg = "Data Iterator is empty; skipping write to target"
+    with caplog.at_level(logging.INFO):
+        assert await backend.write([]) == 0
+
+    assert (
+        "tests.backends.data.test_base",
+        logging.INFO,
+        msg,
+    ) in caplog.record_tuples

--- a/tests/backends/data/test_clickhouse.py
+++ b/tests/backends/data/test_clickhouse.py
@@ -631,7 +631,7 @@ def test_backends_data_clickhouse_write_wrong_operation_type(
     ]
 
     backend = clickhouse_backend()
-    msg = "Append operation_type is not allowed."
+    msg = "Append operation_type is not allowed"
     with pytest.raises(BackendParameterException, match=msg):
         backend.write(data=statements, operation_type=BaseOperationType.APPEND)
     backend.close()

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -463,7 +463,7 @@ def test_backends_data_es_write_with_create_operation(es, es_backend, caplog):
     assert (
         "ralph.backends.data.es",
         logging.INFO,
-        "Data Iterator is empty; skipping write to target.",
+        "Data Iterator is empty; skipping write to target",
     ) in caplog.record_tuples
 
     # Given an iterator with multiple documents, the write method should write the
@@ -569,7 +569,7 @@ def test_backends_data_es_write_with_append_operation(es_backend, caplog):
     should raise a `BackendParameterException`.
     """
     backend = es_backend()
-    msg = "Append operation_type is not allowed."
+    msg = "Append operation_type is not allowed"
     with pytest.raises(BackendParameterException, match=msg):
         with caplog.at_level(logging.ERROR):
             backend.write(data=[{}], operation_type=BaseOperationType.APPEND)
@@ -577,7 +577,7 @@ def test_backends_data_es_write_with_append_operation(es_backend, caplog):
     assert (
         "ralph.backends.data.es",
         logging.ERROR,
-        "Append operation_type is not allowed.",
+        "Append operation_type is not allowed",
     ) in caplog.record_tuples
 
     backend.close()

--- a/tests/backends/data/test_fs.py
+++ b/tests/backends/data/test_fs.py
@@ -787,7 +787,7 @@ def test_backends_data_fs_write_with_delete_operation(
 
     backend = fs_backend()
 
-    msg = "Delete operation_type is not allowed."
+    msg = "Delete operation_type is not allowed"
     with pytest.raises(BackendParameterException, match=msg):
         backend.write(data=[b"foo"], operation_type=BaseOperationType.DELETE)
 
@@ -958,7 +958,7 @@ def test_backends_data_fs_write_with_no_data(fs_backend, caplog):
     with caplog.at_level(logging.INFO):
         assert backend.write(data=[]) == 0
 
-    msg = "Data Iterator is empty; skipping write to target."
+    msg = "Data Iterator is empty; skipping write to target"
     assert ("ralph.backends.data.fs", logging.INFO, msg) in caplog.record_tuples
 
 

--- a/tests/backends/data/test_mongo.py
+++ b/tests/backends/data/test_mongo.py
@@ -753,7 +753,7 @@ def test_backends_data_mongo_write_with_append_operation(mongo_backend, caplog):
     should raise a `BackendParameterException`.
     """
     backend = mongo_backend()
-    msg = "Append operation_type is not allowed."
+    msg = "Append operation_type is not allowed"
     with caplog.at_level(logging.ERROR):
         with pytest.raises(BackendParameterException, match=msg):
             backend.write(data=[], operation_type=BaseOperationType.APPEND)
@@ -845,7 +845,7 @@ def test_backends_data_mongo_write_with_no_data(mongo_backend, caplog):
     with caplog.at_level(logging.INFO):
         assert backend.write(data=[]) == 0
 
-    msg = "Data Iterator is empty; skipping write to target."
+    msg = "Data Iterator is empty; skipping write to target"
     assert ("ralph.backends.data.mongo", logging.INFO, msg) in caplog.record_tuples
     backend.close()
 

--- a/tests/backends/data/test_s3.py
+++ b/tests/backends/data/test_s3.py
@@ -518,7 +518,7 @@ def test_backends_data_s3_write_with_append_or_delete_operation(
     backend = s3_backend()
     with pytest.raises(
         BackendParameterException,
-        match=f"{operation_type.value.capitalize()} operation_type is not allowed.",
+        match=f"{operation_type.value.capitalize()} operation_type is not allowed",
     ):
         backend.write(data=[b"foo"], operation_type=operation_type)
     backend.close()

--- a/tests/backends/data/test_swift.py
+++ b/tests/backends/data/test_swift.py
@@ -612,7 +612,7 @@ def test_backends_data_swift_write_with_invalid_operation(
 
     backend = swift_backend()
 
-    msg = f"{operation_type.value.capitalize()} operation_type is not allowed."
+    msg = f"{operation_type.value.capitalize()} operation_type is not allowed"
     with pytest.raises(BackendParameterException, match=msg):
         backend.write(data=[b"foo"], operation_type=operation_type)
 

--- a/tests/backends/http/test_async_lrs.py
+++ b/tests/backends/http/test_async_lrs.py
@@ -713,7 +713,7 @@ async def test_backends_http_async_lrs_write_without_data(caplog):
         assert (
             "ralph.backends.http.async_lrs",
             logging.INFO,
-            "Data Iterator is empty; skipping write to target.",
+            "Data Iterator is empty; skipping write to target",
         ) in caplog.record_tuples
 
     assert result == 0


### PR DESCRIPTION
## Purpose

We try to align the data backend interface with the http backends.
The `simultaneous` option allows the caller of an async data backend to write data concurrently.

## Proposal

- [x] add `simultaneous` and `max_num_simultaneous` options to async Writable data backends

**Note:** This PR depends on #519

Note: The current behavior of the `max_num_simultaneous` option differs slightly with the http backed implementation:
- We log a warning instead of raising an exception when  `max_num_simultaneous`  is set and `simultaneous` is `False`
- We do not accept unlimited concurrency when `max_num_simultaneous` is set to `None` - we default to the sequential behavior instead.