### PR TITLE
✨(backends) add greedy option for data backends

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -115,6 +115,7 @@ class AsyncESDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        prefetch: Optional[PositiveInt] = None,
         max_statements: Optional[PositiveInt] = None,
     ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
         """Read documents matching the query in the target index and yield them.
@@ -130,8 +131,11 @@ class AsyncESDataBackend(
             raw_output (bool): Controls whether to yield dictionaries or bytes.
             ignore_errors (bool): No impact as encoding errors are not expected in
                 Elasticsearch results.
+            prefetch (int): The number of records to prefetch (queue) while yielding.
+                If `prefetch` is `None` it defaults to `1`, i.e. no records are
+                prefetched.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -141,7 +145,13 @@ class AsyncESDataBackend(
             BackendException: If a failure occurs during Elasticsearch connection.
         """
         statements = super().read(
-            query, target, chunk_size, raw_output, ignore_errors, max_statements
+            query,
+            target,
+            chunk_size,
+            raw_output,
+            ignore_errors,
+            prefetch,
+            max_statements,
         )
         async for statement in statements:
             yield statement

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -123,6 +123,7 @@ class AsyncMongoDataBackend(
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
+        prefetch: Optional[PositiveInt] = None,
         max_statements: Optional[PositiveInt] = None,
     ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
         """Read documents matching the `query` from `target` collection and yield them.
@@ -137,8 +138,11 @@ class AsyncMongoDataBackend(
             ignore_errors (bool): If `True`, encoding errors during the read operation
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
+            prefetch (int): The number of records to prefetch (queue) while yielding.
+                If `prefetch` is `None` it defaults to `1`, i.e. no records are
+                prefetched.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.
@@ -150,7 +154,13 @@ class AsyncMongoDataBackend(
             BackendParameterException: If the `target` is not a valid collection name.
         """
         statements = super().read(
-            query, target, chunk_size, raw_output, ignore_errors, max_statements
+            query,
+            target,
+            chunk_size,
+            raw_output,
+            ignore_errors,
+            prefetch,
+            max_statements,
         )
         async for statement in statements:
             yield statement

--- a/src/ralph/backends/data/clickhouse.py
+++ b/src/ralph/backends/data/clickhouse.py
@@ -226,7 +226,7 @@ class ClickHouseDataBackend(
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -215,7 +215,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
             ignore_errors (bool): No impact as encoding errors are not expected in
                 Elasticsearch results.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             bytes: The next raw document if `raw_output` is True.

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -172,7 +172,7 @@ class FSDataBackend(
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             bytes: The next chunk of the read files if `raw_output` is True.

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -170,7 +170,7 @@ class LDPDataBackend(
             raw_output (bool): Should always be set to `True`.
             ignore_errors (bool): No impact as no encoding operation is performed.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             bytes: The content of the archive matching the query.

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -193,7 +193,7 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -186,7 +186,7 @@ class S3DataBackend(
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -200,7 +200,7 @@ class SwiftDataBackend(
                 will be ignored and logged.
                 If `False` (default), a `BackendException` is raised on any error.
             max_statements (int): The maximum number of statements to yield.
-                If `None` (default), there is no maximum.
+                If `None` (default) or `0`, there is no maximum.
 
         Yield:
             dict: If `raw_output` is False.

--- a/tests/backends/data/test_async_es.py
+++ b/tests/backends/data/test_async_es.py
@@ -398,13 +398,19 @@ async def test_backends_data_async_es_read_with_ignore_errors(
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_read_with_raw_ouput(es, async_es_backend):
+@pytest.mark.parametrize("prefetch", [1, 10])
+async def test_backends_data_async_es_read_with_raw_ouput(
+    prefetch, es, async_es_backend
+):
     """Test the `AsyncESDataBackend.read` method with `raw_output` set to `True`."""
 
     backend = async_es_backend()
     documents = [{"id": idx, "timestamp": now()} for idx in range(10)]
     assert await backend.write(documents) == 10
-    hits = [statement async for statement in backend.read(raw_output=True)]
+    hits = [
+        statement
+        async for statement in backend.read(raw_output=True, prefetch=prefetch)
+    ]
     for i, hit in enumerate(hits):
         assert isinstance(hit, bytes)
         assert json.loads(hit).get("_source") == documents[i]
@@ -413,13 +419,16 @@ async def test_backends_data_async_es_read_with_raw_ouput(es, async_es_backend):
 
 
 @pytest.mark.anyio
-async def test_backends_data_async_es_read_without_raw_ouput(es, async_es_backend):
+@pytest.mark.parametrize("prefetch", [1, 10])
+async def test_backends_data_async_es_read_without_raw_ouput(
+    prefetch, es, async_es_backend
+):
     """Test the `AsyncESDataBackend.read` method with `raw_output` set to `False`."""
 
     backend = async_es_backend()
     documents = [{"id": idx, "timestamp": now()} for idx in range(10)]
     assert await backend.write(documents) == 10
-    hits = [statement async for statement in backend.read()]
+    hits = [statement async for statement in backend.read(prefetch=prefetch)]
     for i, hit in enumerate(hits):
         assert isinstance(hit, dict)
         assert hit.get("_source") == documents[i]

--- a/tests/backends/data/test_async_mongo.py
+++ b/tests/backends/data/test_async_mongo.py
@@ -314,9 +314,9 @@ async def test_backends_data_async_mongo_list_with_history(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("prefetch", [1, 10])
 async def test_backends_data_async_mongo_read_with_raw_output(
-    mongo,
-    async_mongo_backend,
+    prefetch, mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.read` method with `raw_output` set to `True`."""
 
@@ -334,7 +334,10 @@ async def test_backends_data_async_mongo_read_with_raw_output(
     await backend.collection.insert_many(documents)
     await backend.database.foobar.insert_many(documents[:2])
 
-    result = [statement async for statement in backend.read(raw_output=True)]
+    result = [
+        statement
+        async for statement in backend.read(raw_output=True, prefetch=prefetch)
+    ]
     assert result == expected
     result = [
         statement async for statement in backend.read(raw_output=True, target="foobar")
@@ -351,8 +354,9 @@ async def test_backends_data_async_mongo_read_with_raw_output(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("prefetch", [1, 10])
 async def test_backends_data_async_mongo_read_without_raw_output(
-    mongo, async_mongo_backend
+    prefetch, mongo, async_mongo_backend
 ):
     """Test the `AsyncMongoDataBackend.read` method with `raw_output` set to
     `False`.
@@ -372,7 +376,9 @@ async def test_backends_data_async_mongo_read_without_raw_output(
     await backend.collection.insert_many(documents)
     await backend.database.foobar.insert_many(documents[:2])
 
-    assert [statement async for statement in backend.read()] == expected
+    assert [
+        statement async for statement in backend.read(prefetch=prefetch)
+    ] == expected
     assert [statement async for statement in backend.read(target="foobar")] == expected[
         :2
     ]

--- a/tests/backends/data/test_s3.py
+++ b/tests/backends/data/test_s3.py
@@ -278,12 +278,7 @@ def test_backends_data_s3_read_with_valid_name_should_write_to_history(
         "timestamp": freezed_now,
     } in backend.history
 
-    list(
-        backend.read(
-            query="2022-09-30.gz",
-            raw_output=False,
-        )
-    )
+    list(backend.read(query="2022-09-30.gz", raw_output=False))
 
     assert {
         "backend": "s3",


### PR DESCRIPTION
## Purpose

We try to align the data backend interface with the http backends.
The `greedy` option allows the caller to read all records greedily before the generator yields them.

## Proposal

- [x] add `greedy` option to `BaseDataBackend.read` method

**Note:** This PR depends on #520

Update: We propose to rename the greedy option to `prefetch: int` allowing us to set how many statements should be greedingly prefetched.