### PR TITLE
📝(helm) add helm README tutorial to documentation

### DIFF
--- a/docs/tutorials/helm.md
+++ b/docs/tutorials/helm.md
@@ -1,0 +1,1 @@
+../../src/helm/README.md

--- a/docs/tutorials/lrs/index.md
+++ b/docs/tutorials/lrs/index.md
@@ -5,10 +5,13 @@ This tutorial shows you how to run Ralph LRS, step by step.
 !!! warning
 
     Ralph LRS will be executed locally for demonstration purpose.
-    If you want to deploy Ralph LRS on a production server, please refer to the section **Ralph LRS deployment**.
+    If you want to deploy Ralph LRS on a production server, please refer to the 
+    [deployment guide](../helm.md).
 
-Ralph LRS is based on [FastAPI](https://fastapi.tiangolo.com/).
-In this tutorial, we will run the server manually with [Uvicorn](https://www.uvicorn.org/), but other alternatives exists ([Hypercorn](https://pgjones.gitlab.io/hypercorn/), [Daphne](https://github.com/django/daphne)).
+Ralph LRS is based on [FastAPI](https://fastapi.tiangolo.com/). In this tutorial, we
+will run the server manually with [Uvicorn](https://www.uvicorn.org/), but other
+alternatives exists ([Hypercorn](https://pgjones.gitlab.io/hypercorn/),
+[Daphne](https://github.com/django/daphne)).
 
 !!! info "Prerequisites"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
                 - tutorials/lrs/forwarding.md
                 - tutorials/lrs/sentry.md
         - Ralph Library Guide: tutorials/library.md
+        - Ralph Helm chart: tutorials/helm.md
         - Development Guide: tutorials/development_guide.md
     - Contributing: contribute.md
     - Migration: UPGRADE.md


### PR DESCRIPTION
## Purpose

Documentation is missing a tutorial/guide to deploy Ralph.

## Proposal

Making the Helm chart README general enough to be used both for a README and
for documentation.

