### PR TITLE
💚(circle) change deprecated ubuntu machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
   # ---- Tray jobs (k8s) ----
   tray:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: default
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/fun


### PR DESCRIPTION
## Purpose

CircleCI is deprecating all ubuntu machines to ensure pipelines run on latest versions.

## Proposal

Changing ubuntu machines to `default` (latest stable version). Refer to https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177
