### PR TITLE
🔖(major) bump release to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.0.0] - 2024-01-23
+
 ### Added
 
 - Backends: Add `Writable` and `Listable` interfaces to distinguish supported
@@ -420,7 +422,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v3.9.0...main
+[unreleased]: https://github.com/openfun/ralph/compare/v4.0.0...main
+[4.0.0]: https://github.com/openfun/ralph/compare/v3.9.0...v4.0.0
 [3.9.0]: https://github.com/openfun/ralph/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/openfun/ralph/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/openfun/ralph/compare/v3.6.0...v3.7.0

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade appVersion to `4.0.0`
+
 ## [0.2.0] - 2023-11-08
 
 ### Added

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -4,7 +4,7 @@ name: ralph
 type: application
 description: The official Helm chart for Ralph
 version: 0.2.0
-appVersion: "3.9.0"
+appVersion: "4.0.0"
 
 dependencies:
   - name: mongodb

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "4.0.0b1"
+__version__ = "4.0.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 3.9.0
+  version: 4.0.0


### PR DESCRIPTION
## Added

- Backends: Add `Writable` and `Listable` interfaces to distinguish supported
  functionalities among `data` backends
- Backends: Add `max_statements` option to data backends `read` method
- Backends: Add `prefetch` option to async data backends `read` method
- Backends: Add `concurrency` option to async data backends `write` method
- Backends: Add `get_backends` function to automatically discover backends
  for CLI and LRS usage
- Backends: Add client options for WSDataBackend
- Backends: Add `READ_CHUNK_SIZE` and `WRITE_CHUNK_SIZE` data backend settings
- Models: Implement Pydantic model for LRS Statements resource query parameters
- Models: Implement xAPI LMS Profile statements validation
- Models: Add `EdX` to `xAPI` converters for enrollment events
- Project: Add aliases for `ralph-malph` extra dependencies: `backends` and
  `full`

## Changed

- Arnold: Add variable to override PVC name in arnold deployment
- API: `GET /statements` now has "mine" option which matches statements that
  have an authority field matching that of the user
- API: Invalid parameters now return 400 status code
- API: Forwarding PUT now uses PUT (instead of POST)
- API: Incoming statements are enriched with `id`, `timestamp`, `stored`
  and `authority`
- API: Add `RALPH_LRS_RESTRICT_BY_AUTHORITY` option making `?mine=True`
  implicit
- API: Add `RALPH_LRS_RESTRICT_BY_SCOPE` option enabling endpoint access
  control by user scopes
- API: Enhance 'limit' query parameter's validation
- API: Variable `RUNSERVER_AUTH_BACKEND` becomes `RUNSERVER_AUTH_BACKENDS`, and
  multiple authentication methods are supported simultaneously
- Backends: Refactor LRS Statements resource query parameters defined for
  `ralph` API
- Backends: Refactor `database`, `storage`, `http` and `stream` backends under
  the unified `data` backend interface [BC]
- Backends: Refactor LRS `query_statements` and `query_statements_by_ids`
  backends methods under the unified `lrs` backend interface [BC]
- Backends: Update `statementId` and `voidedStatementId` to snake_case,
  with camelCase alias, in `LRSStatementsQuery`
- Backends: Replace reference to a JSON column in ClickHouse with
  function calls on the String column [BC]
- CLI: User credentials must now include an "agent" field which can be created
  using the cli
- CLI: Change `push` to `write` and `fetch` to `read` [BC]
- CLI: Change `-c --chunk-size` option to `-s --chunk-size` [BC]
- CLI: Change websocket backend name `-b ws` to `-b async_ws` along with it's
  uri option `--ws-uri` to `--async-ws-uri` [BC]
- CLI: List cli usage strings in alphabetical order
- CLI: Change backend configuration environment variable prefixes from
  `RALPH_BACKENDS__{{DATABASE|HTTP|STORAGE|STREAM}}__{{BACKEND}}__{{OPTION}}`
  to `RALPH_BACKENDS__DATA__{{BACKEND}}__{{OPTION}}`
- Models: The xAPI `context.contextActivities.category` field is now mandatory
  in the video and virtual classroom profiles. [BC]
- Upgrade base python version to 3.12 for the development stack and Docker
  image
- Upgrade `bcrypt` to `4.1.2`
- Upgrade `cachetools` to `5.3.2`
- Upgrade `fastapi` to `0.108.0`
- Upgrade `sentry_sdk` to `1.39.1`
- Upgrade `uvicorn` to `0.25.0`

## Fixed

- API: Fix a typo ('attachements' -> 'attachments') to ensure compliance with
  the LRS specification and prevent potential silent bugs

## Removed

- Project: Drop support for Python 3.7
- Models: Remove `school`, `course`, `module` context extensions in Edx to xAPI
  base converter
- Models: Remove `name` field in `VideoActivity` xAPI model mistakenly used in
  `video` profile
- CLI: Remove `DEFAULT_BACKEND_CHUNK_SIZE` environment variable configuration

