### PR TITLE
🔖(minor) bump release to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.1.0] - 2024-02-12
+
 ### Added
 
 - Add LRS multitenancy support for user-specific target storage
@@ -439,7 +441,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v4.0.0...main
+[unreleased]: https://github.com/openfun/ralph/compare/v4.1.0...main
+[4.1.0]: https://github.com/openfun/ralph/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/openfun/ralph/compare/v3.9.0...v4.0.0
 [3.9.0]: https://github.com/openfun/ralph/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/openfun/ralph/compare/v3.7.0...v3.8.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@ All instructions to upgrade this project from one release to the next will be do
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### 3.x.x to 4.0.0
+### 3.x to 4.y
 
 #### Upgrade user credentials
 To conform to xAPI specifications, we need to represent users as xAPI Agents. You must therefore delete and re-create the credentials file using the updated cli, OR you can modify it directly to add the `agents` field. The credentials file is located in `{ RALPH_APP_DIR }/{ RALPH_AUTH_FILE }` (defaults to `.ralph/auth.json`). Each user profile must follow the following pattern (see [this post](https://xapi.com/blog/deep-dive-actor-agent/) for examples of valid agent objects) :

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade appVersion to `4.1.0`
+
 ## [0.3.0] - 2024-02-07
 
 ### Added

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -4,5 +4,5 @@ name: ralph
 description: Ralph, the ultimate Learning Record Store (and more!) for your learning analytics 
 type: application
 version: 0.3.0
-appVersion: "4.0.0"
+appVersion: "4.1.0"
 icon: https://raw.githubusercontent.com/openfun/logos/main/ralph/ralph-color-dark.png

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 4.0.0
+  version: 4.1.0


### PR DESCRIPTION
### Added

- Add LRS multitenancy support for user-specific target storage

### Changed

- `query_statements` and `query_statements_by_ids` methods can now take an
optional user-specific target

### Fixed

- Backends: switch LRSStatementsQuery since/until field types to iso 8601 string

### Removed

- Removed `event_table_name` attribute of the ClickHouse data backend

