### PR TITLE
Prepare branch renaming to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,11 @@ jobs:
       - run:
           name: enforce absence of print statements in code
           command: |
-            ! git diff origin/master..HEAD -- . ':(exclude).circleci' | grep "print("
+            ! git diff origin/main..HEAD -- . ':(exclude).circleci' | grep "print("
       - run:
           name: enforce absence of FIXME in code
           command: |
-            ! git diff origin/master..HEAD -- . ':(exclude).circleci' | grep "FIXME"
+            ! git diff origin/main..HEAD -- . ':(exclude).circleci' | grep "FIXME"
       - run:
           name: Check absence of fixup commits
           command: |
@@ -60,9 +60,9 @@ jobs:
           command: |
             pip install --user gitlint requests
       - run:
-          name: lint commit messages added to master
+          name: lint commit messages added to main
           command: |
-            ~/.local/bin/gitlint --commits origin/master..HEAD
+            ~/.local/bin/gitlint --commits origin/main..HEAD
 
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:
@@ -415,7 +415,7 @@ jobs:
             DOCKER_TAG=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v//')
             RELEASE_TYPE=$([[ -z "$CIRCLE_TAG" ]] && echo "branch" || echo "tag ")
             # Display either:
-            # - DOCKER_TAG: master (Git branch)
+            # - DOCKER_TAG: main (Git branch)
             # or
             # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
             echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
@@ -424,7 +424,7 @@ jobs:
             if [[ -n "$CIRCLE_TAG" ]] && [[ "$CIRCLE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                 docker tag ralph:${CIRCLE_SHA1} fundocker/ralph:latest
             fi
-            docker images | grep -E "^fundocker/ralph\s*(${DOCKER_TAG}.*|latest|master)"
+            docker images | grep -E "^fundocker/ralph\s*(${DOCKER_TAG}.*|latest|main)"
 
       # Publish images to DockerHub
       #
@@ -437,7 +437,7 @@ jobs:
             DOCKER_TAG=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v//')
             RELEASE_TYPE=$([[ -z "$CIRCLE_TAG" ]] && echo "branch" || echo "tag ")
             # Display either:
-            # - DOCKER_TAG: master (Git branch)
+            # - DOCKER_TAG: main (Git branch)
             # or
             # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
             echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
@@ -488,7 +488,7 @@ jobs:
             # - DOCS_VERSION: 1.1 (for git tag v1.1.2)
             # - DOCS_ALIAS: latest
             # or
-            # - DOCS_VERSION: master (for master branch)
+            # - DOCS_VERSION: main (for main branch)
             # - No DOCS_ALIAS
             DOCS_VERSION=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v\([0-9]\.[0-9]*\)\..*/\1/')
             DOCS_ALIAS=$([[ -z "$CIRCLE_TAG" ]] && echo "" || echo "latest")
@@ -550,13 +550,13 @@ workflows:
       - check-changelog:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               only: /(?!^v).*/
       - lint-changelog:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               only: /.*/
       # Check Renovate
@@ -643,14 +643,14 @@ workflows:
       #
       # Publish docker images only if all build, lint and test jobs succeed
       # and it has been tagged with a tag starting with the letter v or is on
-      # the master branch
+      # the main branch
       - hub:
           requires:
             - build-docker
             - tray
           filters:
             branches:
-              only: master
+              only: main
             tags:
               only: /^v.*/
 
@@ -668,14 +668,14 @@ workflows:
               only: /^v.*/
 
       # Publish the documentation website to GitHub Pages.
-      # Only do it for master and for tagged stable releases with a tag in the format vX.Y.Z
+      # Only do it for main and for tagged stable releases with a tag in the format vX.Y.Z
       - deploy-docs:
           requires:
             - tray
             - package
           filters:
             branches:
-              only: master
+              only: main
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
@@ -686,6 +686,6 @@ workflows:
             - package
           filters:
             branches:
-              only: master
+              only: main
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,9 +488,9 @@ jobs:
             # - DOCS_VERSION: 1.1 (for git tag v1.1.2)
             # - DOCS_ALIAS: latest
             # or
-            # - DOCS_VERSION: main (for main branch)
+            # - DOCS_VERSION: dev (for main branch)
             # - No DOCS_ALIAS
-            DOCS_VERSION=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v\([0-9]\.[0-9]*\)\..*/\1/')
+            DOCS_VERSION=$([[ -z "$CIRCLE_TAG" ]] && echo "dev" || echo ${CIRCLE_TAG} | sed 's/^v\([0-9]\.[0-9]*\)\..*/\1/')
             DOCS_ALIAS=$([[ -z "$CIRCLE_TAG" ]] && echo "" || echo "latest")
             echo "DOCS_VERSION: ${DOCS_VERSION}"
             echo "DOCS_ALIAS: ${DOCS_ALIAS}"

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -9,7 +9,7 @@ We primarily use GitHub as an issue tracker. If however you're encountering an i
 
 ---
 
-Please make sure you have read our [main Readme](https://github.com/openfun/ralph) as well as our [documentation folder](https://github.com/openfun/ralph/tree/master/docs).
+Please make sure you have read our [main Readme](https://github.com/openfun/ralph) as well as our [documentation folder](https://github.com/openfun/ralph/tree/main/docs).
 
 Also make sure it was not already answered in [an open or close issue](https://github.com/openfun/ralph/issues).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,7 +420,7 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.9.0...master
+[unreleased]: https://github.com/openfun/ralph/compare/v3.9.0...main
 [3.9.0]: https://github.com/openfun/ralph/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/openfun/ralph/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/openfun/ralph/compare/v3.6.0...v3.7.0

--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,8 @@ docs-build: ## build documentation site
 .PHONY: docs-build
 
 docs-deploy: ## deploy documentation site
-	@echo "Deploying docs with version master to gh-pages"
-	@${MIKE} deploy master
+	@echo "Deploying docs with version main to gh-pages"
+	@${MIKE} deploy main
 .PHONY: docs-deploy
 
 docs-serve: ## run mkdocs live server for dev docs

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 </p>
 
 <p align="center">
-<a href="https://circleci.com/gh/openfun/ralph/tree/master">
-    <img src="https://img.shields.io/circleci/build/gh/openfun/ralph/master?label=Tests&logo=circleci" alt="Tests Status">
+<a href="https://circleci.com/gh/openfun/ralph/tree/main">
+    <img src="https://img.shields.io/circleci/build/gh/openfun/ralph/main?label=Tests&logo=circleci" alt="Tests Status">
 </a>
 <a href="https://pypi.org/project/ralph-malph">
     <img src="https://img.shields.io/pypi/v/ralph-malph?label=PyPI+package" alt="PyPI package version">
@@ -175,7 +175,7 @@ ralph COMMAND --help
 
 ## Migrating
 
-Some major version changes require updating persistence layers. Check out the [migration guide](https://github.com/openfun/ralph/blob/master/UPGRADE.md) for more information.
+Some major version changes require updating persistence layers. Check out the [migration guide](https://github.com/openfun/ralph/blob/main/UPGRADE.md) for more information.
 
 ## Contributing
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -93,7 +93,7 @@ git push origin feature/your-new-feature
 
 To initiate a Pull Request (PR), head to Ralph project's GitHub repository and click on <kbd>New Pull Request</kbd>.
 
-Set your branch as the source and Ralph project's `master` branch as the target.
+Set your branch as the source and Ralph project's `main` branch as the target.
 
 Provide a clear title for your PR and make use of the provided PR body template to document the changes made by your PR.
 This helps streamline the review process and maintain a well-documented project history.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-<a href="https://circleci.com/gh/openfun/ralph/tree/master">
-    <img src="https://img.shields.io/circleci/build/gh/openfun/ralph/master?label=Tests&logo=circleci" alt="CircleCI tests">
+<a href="https://circleci.com/gh/openfun/ralph/tree/main">
+    <img src="https://img.shields.io/circleci/build/gh/openfun/ralph/main?label=Tests&logo=circleci" alt="CircleCI tests">
 </a>
 <a href="https://pypi.org/project/ralph-malph">
     <img src="https://img.shields.io/pypi/v/ralph-malph?label=PyPi+package" alt="PyPi version">

--- a/docs/theme/announce.html
+++ b/docs/theme/announce.html
@@ -1,5 +1,5 @@
 <!-- the following line is displayed in the announcement bar -->
 <!-- keep length under 164 characters (less HTML tags) to fit on 1280px desktop window -->
 🌟 Big News! Ralph v4 is here. Don't forget to check out our 
-<a href=https://github.com/openfun/ralph/blob/master/UPGRADE.md>migration guide</a> 
+<a href=https://github.com/openfun/ralph/blob/main/UPGRADE.md>migration guide</a> 
 for a seamless transition. 🚀

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = ["version"]
 [project.urls]
 "Homepage" = "https://openfun.github.io/ralph/"
 "Bug Tracker" = "https://github.com/openfun/ralph/issues"
-"Changelog" = "https://github.com/openfun/ralph/blob/master/CHANGELOG.md"
+"Changelog" = "https://github.com/openfun/ralph/blob/main/CHANGELOG.md"
 "Repository" = "https://github.com/openfun/ralph"
 
 [project.optional-dependencies]

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -31,6 +31,6 @@ and this project adheres to
 
 - Add an official Helm Chart (experimental)
 
-[unreleased]: https://github.com/openfun/ralph/tree/master/src/helm
+[unreleased]: https://github.com/openfun/ralph/tree/main/src/helm
 [0.2.0]: https://github.com/openfun/ralph/releases/tag/helm-v0.2.0
 [0.1.0]: https://github.com/openfun/ralph/releases/tag/helm-v0.1.0


### PR DESCRIPTION
## Purpose

`master` naming for repos is deprecated in the tech industry.
`main` is now the popular choice, and it would be easier for devs that openfun default branches be named `main`.

## Proposal

- 🧑‍💻(project) prepare branch renaming from master to main
- 📝(project) rename `main` doc version to `dev`

