### PR TITLE
✨(backends) replace archive cli argument with query (rebased)

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -111,7 +111,7 @@ class AsyncESDataBackend(
 
     async def read(  # noqa: PLR0913
         self,
-        query: Optional[Union[str, ESQuery]] = None,
+        query: Optional[ESQuery] = None,
         target: Optional[str] = None,
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
@@ -122,9 +122,7 @@ class AsyncESDataBackend(
         """Read documents matching the query in the target index and yield them.
 
         Args:
-            query (str or ESQuery): A query in the Lucene query string syntax or a
-                dictionary defining a search definition using the Elasticsearch Query
-                DSL. The Lucene query overrides the query DSL if present. See ESQuery.
+            query (ESQuery): The Elasticsearch query to use when fetching documents.
             target (str or None): The target Elasticsearch index name to query.
                 If target is `None`, the `DEFAULT_INDEX` is used instead.
             chunk_size (int or None): The chunk size when reading documents by batches.
@@ -181,10 +179,7 @@ class AsyncESDataBackend(
                 raise BackendException(msg % error) from error
 
         limit = query.size
-        kwargs = query.dict(exclude={"query_string", "size"})
-        if query.query_string:
-            kwargs["q"] = query.query_string
-
+        kwargs = query.dict()
         count = chunk_size
         # The first condition is set to comprise either limit as None
         # (when the backend query does not have `size` parameter),
@@ -219,7 +214,7 @@ class AsyncESDataBackend(
         """Write data documents to the target index and return their count.
 
         Args:
-            data: (Iterable or IOBase): The data containing documents to write.
+            data (Iterable or IOBase): The data containing documents to write.
             target (str or None): The target Elasticsearch index name.
                 If target is `None`, the `DEFAULT_INDEX` is used instead.
             chunk_size (int or None): The number of documents to write in one batch.

--- a/src/ralph/backends/data/async_lrs.py
+++ b/src/ralph/backends/data/async_lrs.py
@@ -172,7 +172,7 @@ class AsyncLRSDataBackend(
         """Write `data` records to the `target` endpoint and return their count.
 
         Args:
-            data: (Iterable): The data to write.
+            data (Iterable): The data to write.
             target (str or None): Endpoint in which to write data (e.g. `/statements`).
                 If `target` is `None`, `/xAPI/statements` default endpoint is used.
             chunk_size (int or None): The number of records or bytes to write in one

--- a/src/ralph/backends/data/async_ws.py
+++ b/src/ralph/backends/data/async_ws.py
@@ -10,7 +10,6 @@ from websockets.http import USER_AGENT
 from ralph.backends.data.base import (
     BaseAsyncDataBackend,
     BaseDataBackendSettings,
-    BaseQuery,
     DataBackendStatus,
 )
 from ralph.conf import BaseSettingsConfig, ClientOptions
@@ -78,7 +77,7 @@ class WSDataBackendSettings(BaseDataBackendSettings):
     URI: AnyUrl
 
 
-class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, BaseQuery]):
+class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, str]):
     """Websocket stream backend."""
 
     name = "async_ws"
@@ -125,7 +124,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, BaseQuery])
 
     async def read(  # noqa: PLR0913
         self,
-        query: Optional[Union[str, BaseQuery]] = None,
+        query: Optional[str] = None,
         target: Optional[str] = None,
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
@@ -136,7 +135,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, BaseQuery])
         """Read records matching the `query` in the `target` container and yield them.
 
         Args:
-            query: (str or Query): Ignored.
+            query (str): Ignored.
             target (str or None): Ignored.
             chunk_size (int or None): Ignored.
             raw_output (bool): Controls whether to yield bytes or dictionaries.
@@ -174,7 +173,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, BaseQuery])
 
     async def _read_bytes(
         self,
-        query: BaseQuery,  # noqa: ARG002
+        query: str,  # noqa: ARG002
         target: Optional[str],
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
@@ -198,7 +197,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, BaseQuery])
 
     async def _read_dicts(
         self,
-        query: BaseQuery,
+        query: str,
         target: Optional[str],
         chunk_size: int,
         ignore_errors: bool,

--- a/src/ralph/backends/data/lrs.py
+++ b/src/ralph/backends/data/lrs.py
@@ -115,7 +115,7 @@ class LRSDataBackend(
 
     def read(  # noqa: PLR0913
         self,
-        query: Optional[Union[str, LRSStatementsQuery]] = None,
+        query: Optional[LRSStatementsQuery] = None,
         target: Optional[str] = None,
         chunk_size: Optional[int] = None,
         raw_output: bool = False,
@@ -202,7 +202,7 @@ class LRSDataBackend(
         """Write `data` records to the `target` endpoint and return their count.
 
         Args:
-            data: (Iterable): The data to write.
+            data (Iterable): The data to write.
             target (str or None): Endpoint in which to write data (e.g. `/statements`).
                 If `target` is `None`, `/xAPI/statements` default endpoint is used.
             chunk_size (int or None): The number of records or bytes to write in one

--- a/src/ralph/backends/lrs/async_es.py
+++ b/src/ralph/backends/lrs/async_es.py
@@ -40,8 +40,9 @@ class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBa
 
     async def query_statements_by_ids(self, ids: List[str]) -> AsyncIterator[dict]:
         """Yield statements with matching ids from the backend."""
+        query = self.query_class(query={"terms": {"_id": ids}})
         try:
-            async for document in self.read(query={"query": {"terms": {"_id": ids}}}):
+            async for document in self.read(query=query):
                 yield document["_source"]
         except (BackendException, BackendParameterException) as error:
             logger.error("Failed to read from Elasticsearch")

--- a/src/ralph/backends/lrs/async_mongo.py
+++ b/src/ralph/backends/lrs/async_mongo.py
@@ -46,10 +46,9 @@ class AsyncMongoLRSBackend(
 
     async def query_statements_by_ids(self, ids: List[str]) -> AsyncIterator[dict]:
         """Yield statements with matching ids from the backend."""
+        query = self.query_class(filter={"_source.id": {"$in": ids}})
         try:
-            async for document in self.read(
-                query={"filter": {"_source.id": {"$in": ids}}}
-            ):
+            async for document in self.read(query=query):
                 yield document["_source"]
         except (BackendException, BackendParameterException) as error:
             logger.error("Failed to read from MongoDB")

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -88,13 +88,13 @@ class ClickHouseLRSBackend(
         sort_order = "ASCENDING" if params.ascending else "DESCENDING"
         order_by = f"emission_time {sort_order}, event_id {sort_order}"
 
-        query = {
-            "select": ["event_id", "emission_time", "event"],
-            "where": where,
-            "parameters": ch_params,
-            "limit": params.limit,
-            "sort": order_by,
-        }
+        query = self.query_class(
+            select=["event_id", "emission_time", "event"],
+            where=where,
+            parameters=ch_params,
+            limit=params.limit,
+            sort=order_by,
+        )
         try:
             clickhouse_response = list(
                 self.read(
@@ -130,15 +130,15 @@ class ClickHouseLRSBackend(
             for i in range(0, len(ids), chunk_size):
                 yield ids[i : i + chunk_size]
 
-        query = {
-            "select": "event",
-            "where": "event_id IN ({ids:Array(String)})",
-            "parameters": {"ids": ["1"]},
-            "column_oriented": True,
-        }
+        query = self.query_class(
+            select="event",
+            where="event_id IN ({ids:Array(String)})",
+            parameters={"ids": ["1"]},
+            column_oriented=True,
+        )
         try:
             for chunk_ids in chunk_id_list():
-                query["parameters"]["ids"] = chunk_ids
+                query.parameters["ids"] = chunk_ids
                 ch_response = self.read(
                     query=query,
                     target=self.event_table_name,

--- a/src/ralph/backends/lrs/es.py
+++ b/src/ralph/backends/lrs/es.py
@@ -52,8 +52,9 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
 
     def query_statements_by_ids(self, ids: List[str]) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
+        query = self.query_class(query={"terms": {"_id": ids}})
         try:
-            es_response = self.read(query={"query": {"terms": {"_id": ids}}})
+            es_response = self.read(query=query)
             yield from (document["_source"] for document in es_response)
         except (BackendException, BackendParameterException) as error:
             logger.error("Failed to read from Elasticsearch")

--- a/src/ralph/backends/lrs/mongo.py
+++ b/src/ralph/backends/lrs/mongo.py
@@ -57,8 +57,9 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
 
     def query_statements_by_ids(self, ids: List[str]) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
+        query = self.query_class(filter={"_source.id": {"$in": ids}})
         try:
-            mongo_response = self.read(query={"filter": {"_source.id": {"$in": ids}}})
+            mongo_response = self.read(query=query)
             yield from (document["_source"] for document in mongo_response)
         except (BackendException, BackendParameterException) as error:
             logger.error("Failed to read from MongoDB")

--- a/tests/backends/data/test_async_mongo.py
+++ b/tests/backends/data/test_async_mongo.py
@@ -555,17 +555,6 @@ async def test_backends_data_async_mongo_read_without_ignore_errors(
     "query",
     [
         '{"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}}',
-        {"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}},
-        MongoQuery(
-            query_string='{"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}}'
-        ),
-        # Given both `query_string` and other query arguments, only the `query_string`
-        # should be applied.
-        MongoQuery(
-            query_string='{"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}}',
-            filter={"id": {"$eq": "foo"}},
-            projection={"id": 0},
-        ),
         MongoQuery(filter={"id": {"$eq": "bar"}}, projection={"id": 1}),
     ],
 )
@@ -577,6 +566,8 @@ async def test_backends_data_async_mongo_read_with_query(
 
     # Create records
     backend = async_mongo_backend()
+    if isinstance(query, str):
+        query = MongoQuery.from_string(query)
     documents = [
         {"_id": ObjectId("64945e53a4ee2699573e0d6f"), "id": "foo", "qux": "foo"},
         {"_id": ObjectId("64945e530468d817b1f756da"), "id": "bar", "qux": "foo"},

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -416,7 +416,14 @@ def test_backends_data_es_read_with_query(es, es_backend, caplog):
     assert results[2]["_source"]["id"] == 4
 
     # Find every odd item.
-    query = {"query": {"term": {"modulo": 1}}}
+    query = ESQuery(query={"term": {"modulo": 1}})
+    results = list(backend.read(query=query))
+    assert len(results) == 2
+    assert results[0]["_source"]["id"] == 1
+    assert results[1]["_source"]["id"] == 3
+
+    # Find every odd item with a json query string.
+    query = ESQuery.from_string(json.dumps({"query": {"term": {"modulo": 1}}}))
     results = list(backend.read(query=query))
     assert len(results) == 2
     assert results[0]["_source"]["id"] == 1
@@ -424,14 +431,21 @@ def test_backends_data_es_read_with_query(es, es_backend, caplog):
 
     # Find documents with ID equal to one or five.
     query = "id:(1 OR 5)"
-    results = list(backend.read(query=query))
+    with caplog.at_level(logging.INFO):
+        query = ESQuery.from_string(query)
+        results = list(backend.read(query=query))
     assert len(results) == 1
     assert results[0]["_source"]["id"] == 1
+    assert (
+        "ralph.backends.data.es",
+        logging.INFO,
+        "Fallback to Lucene Query as the query is not an ESQuery: id:(1 OR 5)",
+    ) in caplog.record_tuples
 
     # Check query argument type
     with pytest.raises(
         BackendParameterException,
-        match="'query' argument is expected to be a ESQuery instance.",
+        match="'query' argument is expected to be a ESQuery instance",
     ):
         with caplog.at_level(logging.ERROR):
             list(backend.read(query={"not_query": "foo"}))
@@ -439,9 +453,7 @@ def test_backends_data_es_read_with_query(es, es_backend, caplog):
     assert (
         "ralph.backends.data.base",
         logging.ERROR,
-        "The 'query' argument is expected to be a ESQuery instance. "
-        "[{'loc': ('not_query',), 'msg': 'extra fields not permitted', "
-        "'type': 'value_error.extra'}]",
+        "The 'query' argument is expected to be a ESQuery instance",
     ) in caplog.record_tuples
 
     backend.close()

--- a/tests/backends/data/test_fs.py
+++ b/tests/backends/data/test_fs.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 import pytest
 
-from ralph.backends.data.base import BaseOperationType, BaseQuery, DataBackendStatus
+from ralph.backends.data.base import BaseOperationType, DataBackendStatus
 from ralph.backends.data.fs import FSDataBackend, FSDataBackendSettings
 from ralph.exceptions import BackendException, BackendParameterException
 from ralph.utils import now
@@ -30,7 +30,7 @@ def test_backends_data_fs_default_instantiation(monkeypatch, fs):
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__FS__{name}", raising=False)
 
     assert FSDataBackend.name == "fs"
-    assert FSDataBackend.query_class == BaseQuery
+    assert FSDataBackend.query_class == str
     assert FSDataBackend.default_operation_type == BaseOperationType.CREATE
     assert FSDataBackend.settings_class == FSDataBackendSettings
     backend = FSDataBackend()

--- a/tests/backends/data/test_ldp.py
+++ b/tests/backends/data/test_ldp.py
@@ -13,7 +13,7 @@ import pytest
 import requests
 import requests_mock
 
-from ralph.backends.data.base import BaseQuery, DataBackendStatus
+from ralph.backends.data.base import DataBackendStatus
 from ralph.backends.data.ldp import LDPDataBackend
 from ralph.conf import settings
 from ralph.exceptions import BackendException, BackendParameterException
@@ -39,7 +39,7 @@ def test_backends_data_ldp_default_instantiation(monkeypatch, fs):
         monkeypatch.delenv(f"RALPH_BACKENDS__DATA__LDP__{name}", raising=False)
 
     assert LDPDataBackend.name == "ldp"
-    assert LDPDataBackend.query_class == BaseQuery
+    assert LDPDataBackend.query_class == str
     backend = LDPDataBackend()
     assert isinstance(backend.client, ovh.Client)
     assert backend.service_name is None

--- a/tests/backends/data/test_mongo.py
+++ b/tests/backends/data/test_mongo.py
@@ -430,17 +430,6 @@ def test_backends_data_mongo_read_without_ignore_errors(mongo, mongo_backend, ca
     "query",
     [
         '{"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}}',
-        {"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}},
-        MongoQuery(
-            query_string='{"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}}'
-        ),
-        # Given both `query_string` and other query arguments, only the `query_string`
-        # should be applied.
-        MongoQuery(
-            query_string='{"filter": {"id": {"$eq": "bar"}}, "projection": {"id": 1}}',
-            filter={"id": {"$eq": "foo"}},
-            projection={"id": 0},
-        ),
         MongoQuery(filter={"id": {"$eq": "bar"}}, projection={"id": 1}),
     ],
 )
@@ -449,6 +438,8 @@ def test_backends_data_mongo_read_with_query(query, mongo, mongo_backend):
 
     # Create records
     backend = mongo_backend()
+    if isinstance(query, str):
+        query = MongoQuery.from_string(query)
     documents = [
         {"_id": ObjectId("64945e53a4ee2699573e0d6f"), "id": "foo", "qux": "foo"},
         {"_id": ObjectId("64945e530468d817b1f756da"), "id": "bar", "qux": "foo"},

--- a/tests/backends/lrs/test_async_es.py
+++ b/tests/backends/lrs/test_async_es.py
@@ -35,8 +35,8 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             {},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {"match_all": {}},
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -48,8 +48,8 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             {"statementId": "statementId"},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {"bool": {"filter": [{"term": {"_id": "statementId"}}]}},
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -61,6 +61,7 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             {"statementId": "statementId", "agent": {"mbox": "mailto:foo@bar.baz"}},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -69,7 +70,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -84,6 +84,7 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -98,7 +99,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -113,6 +113,7 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -127,7 +128,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -145,6 +145,7 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -160,7 +161,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -175,6 +175,7 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -196,7 +197,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -211,6 +211,7 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -231,7 +232,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -243,8 +243,8 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             {"search_after": "1686557542970|0", "pit_id": "46ToAwMDaWR5BXV1a"},
             {
                 "pit": {"id": "46ToAwMDaWR5BXV1a", "keep_alive": None},
+                "q": None,
                 "query": {"match_all": {}},
-                "query_string": None,
                 "search_after": ["1686557542970", "0"],
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -256,8 +256,8 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
             {"ignore_order": True},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {"match_all": {}},
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": "_shard_doc",

--- a/tests/backends/lrs/test_async_mongo.py
+++ b/tests/backends/lrs/test_async_mongo.py
@@ -39,7 +39,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 1. Query by statementId.
@@ -53,7 +52,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 2. Query by statementId and agent with mbox IFI.
@@ -70,7 +68,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 3. Query by statementId and agent with mbox_sha1sum IFI.
@@ -92,7 +89,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 4. Query by statementId and agent with openid IFI.
@@ -112,7 +108,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 5. Query by statementId and agent with account IFI.
@@ -136,7 +131,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 6. Query by verb and activity.
@@ -157,7 +151,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 7. Query by timerange (with since/until).
@@ -179,7 +172,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 8. Query by timerange (with only until).
@@ -199,7 +191,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 9. Query with pagination.
@@ -215,7 +206,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 10. Query with pagination in ascending order.
@@ -231,7 +221,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", ASCENDING),
                     ("_id", ASCENDING),
                 ],
-                "query_string": None,
             },
         ),
     ],

--- a/tests/backends/lrs/test_clickhouse.py
+++ b/tests/backends/lrs/test_clickhouse.py
@@ -273,13 +273,13 @@ def test_backends_database_clickhouse_query_statements_query(
     def mock_read(query, target, ignore_errors):
         """Mock the `ClickHouseDataBackend.read` method."""
 
-        assert query == {
-            "select": ["event_id", "emission_time", "event"],
-            "where": expected_params["where"],
-            "parameters": expected_params["params"],
-            "limit": expected_params["limit"],
-            "sort": expected_params["sort"],
-        }
+        assert query == backend.query_class(
+            select=["event_id", "emission_time", "event"],
+            where=expected_params["where"],
+            parameters=expected_params["params"],
+            limit=expected_params["limit"],
+            sort=expected_params["sort"],
+        )
 
         return {}
 

--- a/tests/backends/lrs/test_es.py
+++ b/tests/backends/lrs/test_es.py
@@ -35,8 +35,8 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             {},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {"match_all": {}},
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -48,8 +48,8 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             {"statementId": "statementId"},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {"bool": {"filter": [{"term": {"_id": "statementId"}}]}},
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -61,6 +61,7 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             {"statementId": "statementId", "agent": {"mbox": "mailto:foo@bar.baz"}},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -69,7 +70,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -84,6 +84,7 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -98,7 +99,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -113,6 +113,7 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -127,7 +128,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -145,6 +145,7 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -160,7 +161,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -175,6 +175,7 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -196,7 +197,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -211,6 +211,7 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             },
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {
                     "bool": {
                         "filter": [
@@ -231,7 +232,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                         ]
                     }
                 },
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -243,8 +243,8 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             {"search_after": "1686557542970|0", "pit_id": "46ToAwMDaWR5BXV1a"},
             {
                 "pit": {"id": "46ToAwMDaWR5BXV1a", "keep_alive": None},
+                "q": None,
                 "query": {"match_all": {}},
-                "query_string": None,
                 "search_after": ["1686557542970", "0"],
                 "size": 0,
                 "sort": [{"timestamp": {"order": "desc"}}],
@@ -256,8 +256,8 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
             {"ignore_order": True},
             {
                 "pit": {"id": None, "keep_alive": None},
+                "q": None,
                 "query": {"match_all": {}},
-                "query_string": None,
                 "search_after": None,
                 "size": 0,
                 "sort": "_shard_doc",

--- a/tests/backends/lrs/test_mongo.py
+++ b/tests/backends/lrs/test_mongo.py
@@ -39,7 +39,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 1. Query by statementId.
@@ -53,7 +52,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 2. Query by statementId and agent with mbox IFI.
@@ -70,7 +68,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 3. Query by statementId and agent with mbox_sha1sum IFI.
@@ -92,7 +89,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 4. Query by statementId and agent with openid IFI.
@@ -112,7 +108,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 5. Query by statementId and agent with account IFI.
@@ -136,7 +131,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 6. Query by verb and activity.
@@ -157,7 +151,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 7. Query by timerange (with since/until).
@@ -179,7 +172,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 8. Query by timerange (with only until).
@@ -199,7 +191,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 9. Query with pagination.
@@ -215,7 +206,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", DESCENDING),
                     ("_id", DESCENDING),
                 ],
-                "query_string": None,
             },
         ),
         # 10. Query with pagination in ascending order.
@@ -231,7 +221,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                     ("_source.timestamp", ASCENDING),
                     ("_id", ASCENDING),
                 ],
-                "query_string": None,
             },
         ),
     ],

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -703,7 +703,7 @@ def es_lrs_backend():
 def swift_backend():
     """Return get_swift_data_backend function."""
 
-    def get_swift_data_backend():
+    def get_swift_data_backend(container: str = "container_name"):
         """Return an instance of SwiftDataBackend."""
         settings = SwiftDataBackend.settings_class(
             AUTH_URL="https://auth.cloud.ovh.net/",
@@ -716,7 +716,7 @@ def swift_backend():
             REGION_NAME="os_region_name",
             OBJECT_STORAGE_URL="os_storage_url/ralph_logs_container",
             USER_DOMAIN_NAME="Default",
-            DEFAULT_CONTAINER="container_name",
+            DEFAULT_CONTAINER=container,
             LOCALE_ENCODING="utf8",
             READ_CHUNK_SIZE=500,
             WRITE_CHUNK_SIZE=499,
@@ -739,7 +739,7 @@ def moto_fs(fs):
 def s3_backend():
     """Return the `get_s3_data_backend` function."""
 
-    def get_s3_data_backend():
+    def get_s3_data_backend(bucket_name: str = "bucket_name"):
         """Return an instance of S3DataBackend."""
         settings = S3DataBackend.settings_class(
             ACCESS_KEY_ID="access_key_id",
@@ -747,7 +747,7 @@ def s3_backend():
             SESSION_TOKEN="session_token",
             ENDPOINT_URL=None,
             DEFAULT_REGION="default-region",
-            DEFAULT_BUCKET_NAME="bucket_name",
+            DEFAULT_BUCKET_NAME=bucket_name,
             LOCALE_ENCODING="utf8",
             READ_CHUNK_SIZE=4096,
             WRITE_CHUNK_SIZE=3999,

--- a/tests/test_cli_usage.py
+++ b/tests/test_cli_usage.py
@@ -108,8 +108,9 @@ def test_cli_read_command_usage():
 
     assert result.exit_code == 0
     assert (
-        "Usage: ralph read [OPTIONS] [ARCHIVE]\n\n"
-        "  Read an archive or records from a configured backend.\n\n"
+        "Usage: ralph read [OPTIONS] [QUERY]\n\n"
+        "  Read records matching the QUERY (json or string) from a configured backend."
+        "\n\n"
         "Options:\n"
         "  -b, --backend "
         "[async_es|async_lrs|async_mongo|async_ws|clickhouse|es|fs|ldp|lrs|mongo|s3|"
@@ -233,10 +234,6 @@ def test_cli_read_command_usage():
         "  -s, --chunk-size INTEGER        Get events by chunks of size #\n"
         "  -t, --target TEXT               Endpoint from which to read events (e.g.\n"
         "                                  `/statements`)\n"
-        '  -q, --query \'{"KEY": "VALUE", "KEY": "VALUE"}\'\n'
-        "                                  Query object as a JSON string (database and"
-        "\n"
-        "                                  HTTP backends ONLY)\n"
         "  -i, --ignore_errors BOOLEAN     Ignore errors during the encoding operation."
         "\n"
         "                                  [default: False]\n"


### PR DESCRIPTION
## Purpose

The `archive` argument in the `read` cli command is not used anymore.
Instead, currently, a `--query` option is used, which only accepts JSON strings.
This complicates the usage of backends that do not require a query in the form of a dictionary (e.g.: fs, s3, ldp backends).

Example:
```
ralph read -b fs -q '{"query_string": "LICENSE.md"}'
```

We want to accept a plain string as the query argument to simplify CLI usage with backends that don't need a dictionary query.

Example:
```
ralph read -b fs LICENSE.md
```

Also, this would simplify the use of the ES data backend with a Lucene query string - e.g.: `ralph read -b es id:1`

Furthermore, the current usage of the `BaseQuery` model is complicated - not all backends need to define a custom query model and backends that do need a custom query model have to handle the case when the query is a string.

## Proposal

- [x] Replace the archive CLI argument with a query argument that accepts a JSON string or a plain string
- [x] Remove the previously defined query option, which was JSON only
- [x] Allow Backend `Query` to be of type `string`.
- [x] Remove `BaseQuery.query_string` field and handle JSON string queries in a dedicated `from_string` method.

Note: This PR rebases PR #491 to point to PR #515 to avoid merge conflicts. We deviated slightly from the original implementation to preserve the ability to use a Lucene query string for the ESDataBackend.