### PR TITLE
🚚(backends) move backend utilities to BackendUtilityMixin

### DIFF
--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -16,7 +16,6 @@ from ralph.backends.data.base import (
 )
 from ralph.backends.data.es import ESDataBackend, ESDataBackendSettings, ESQuery
 from ralph.exceptions import BackendException
-from ralph.utils import async_parse_dict_to_bytes, parse_iterable_to_dict
 
 Settings = TypeVar("Settings", bound=ESDataBackendSettings)
 
@@ -155,20 +154,6 @@ class AsyncESDataBackend(
         async for statement in statements:
             yield statement
 
-    async def _read_bytes(
-        self,
-        query: ESQuery,
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-    ) -> AsyncIterator[bytes]:
-        """Method called by `self.read` yielding bytes. See `self.read`."""
-        statements = self._read_dicts(query, target, chunk_size, ignore_errors)
-        async for statement in async_parse_dict_to_bytes(
-            statements, self.settings.LOCALE_ENCODING, ignore_errors, self.logger
-        ):
-            yield statement
-
     async def _read_dicts(
         self,
         query: ESQuery,
@@ -256,20 +241,6 @@ class AsyncESDataBackend(
         """
         return await super().write(
             data, target, chunk_size, ignore_errors, operation_type, concurrency
-        )
-
-    async def _write_bytes(  # noqa: PLR0913
-        self,
-        data: Iterable[bytes],
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-        operation_type: BaseOperationType,
-    ) -> int:
-        """Method called by `self.write` writing bytes. See `self.write`."""
-        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
-        return await self._write_dicts(
-            statements, target, chunk_size, ignore_errors, operation_type
         )
 
     async def _write_dicts(  # noqa: PLR0913

--- a/src/ralph/backends/data/async_lrs.py
+++ b/src/ralph/backends/data/async_lrs.py
@@ -17,7 +17,7 @@ from ralph.backends.data.base import (
 from ralph.backends.data.lrs import LRSDataBackendSettings, StatementResponse
 from ralph.backends.lrs.base import LRSStatementsQuery
 from ralph.exceptions import BackendException
-from ralph.utils import async_parse_dict_to_bytes, iter_by_batch, parse_iterable_to_dict
+from ralph.utils import iter_by_batch
 
 
 class AsyncLRSDataBackend(
@@ -115,20 +115,6 @@ class AsyncLRSDataBackend(
         async for statement in statements:
             yield statement
 
-    async def _read_bytes(
-        self,
-        query: LRSStatementsQuery,
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-    ) -> AsyncIterator[bytes]:
-        """Method called by `self.read` yielding bytes. See `self.read`."""
-        statements = self._read_dicts(query, target, chunk_size, ignore_errors)
-        async for statement in async_parse_dict_to_bytes(
-            statements, self.settings.LOCALE_ENCODING, ignore_errors, self.logger
-        ):
-            yield statement
-
     async def _read_dicts(
         self,
         query: LRSStatementsQuery,
@@ -201,20 +187,6 @@ class AsyncLRSDataBackend(
         """
         return await super().write(
             data, target, chunk_size, ignore_errors, operation_type, concurrency
-        )
-
-    async def _write_bytes(  # noqa: PLR0913
-        self,
-        data: Iterable[bytes],
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-        operation_type: BaseOperationType,
-    ) -> int:
-        """Method called by `self.write` writing bytes. See `self.write`."""
-        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
-        return await self._write_dicts(
-            statements, target, chunk_size, ignore_errors, operation_type
         )
 
     async def _write_dicts(  # noqa: PLR0913

--- a/src/ralph/backends/data/async_mongo.py
+++ b/src/ralph/backends/data/async_mongo.py
@@ -15,7 +15,7 @@ from ralph.backends.data.mongo import (
     MongoQuery,
 )
 from ralph.exceptions import BackendException, BackendParameterException
-from ralph.utils import async_parse_dict_to_bytes, iter_by_batch, parse_iterable_to_dict
+from ralph.utils import iter_by_batch
 
 from ..data.base import (
     AsyncListable,
@@ -164,20 +164,6 @@ class AsyncMongoDataBackend(
         async for statement in statements:
             yield statement
 
-    async def _read_bytes(
-        self,
-        query: MongoQuery,
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-    ) -> AsyncIterator[bytes]:
-        """Method called by `self.read` yielding bytes. See `self.read`."""
-        statements = self._read_dicts(query, target, chunk_size, ignore_errors)
-        async for statement in async_parse_dict_to_bytes(
-            statements, self.settings.LOCALE_ENCODING, ignore_errors, self.logger
-        ):
-            yield statement
-
     async def _read_dicts(
         self,
         query: MongoQuery,
@@ -234,20 +220,6 @@ class AsyncMongoDataBackend(
         """
         return await super().write(
             data, target, chunk_size, ignore_errors, operation_type, concurrency
-        )
-
-    async def _write_bytes(  # noqa: PLR0913
-        self,
-        data: Iterable[bytes],
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-        operation_type: BaseOperationType,
-    ) -> int:
-        """Method called by `self.write` writing bytes. See `self.write`."""
-        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
-        return await self._write_dicts(
-            statements, target, chunk_size, ignore_errors, operation_type
         )
 
     async def _write_dicts(  # noqa: PLR0913

--- a/src/ralph/backends/data/async_ws.py
+++ b/src/ralph/backends/data/async_ws.py
@@ -13,7 +13,6 @@ from ralph.backends.data.base import (
 )
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException
-from ralph.utils import async_parse_iterable_to_dict
 
 
 class WSDataBackendSettings(BaseDataBackendSettings):
@@ -151,10 +150,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, BaseQuery])
         ignore_errors: bool,
     ) -> AsyncIterator[dict]:
         """Method called by `self.read` yielding dictionaries. See `self.read`."""
-        statements = self._read_bytes(query, target, chunk_size, ignore_errors)
-        statements = async_parse_iterable_to_dict(
-            statements, ignore_errors, self.logger
-        )
+        statements = super()._read_dicts(query, target, chunk_size, ignore_errors)
         async for statement in statements:
             yield statement
 

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -19,7 +19,6 @@ from ralph.backends.data.base import (
 )
 from ralph.conf import BaseSettingsConfig, ClientOptions, CommaSeparatedTuple
 from ralph.exceptions import BackendException
-from ralph.utils import parse_dict_to_bytes, parse_iterable_to_dict
 
 
 class ESClientOptions(ClientOptions):
@@ -228,18 +227,6 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
             query, target, chunk_size, raw_output, ignore_errors, max_statements
         )
 
-    def _read_bytes(
-        self,
-        query: ESQuery,
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-    ) -> Iterator[bytes]:
-        """Method called by `self.read` yielding bytes. See `self.read`."""
-        locale = self.settings.LOCALE_ENCODING
-        statements = self._read_dicts(query, target, chunk_size, ignore_errors)
-        yield from parse_dict_to_bytes(statements, locale, ignore_errors, self.logger)
-
     def _read_dicts(
         self,
         query: ESQuery,
@@ -320,20 +307,6 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
                 supported.
         """
         return super().write(data, target, chunk_size, ignore_errors, operation_type)
-
-    def _write_bytes(  # noqa: PLR0913
-        self,
-        data: Iterable[bytes],
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-        operation_type: BaseOperationType,
-    ) -> int:
-        """Method called by `self.write` writing bytes. See `self.write`."""
-        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
-        return self._write_dicts(
-            statements, target, chunk_size, ignore_errors, operation_type
-        )
 
     def _write_dicts(  # noqa: PLR0913
         self,

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -21,7 +21,7 @@ from ralph.backends.data.base import (
 from ralph.backends.data.mixins import HistoryMixin
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException, BackendParameterException
-from ralph.utils import now, parse_dict_to_bytes, parse_iterable_to_dict
+from ralph.utils import now
 
 
 class FSDataBackendSettings(BaseDataBackendSettings):
@@ -209,7 +209,7 @@ class FSDataBackend(
     ) -> Iterator[dict]:
         """Method called by `self.read` yielding dictionaries. See `self.read`."""
         for file, path in self._iter_files_matching_query(target, query):
-            yield from parse_iterable_to_dict(file, ignore_errors, self.logger)
+            yield from self.parse_iterable_to_dict(file, ignore_errors)
             # The file has been read, add a new entry to the history.
             self._append_to_history("read", path)
 
@@ -301,10 +301,8 @@ class FSDataBackend(
         operation_type: BaseOperationType,
     ) -> int:
         """Method called by `self.write` writing dictionaries. See `self.write`."""
-        locale = self.settings.LOCALE_ENCODING
-        statements = parse_dict_to_bytes(data, locale, ignore_errors, self.logger)
-        return self._write_bytes(
-            statements, target, chunk_size, ignore_errors, operation_type
+        return super()._write_dicts(
+            data, target, chunk_size, ignore_errors, operation_type
         )
 
     def _write_bytes(  # noqa: PLR0913

--- a/src/ralph/backends/data/lrs.py
+++ b/src/ralph/backends/data/lrs.py
@@ -18,7 +18,7 @@ from ralph.backends.data.base import (
 from ralph.backends.lrs.base import LRSStatementsQuery
 from ralph.conf import BaseSettingsConfig, HeadersParameters
 from ralph.exceptions import BackendException
-from ralph.utils import iter_by_batch, parse_dict_to_bytes, parse_iterable_to_dict
+from ralph.utils import iter_by_batch
 
 
 class LRSHeaders(HeadersParameters):
@@ -145,19 +145,6 @@ class LRSDataBackend(
             query, target, chunk_size, raw_output, ignore_errors, max_statements
         )
 
-    def _read_bytes(
-        self,
-        query: LRSStatementsQuery,
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-    ) -> Iterator[bytes]:
-        """Method called by `self.read` yielding bytes. See `self.read`."""
-        statements = self._read_dicts(query, target, chunk_size, ignore_errors)
-        yield from parse_dict_to_bytes(
-            statements, self.settings.LOCALE_ENCODING, ignore_errors, self.logger
-        )
-
     def _read_dicts(
         self,
         query: LRSStatementsQuery,
@@ -226,20 +213,6 @@ class LRSDataBackend(
                 instead. See `BaseOperationType`.
         """
         return super().write(data, target, chunk_size, ignore_errors, operation_type)
-
-    def _write_bytes(  # noqa: PLR0913
-        self,
-        data: Iterable[bytes],
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-        operation_type: BaseOperationType,
-    ) -> int:
-        """Method called by `self.write` writing bytes. See `self.write`."""
-        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
-        return self._write_dicts(
-            statements, target, chunk_size, ignore_errors, operation_type
-        )
 
     def _write_dicts(  # noqa: PLR0913
         self,

--- a/src/ralph/backends/data/mongo.py
+++ b/src/ralph/backends/data/mongo.py
@@ -34,7 +34,7 @@ from ralph.backends.data.base import (
 )
 from ralph.conf import BaseSettingsConfig, ClientOptions
 from ralph.exceptions import BackendException, BackendParameterException
-from ralph.utils import iter_by_batch, parse_dict_to_bytes, parse_iterable_to_dict
+from ralph.utils import iter_by_batch
 
 
 class MongoClientOptions(ClientOptions):
@@ -208,18 +208,6 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
             query, target, chunk_size, raw_output, ignore_errors, max_statements
         )
 
-    def _read_bytes(
-        self,
-        query: MongoQuery,
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-    ) -> Iterator[bytes]:
-        """Method called by `self.read` yielding bytes. See `self.read`."""
-        locale = self.settings.LOCALE_ENCODING
-        statements = self._read_dicts(query, target, chunk_size, ignore_errors)
-        yield from parse_dict_to_bytes(statements, locale, ignore_errors, self.logger)
-
     def _read_dicts(
         self,
         query: MongoQuery,
@@ -271,20 +259,6 @@ class MongoDataBackend(BaseDataBackend[Settings, MongoQuery], Writable, Listable
                 supported.
         """
         return super().write(data, target, chunk_size, ignore_errors, operation_type)
-
-    def _write_bytes(  # noqa: PLR0913
-        self,
-        data: Iterable[bytes],
-        target: Optional[str],
-        chunk_size: int,
-        ignore_errors: bool,
-        operation_type: BaseOperationType,
-    ) -> int:
-        """Method called by `self.write` writing bytes. See `self.write`."""
-        statements = parse_iterable_to_dict(data, ignore_errors, self.logger)
-        return self._write_dicts(
-            statements, target, chunk_size, ignore_errors, operation_type
-        )
 
     def _write_dicts(  # noqa: PLR0913
         self,

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -29,7 +29,7 @@ from ralph.backends.data.base import (
 from ralph.backends.data.mixins import HistoryMixin
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException
-from ralph.utils import now, parse_dict_to_bytes, parse_iterable_to_dict
+from ralph.utils import now
 
 
 class S3DataBackendSettings(BaseDataBackendSettings):
@@ -241,7 +241,7 @@ class S3DataBackend(
         response = self._get_object(target, query.query_string)
         try:
             lines = response["Body"].iter_lines(chunk_size)
-            yield from parse_iterable_to_dict(lines, ignore_errors, self.logger)
+            yield from self.parse_iterable_to_dict(lines, ignore_errors)
         except (ReadTimeoutError, ResponseStreamingError) as err:
             msg = "Failed to read chunk from object %s"
             self.logger.error(msg, query.query_string)
@@ -319,10 +319,8 @@ class S3DataBackend(
         operation_type: BaseOperationType,
     ) -> int:
         """Method called by `self.write` writing dictionaries. See `self.write`."""
-        locale = self.settings.LOCALE_ENCODING
-        statements = parse_dict_to_bytes(data, locale, ignore_errors, self.logger)
-        return self._write_bytes(
-            statements, target, chunk_size, ignore_errors, operation_type
+        return super()._write_dicts(
+            data, target, chunk_size, ignore_errors, operation_type
         )
 
     def _write_bytes(  # noqa: PLR0913

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -20,7 +20,7 @@ from ralph.backends.data.base import (
 from ralph.backends.data.mixins import HistoryMixin
 from ralph.conf import BaseSettingsConfig
 from ralph.exceptions import BackendException
-from ralph.utils import now, parse_dict_to_bytes, parse_iterable_to_dict
+from ralph.utils import now
 
 
 class SwiftDataBackendSettings(BaseDataBackendSettings):
@@ -258,7 +258,7 @@ class SwiftDataBackend(
             query.query_string,
         )
         resp_headers, content = self._get_object(target, query.query_string, chunk_size)
-        yield from parse_iterable_to_dict(content, ignore_errors, self.logger)
+        yield from self.parse_iterable_to_dict(content, ignore_errors)
         # Archive read, add a new entry to the history
         self.append_to_history(
             {
@@ -327,10 +327,8 @@ class SwiftDataBackend(
         operation_type: BaseOperationType,
     ) -> int:
         """Method called by `self.write` writing dictionaries. See `self.write`."""
-        locale = self.settings.LOCALE_ENCODING
-        statements = parse_dict_to_bytes(data, locale, ignore_errors, self.logger)
-        return self._write_bytes(
-            statements, target, chunk_size, ignore_errors, operation_type
+        return super()._write_dicts(
+            data, target, chunk_size, ignore_errors, operation_type
         )
 
     def _write_bytes(  # noqa: PLR0913

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -73,9 +73,6 @@ def test_backends_data_base_validate_backend_query_with_invalid_input(
         def _read_dicts(self, query, *args):
             yield
 
-        def _read_bytes(self, query, *args):
-            yield
-
         def status(self):
             pass
 
@@ -189,9 +186,6 @@ async def test_backends_data_base_async_read_with_prefetch(
                 consumed_items["count"] += 1
                 yield {"foo": "bar"}
 
-        async def _read_bytes(self, *args):
-            pass
-
         async def status(self):
             pass
 
@@ -222,9 +216,6 @@ async def test_backends_data_base_async_read_with_invalid_prefetch(caplog):
         """A class mocking the base database class."""
 
         async def _read_dicts(self, *args):
-            pass
-
-        async def _read_bytes(self, *args):
             pass
 
         async def status(self):
@@ -259,9 +250,6 @@ async def test_backends_data_base_async_read_with_an_error_while_prefetching(cap
 
             self.logger.error("connection error")
             raise BackendException("connection error")
-
-        async def _read_bytes(self, *args):
-            pass
 
         async def status(self):
             pass
@@ -376,12 +364,6 @@ async def test_backends_data_base_async_write_with_concurrency(
         async def _read_dicts(self, *args):
             pass
 
-        async def _read_bytes(self, *args):
-            pass
-
-        async def _write_bytes(self, data, *args):
-            pass
-
         async def _write_dicts(self, data, *args):
             write_calls["count"] += 1
             item_count = 0
@@ -440,12 +422,6 @@ async def test_backends_data_base_write_with_invalid_parameters(caplog):
         def _read_dicts(self, *args):
             pass
 
-        def _read_bytes(self, *args):
-            pass
-
-        def _write_bytes(self, *args):
-            pass
-
         def _write_dicts(self, *args):
             return 1
 
@@ -493,12 +469,6 @@ async def test_backends_data_base_async_write_with_invalid_parameters(caplog):
         unsupported_operation_types = {BaseOperationType.DELETE}
 
         async def _read_dicts(self, *args):
-            pass
-
-        async def _read_bytes(self, *args):
-            pass
-
-        async def _write_bytes(self, *args):
             pass
 
         async def _write_dicts(self, *args):


### PR DESCRIPTION
## Purpose

Some methods that were placed in `ralph.utils` are data-backend-specific.
To allow configuring logging in a by-backend basis, they accept a `logger` argument, which adds complexity to their function signature.

Also, it is common for backends to implement only one of `_read_bytes`/`_read_dicts` methods and reuse its implementation for the other one. (same for `_write_dicts` and `_write_bytes`) which causes some repetition among backends.

## Proposal

- [x] move backend-specific utilities to a `BackendUtilityMixin`
- [x] add default implementations for abstract write and read methods
- [x] make one of the read/write methods non-abstract (`_read_bytes` and `_write_bytes`)
- [ ] add tests

