### PR TITLE
🔨(project) use docker healthcheck for database services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,9 +235,8 @@ run-all: \
 .PHONY: run-all
 
 run-clickhouse: ## start clickhouse backend
-	@$(COMPOSE) up -d clickhouse
 	@echo "Waiting for clickhouse to be up and running..."
-	@$(COMPOSE_RUN) dockerize -wait tcp://clickhouse:9000 -timeout 60s
+	@$(COMPOSE) up -d --wait clickhouse
 .PHONY: run-clickhouse
 
 run-databases: ## alias for running databases services
@@ -248,21 +247,18 @@ run-databases: \
 .PHONY: run-databases
 
 run-es: ## start elasticsearch backend
-	@$(COMPOSE) up -d elasticsearch
 	@echo "Waiting for elasticsearch to be up and running..."
-	@$(COMPOSE_RUN) dockerize -wait tcp://elasticsearch:9200 -timeout 60s
+	@$(COMPOSE) up -d --wait elasticsearch
 .PHONY: run-es
 
 run-mongo: ## start mongodb backend
-	@$(COMPOSE) up -d mongo
 	@echo "Waiting for mongo to be up and running..."
-	@$(COMPOSE_RUN) dockerize -wait tcp://mongo:27017 -timeout 60s
+	@$(COMPOSE) up -d --wait mongo
 .PHONY: run-mongo
 
 run-swift: ## start swift backend
-	@$(COMPOSE) up -d swift
 	@echo "Waiting for swift to be up and running..."
-	@$(COMPOSE_RUN) dockerize -wait tcp://swift:8080 -wait tcp://swift:35357 -timeout 60s
+	@$(COMPOSE) up -d --wait swift
 .PHONY: run-swift
 
 status: ## an alias for "docker compose ps"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,11 +37,19 @@ services:
       memlock:
         soft: -1
         hard: -1
+    healthcheck:
+      test: curl --fail http://localhost:9200/_cluster/health?wait_for_status=green || exit 1
+      interval: 1s
+      retries: 60
 
   mongo:
     image: mongo:5.0.9
     ports:
       - "27017:27017"
+    healthcheck:
+      test: mongosh --eval 'db.runCommand("ping").ok' localhost:27017/test --quiet
+      interval: 1s
+      retries: 60
 
   clickhouse:
       image: clickhouse/clickhouse-server:23.1.1.3077-alpine
@@ -58,6 +66,10 @@ services:
           nofile:
               soft: 262144
               hard: 262144
+      healthcheck:
+        test:  wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+        interval: 1s
+        retries: 60
 
   swift:
     image: kklopfenstein/openstack-swift-keystone-docker
@@ -66,7 +78,7 @@ services:
       - "49178:35357"
     environment:
       KS_SWIFT_PUBLIC_URL: http://127.0.0.1:49177
-
-  # -- tools
-  dockerize:
-    image: jwilder/dockerize
+    healthcheck:
+        test: curl -s http://127.0.0.1:35357 || exit 1
+        interval: 1s
+        retries: 60


### PR DESCRIPTION
## Purpose

Docker compose provides `healthcheck` since format version 3.4.
https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck


## Proposal

Changing from dockerize to docker healthchecks for all database services locally.

