### PR TITLE
🐛(backends) disallow namespace package discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Backends: the first argument of the `get_backends` method now requires a list
+  of dotted backend paths instead of a tuple of packages containing backends.
+
 ## [4.1.0] - 2024-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Backends: Add `ralph.backends.data` and `ralph.backends.lrs` entry points
+  to discover backends from plugins.
+
 ### Changed
 
 - Backends: the first argument of the `get_backends` method now requires a list
-  of dotted backend paths instead of a tuple of packages containing backends.
+  of `EntryPoints`, each pointing to a backend class, instead of a tuple of
+  packages containing backends.
+- API: The `RUNSERVER_BACKEND` configuration value is no longer validated to
+  point to an existing backend.
 
 ## [4.1.0] - 2024-02-12
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ keywords = ["LRS", "Analytics", "xAPI", "Open edX"]
 dependencies = [
     # By default, we only consider core dependencies required to use Ralph as a
     # library (mostly models).
+    "importlib-metadata>=7.0.1, <8.0",
     "langcodes>=3.2.0",
     "pydantic[dotenv,email]>=1.10.0, <2.0",
     "rfc3987>=1.3.0",
@@ -130,6 +131,28 @@ full = [
 
 [project.scripts]
 ralph = "ralph.__main__:cli.cli"
+
+[project.entry-points."ralph.backends.data"]
+async_es = "ralph.backends.data.async_es:AsyncESDataBackend"
+async_lrs = "ralph.backends.data.async_lrs:AsyncLRSDataBackend"
+async_mongo = "ralph.backends.data.async_mongo:AsyncMongoDataBackend"
+async_ws = "ralph.backends.data.async_ws:AsyncWSDataBackend"
+clickhouse = "ralph.backends.data.clickhouse:ClickHouseDataBackend"
+es = "ralph.backends.data.es:ESDataBackend"
+fs = "ralph.backends.data.fs:FSDataBackend"
+ldp = "ralph.backends.data.ldp:LDPDataBackend"
+lrs = "ralph.backends.data.lrs:LRSDataBackend"
+mongo = "ralph.backends.data.mongo:MongoDataBackend"
+s3 = "ralph.backends.data.s3:S3DataBackend"
+swift = "ralph.backends.data.swift:SwiftDataBackend"
+
+[project.entry-points."ralph.backends.lrs"]
+async_es = "ralph.backends.lrs.async_es:AsyncESLRSBackend"
+async_mongo = "ralph.backends.lrs.async_mongo:AsyncMongoLRSBackend"
+clickhouse = "ralph.backends.lrs.clickhouse:ClickHouseLRSBackend"
+es = "ralph.backends.lrs.es:ESLRSBackend"
+fs = "ralph.backends.lrs.fs:FSLRSBackend"
+mongo = "ralph.backends.lrs.mongo:MongoLRSBackend"
 
 [tool.setuptools]
 packages = { find = { where = ["src"] } }

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -1,7 +1,6 @@
 """Configurations for Ralph."""
 
 import io
-import sys
 from enum import Enum
 from pathlib import Path
 from typing import List, Sequence, Tuple, Union
@@ -9,13 +8,7 @@ from typing import List, Sequence, Tuple, Union
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, BaseSettings, Extra, root_validator
 
 from ralph.exceptions import ConfigurationException
-
-from .utils import import_string
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from ralph.utils import import_string
 
 try:
     from click import get_app_dir
@@ -222,9 +215,7 @@ class Settings(BaseSettings):
     RUNSERVER_AUTH_BACKENDS: AuthBackends = AuthBackends([AuthBackend.BASIC])
     RUNSERVER_AUTH_OIDC_AUDIENCE: str = None
     RUNSERVER_AUTH_OIDC_ISSUER_URI: AnyHttpUrl = None
-    RUNSERVER_BACKEND: Literal[
-        "async_es", "async_mongo", "clickhouse", "es", "fs", "mongo"
-    ] = "es"
+    RUNSERVER_BACKEND: str = "es"
     RUNSERVER_HOST: str = "0.0.0.0"  # noqa: S104
     RUNSERVER_MAX_SEARCH_HITS_COUNT: int = 100
     RUNSERVER_POINT_IN_TIME_KEEP_ALIVE: str = "1m"

--- a/tests/backends/test_loader.py
+++ b/tests/backends/test_loader.py
@@ -33,26 +33,32 @@ from ralph.backends.lrs.mongo import MongoLRSBackend
 def test_backends_loader_get_backends(caplog):
     """Test the `get_backends` function."""
 
-    # Given a non existing module name, the `get_backends` function should skip it.
-    with caplog.at_level(logging.WARNING):
-        assert not get_backends(("non_existent_package.foo",), (BaseDataBackend,))
+    # Given a non existing backend, the `get_backends` function should skip it.
+    with caplog.at_level(logging.DEBUG):
+        assert not get_backends(["non_existent_package.Foo"], (BaseDataBackend,))
 
     assert (
         "ralph.backends.loader",
-        logging.WARNING,
-        "Could not find 'non_existent_package.foo' package; skipping it",
+        logging.DEBUG,
+        "Failed to import 'non_existent_package.Foo' backend: "
+        "No module named 'non_existent_package'",
     ) in caplog.record_tuples
 
     # Given a module with a sub-module raising an exception during the import,
     # the `get_backends` function should skip it.
-    paths = ("tests.backends.test_utils_backends",)
+    paths = [
+        "tests.backends.test_utils_backends.invalid_backends.InvalidBackend",
+        "tests.backends.test_utils_backends.valid_backends.AsyncWSDataBackend",
+        "tests.backends.test_utils_backends.valid_backends.FSDataBackend",
+    ]
     with caplog.at_level(logging.DEBUG):
         assert get_backends(paths, (BaseDataBackend,)) == {"fs": FSDataBackend}
 
     assert (
         "ralph.backends.loader",
         logging.DEBUG,
-        "Failed to import tests.backends.test_utils_backends.invalid_backends module: "
+        "Failed to import "
+        "'tests.backends.test_utils_backends.invalid_backends.InvalidBackend' backend: "
         "No module named 'invalid_backends'",
     ) in caplog.record_tuples
 

--- a/tests/backends/test_loader.py
+++ b/tests/backends/test_loader.py
@@ -1,6 +1,12 @@
 """Tests for Ralph's backend utilities."""
 
 import logging
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import EntryPoint, EntryPoints, entry_points
+else:
+    from importlib.metadata import EntryPoint, EntryPoints, entry_points
 
 from ralph.backends.data.async_es import AsyncESDataBackend
 from ralph.backends.data.async_lrs import AsyncLRSDataBackend
@@ -29,43 +35,92 @@ from ralph.backends.lrs.es import ESLRSBackend
 from ralph.backends.lrs.fs import FSLRSBackend
 from ralph.backends.lrs.mongo import MongoLRSBackend
 
+from tests.backends.test_utils_backends.valid_backends import TestBackend
+
 
 def test_backends_loader_get_backends(caplog):
     """Test the `get_backends` function."""
 
     # Given a non existing backend, the `get_backends` function should skip it.
     with caplog.at_level(logging.DEBUG):
-        assert not get_backends(["non_existent_package.Foo"], (BaseDataBackend,))
+        assert not get_backends(
+            EntryPoints(
+                [EntryPoint(name="foo", value="non_existent_package:Foo", group="g")]
+            ),
+            (BaseDataBackend,),
+        )
 
     assert (
         "ralph.backends.loader",
         logging.DEBUG,
-        "Failed to import 'non_existent_package.Foo' backend: "
+        "Failed to import 'foo' backend from 'non_existent_package:Foo': "
         "No module named 'non_existent_package'",
     ) in caplog.record_tuples
 
     # Given a module with a sub-module raising an exception during the import,
     # the `get_backends` function should skip it.
-    paths = [
-        "tests.backends.test_utils_backends.invalid_backends.InvalidBackend",
-        "tests.backends.test_utils_backends.valid_backends.AsyncWSDataBackend",
-        "tests.backends.test_utils_backends.valid_backends.FSDataBackend",
-    ]
+    entries = EntryPoints(
+        [
+            EntryPoint(
+                name="invalid",
+                value=(
+                    "tests.backends.test_utils_backends.invalid_backends:InvalidBackend"
+                ),
+                group="g",
+            ),
+            EntryPoint(
+                name="async_ws_data_backend",
+                value=(
+                    "tests.backends.test_utils_backends.valid_backends"
+                    ":AsyncWSDataBackend"
+                ),
+                group="g",
+            ),
+            EntryPoint(
+                name="fs_backend",
+                value="tests.backends.test_utils_backends.valid_backends:FSDataBackend",
+                group="g",
+            ),
+        ]
+    )
     with caplog.at_level(logging.DEBUG):
-        assert get_backends(paths, (BaseDataBackend,)) == {"fs": FSDataBackend}
+        assert get_backends(entries, (BaseDataBackend,)) == {
+            "fs_backend": FSDataBackend
+        }
 
     assert (
         "ralph.backends.loader",
         logging.DEBUG,
-        "Failed to import "
-        "'tests.backends.test_utils_backends.invalid_backends.InvalidBackend' backend: "
+        "Failed to import 'invalid' backend from "
+        "'tests.backends.test_utils_backends.invalid_backends:InvalidBackend': "
         "No module named 'invalid_backends'",
     ) in caplog.record_tuples
 
 
-def test_backends_loader_get_cli_backends():
+def test_backends_loader_get_cli_backends(monkeypatch):
     """Test the `get_cli_backends` function."""
+
+    def mock_entry_points(group):
+        assert group == "ralph.backends.data"
+        return list(entry_points(group="ralph.backends.data")) + [
+            EntryPoint(
+                name="test_backend",
+                value="tests.backends.test_utils_backends.valid_backends:TestBackend",
+                group="ralph.backends.data",
+            ),
+            EntryPoint(
+                name="invalid_entry_point_exception",
+                value=(
+                    "tests.backends.test_utils_backends.invalid_backends:InvalidBackend"
+                ),
+                group="ralph.backends.data",
+            ),
+        ]
+
+    monkeypatch.setattr("ralph.backends.loader.entry_points", mock_entry_points)
+    get_cli_backends.cache_clear()
     assert get_cli_backends() == {
+        "test_backend": TestBackend,
         "async_es": AsyncESDataBackend,
         "async_lrs": AsyncLRSDataBackend,
         "async_mongo": AsyncMongoDataBackend,
@@ -83,6 +138,7 @@ def test_backends_loader_get_cli_backends():
 
 def test_backends_loader_get_cli_write_backends():
     """Test the `get_cli_write_backends` function."""
+    get_cli_backends.cache_clear()
     assert get_cli_write_backends() == {
         "async_es": AsyncESDataBackend,
         "async_lrs": AsyncLRSDataBackend,
@@ -99,6 +155,7 @@ def test_backends_loader_get_cli_write_backends():
 
 def test_backends_loader_get_cli_list_backends():
     """Test the `get_cli_list_backends` function."""
+    get_cli_backends.cache_clear()
     assert get_cli_list_backends() == {
         "async_es": AsyncESDataBackend,
         "async_mongo": AsyncMongoDataBackend,
@@ -112,9 +169,30 @@ def test_backends_loader_get_cli_list_backends():
     }
 
 
-def test_backends_loader_get_lrs_backends():
+def test_backends_loader_get_lrs_backends(monkeypatch):
     """Test the `get_lrs_backends` function."""
+
+    def mock_entry_points(group):
+        assert group == "ralph.backends.lrs"
+        return list(entry_points(group="ralph.backends.lrs")) + [
+            EntryPoint(
+                name="test_backend",
+                value="tests.backends.test_utils_backends.valid_backends:TestBackend",
+                group="ralph.backends.lrs",
+            ),
+            EntryPoint(
+                name="invalid_entry_point_exception",
+                value=(
+                    "tests.backends.test_utils_backends.invalid_backends:InvalidBackend"
+                ),
+                group="ralph.backends.lrs",
+            ),
+        ]
+
+    monkeypatch.setattr("ralph.backends.loader.entry_points", mock_entry_points)
+    get_lrs_backends.cache_clear()
     assert get_lrs_backends() == {
+        "test_backend": TestBackend,
         "async_es": AsyncESLRSBackend,
         "async_mongo": AsyncMongoLRSBackend,
         "clickhouse": ClickHouseLRSBackend,

--- a/tests/backends/test_utils_backends/valid_backends.py
+++ b/tests/backends/test_utils_backends/valid_backends.py
@@ -2,3 +2,16 @@
 
 from ralph.backends.data.async_ws import AsyncWSDataBackend  # noqa: F401
 from ralph.backends.data.fs import FSDataBackend  # noqa: F401
+from ralph.backends.lrs.fs import FSLRSBackend
+
+
+class TestBackend(FSLRSBackend):
+    """Test Backend to check entry point discovery."""
+
+    name = "TestBackend"
+
+
+class TestIgnoredBackend(FSLRSBackend):
+    """Test Backend to check ignored entry point discovery."""
+
+    name = "TestIgnoredBackend"


### PR DESCRIPTION
## Purpose

The automatic backend discovery by package name implemented in the `get_backends` method allowed the use of namespace package plugins, which is undesired. We want to support backend discovery using package metadata (entry points) exclusively in the future.

## Proposal

- [x] update the `get_backends` method to load backends from a predefined list of dotted backend paths.
- [x] add entry point backend discovery.
- [ ] update documentation. (in a separate PR?)

P.S.: I haven't noticed a change in performance with the addition of entry point backend discovery:

Tried: `perf stat -r 10 ./bin/ralph read` (which loads all backends to display the help page):
 - main (2.6699 +- 0.0402 seconds time elapsed)
 - this PR (2.7070 +- 0.0624 seconds time elapsed)

