### PR TITLE
🔧(project) add aliases for grouping extra dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
             - v1-dependencies-<< parameters.python-image >>-{{ .Revision }}
       - run:
           name: Install development dependencies
-          command: pip install --user .[backend-clickhouse,backend-es,backend-ldp,backend-lrs,backend-mongo,backend-s3,backend-swift,backend-ws,cli,dev,lrs]
+          command: pip install --user .[dev,full]
       - save_cache:
           paths:
             - ~/.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
   functionalities among `data` backends
 - Backends: Add `get_backends` function to automatically discover backends
   for CLI and LRS usage
+- Add aliases for `ralph-malph` extra dependencies: `backends` and `full`
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
         libffi-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install .[backend-clickhouse,backend-es,backend-ldp,backend-lrs,backend-mongo,backend-s3,backend-swift,backend-ws,cli,lrs]
+RUN pip install .[full]
 
 
 # -- Core --

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Ralph is distributed as a standard python package; it can be installed _via_
 ```bash
 # Install the full package
 pip install \
-    ralph-malph[backend-es,backend-ldp,backend-mongo,backend-swift,backend-ws,cli,lrs]
+    ralph-malph[full]
 
 # Install only the core package (library usage without backends, CLI and LRS)
 pip install ralph-malph

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,11 +73,18 @@ pip install ralph-malph[backend-es,lrs]
 pip install ralph-malph[backend-es,lrs,cli]
 ```
 
+- If you want to play around with backends with Ralph as a library, you can install: 
+
+```bash
+pip install ralph-malph[backends]
+```
+
 - If you have various uses for Ralph's features or would like to discover all the existing functionnalities, it is recommended to install the **full package**: 
 
 ```bash
-pip install ralph-malph[backend-clickhouse,backend-es,backend-ldp,backend-lrs,backend-mongo,backend-s3,backend-swift,backend-ws,cli,lrs]
+pip install ralph-malph[full]
 ```
+
 
 ### Install from DockerHub
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,12 @@ backend-swift = [
 backend-ws = [
     "websockets>=10.3",
 ]
+backends = [
+    "ralph-malph[backend-clickhouse,backend-es,backend-ldp,backend-lrs,backend-mongo,backend-s3,backend-swift]",
+]
+ci = [
+    "twine==4.0.2",
+]
 cli = [
     "bcrypt>=4.0.0",
     "click>=8.1.0",
@@ -109,9 +115,6 @@ dev = [
     "types-requests<2.31.0.11",
     "types-cachetools ==5.3.0.7",
 ]
-ci = [
-    "twine==4.0.2",
-]
 lrs = [
     "bcrypt==4.0.1",
     "fastapi==0.104.1",
@@ -120,6 +123,9 @@ lrs = [
     "sentry_sdk==1.34.0",
     "python-jose==3.3.0",
     "uvicorn[standard]==0.24.0.post1",
+]
+full = [
+    "ralph-malph[backends,cli,lrs]",
 ]
 
 


### PR DESCRIPTION
## Purpose

Ralph package has a lot of extra dependencies, and it can be harsh having to list them when wanting to install a full package.

## Proposal

Adding three aliases:
- `backends` that groups all backends extra dependencies;
- `full` that groups all functional extra dependencies (`backends`, `cli` and `lrs`);
- `all` that groups all the extra dependencies (`full`, `ci` and `dev`).

