### PR TITLE
💥(project) drop support for python3.7 and unpin dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ workflows:
           matrix:
             parameters:
               python-image:
-                [python:3.7, python:3.8, python:3.9, python:3.10, python:3.11]
+                [python:3.8, python:3.9, python:3.10, python:3.11]
           filters:
             tags:
               only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ have an authority field matching that of the user
 
 - `school`, `course`, `module` context extensions in Edx to xAPI base converter
 - `name` field in `VideoActivity` xAPI model mistakenly used in `video` profile
+- drop support for python 3.7
 
 ## [3.9.0] - 2023-07-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { file = "LICENSE.md" }
 keywords = ["LRS", "Analytics", "xAPI", "Open edX"]
 dependencies = [
@@ -55,7 +54,7 @@ backend-ldp = [
     "requests>=2.0.0",
 ]
 backend-lrs = [
-    "httpx<0.25.0", # pin as Python 3.7 is no longer supported from release 0.25.0
+    "httpx<0.25.0", # pin as `pytest-httpx<0.23.0` requires `httpx==0.24.*`
     "more-itertools==10.1.0",
 ]
 backend-mongo = [
@@ -101,9 +100,9 @@ dev = [
     "pytest==7.4.3",
     "pytest-asyncio==0.21.1",
     "pytest-cov==4.1.0",
-    "pytest-httpx<0.23.0", # pin as Python 3.7 and 3.8 is no longer supported from release 0.23.0
+    "pytest-httpx<0.23.0", # pin as Python 3.8 is no longer supported from release 0.23.0
     "requests-mock==1.11.0",
-    "responses<0.23.2", # pin until boto3 supports urllib3>=2
+    "responses==0.24.1",
     "ruff==0.1.5",
     "types-python-dateutil == 2.8.19.14",
     "types-python-jose == 3.3.4.8",
@@ -117,12 +116,7 @@ lrs = [
     "bcrypt==4.0.1",
     "fastapi==0.104.1",
     "cachetools==5.3.2",
-    # We temporary pin `h11` to avoid pip downloading the latest version to solve a
-    # dependency conflict caused by `httpx` which requires httpcore>=0.15.0,<0.16.0 and
-    # `httpcore` depends on h11>=0.11,<0.13.
-    # See: https://github.com/encode/httpx/issues/2244
-    "h11>=0.11.0",
-    "httpx<0.25.0", # pin as Python 3.7 is no longer supported from release 0.25.0
+    "httpx<0.25.0", # pin as `pytest-httpx<0.23.0` requires `httpx==0.24.*`
     "sentry_sdk==1.34.0",
     "python-jose==3.3.0",
     "uvicorn[standard]==0.24.0.post1",


### PR DESCRIPTION
## Purpose

As a significant part of `ralph` no longer supports python3.7, it might be time to drop support for python3.7 officially.

## Proposal

- [x] drop support for `python3.7`
- [x] unpin python dependencies (pinned to support python3.7)

