### PR TITLE
🐛(api) fix activity querying for statements with object missing a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to
 - API: The `RUNSERVER_BACKEND` configuration value is no longer validated to
   point to an existing backend.
 
+### Fixed
+
+- LRS: Fix querying on `activity` when LRS contains statements with an object
+  lacking a `objectType` attribute
+
 ## [4.1.0] - 2024-02-12
 
 ### Added

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -62,9 +62,6 @@ class ClickHouseLRSBackend(
             where.append("JSONExtractString(event, 'verb', 'id') = {verb:String}")
 
         if params.activity:
-            where.append(
-                "JSONExtractString(event, 'object', 'objectType') = 'Activity'"
-            )
             where.append("JSONExtractString(event, 'object', 'id') = {activity:String}")
 
         if params.since:

--- a/src/ralph/backends/lrs/es.py
+++ b/src/ralph/backends/lrs/es.py
@@ -82,7 +82,6 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
 
         if params.activity:
             es_query_filters += [
-                {"term": {"object.objectType.keyword": "Activity"}},
                 {"term": {"object.id.keyword": params.activity}},
             ]
 

--- a/src/ralph/backends/lrs/mongo.py
+++ b/src/ralph/backends/lrs/mongo.py
@@ -90,7 +90,6 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
         if params.activity:
             mongo_query_filters.update(
                 {
-                    "_source.object.objectType": "Activity",
                     "_source.object.id": params.activity,
                 },
             )

--- a/tests/backends/lrs/test_async_es.py
+++ b/tests/backends/lrs/test_async_es.py
@@ -186,7 +186,6 @@ def test_backends_lrs_async_es_default_instantiation(monkeypatch, fs):
                                     )
                                 }
                             },
-                            {"term": {"object.objectType.keyword": "Activity"}},
                             {
                                 "term": {
                                     "object.id.keyword": (

--- a/tests/backends/lrs/test_async_mongo.py
+++ b/tests/backends/lrs/test_async_mongo.py
@@ -147,7 +147,6 @@ def test_backends_lrs_async_mongo_default_instantiation(monkeypatch, fs):
                 "filter": {
                     "_source.verb.id": "http://adlnet.gov/expapi/verbs/attended",
                     "_source.object.id": "http://www.example.com/meetings/34534",
-                    "_source.object.objectType": "Activity",
                 },
                 "limit": 0,
                 "projection": None,
@@ -271,7 +270,7 @@ async def test_backends_lrs_async_mongo_query_statements_with_success(
     meta = {
         "actor": {"account": {"name": "test_name", "homePage": "http://example.com"}},
         "verb": {"id": "verb_id"},
-        "object": {"id": "http://example.com", "objectType": "Activity"},
+        "object": {"id": "http://example.com"},
     }
     documents = [
         {"id": "62b9ce922c26b46b68ffc68f", **timestamp, **meta},

--- a/tests/backends/lrs/test_clickhouse.py
+++ b/tests/backends/lrs/test_clickhouse.py
@@ -184,7 +184,6 @@ def test_backends_lrs_clickhouse_default_instantiation(monkeypatch, fs):
             {
                 "where": [
                     "JSONExtractString(event, 'verb', 'id') = {verb:String}",
-                    "JSONExtractString(event, 'object', 'objectType') = 'Activity'",
                     "JSONExtractString(event, 'object', 'id') = {activity:String}",
                 ],
                 "params": {
@@ -319,7 +318,7 @@ def test_backends_lrs_clickhouse_query_statements(clickhouse, clickhouse_lrs_bac
             "timestamp": datetime_object.isoformat(),
             "actor": {"account": {"name": "test_name"}},
             "verb": {"id": "verb_id"},
-            "object": {"id": "http://example.com", "objectType": "Activity"},
+            "object": {"id": "http://example.com"},
         },
     ]
     success = backend.write(statements, chunk_size=1)
@@ -335,7 +334,7 @@ def test_backends_lrs_clickhouse_query_statements(clickhouse, clickhouse_lrs_bac
             "timestamp": datetime_object.isoformat(),
             "actor": {"account": {"name": "test_name"}},
             "verb": {"id": "verb_id"},
-            "object": {"id": "http://example.com", "objectType": "Activity"},
+            "object": {"id": "http://example.com"},
         },
     ]
     success = backend.write(statements_custom, target=custom_target, chunk_size=1)
@@ -375,7 +374,7 @@ def test_backends_lrs_clickhouse__find(clickhouse, clickhouse_lrs_backend):
             "timestamp": datetime_object.isoformat(),
             "actor": {"account": {"name": "test_name"}},
             "verb": {"id": "verb_id"},
-            "object": {"id": "http://example.com", "objectType": "Activity"},
+            "object": {"id": "http://example.com"},
         },
     ]
 
@@ -420,7 +419,7 @@ def test_backends_lrs_clickhouse_query_statements_by_ids(
             "timestamp": datetime_object.isoformat(),
             "actor": {"account": {"name": "test_name"}},
             "verb": {"id": "verb_id"},
-            "object": {"id": "http://example.com", "objectType": "Activity"},
+            "object": {"id": "http://example.com"},
         },
     ]
     count = backend.write(statements, chunk_size=1)
@@ -436,7 +435,7 @@ def test_backends_lrs_clickhouse_query_statements_by_ids(
             "timestamp": datetime_object.isoformat(),
             "actor": {"account": {"name": "test_name"}},
             "verb": {"id": "verb_id"},
-            "object": {"id": "http://example.com", "objectType": "Activity"},
+            "object": {"id": "http://example.com"},
         },
     ]
     count = backend.write(statements_custom, target=custom_target, chunk_size=1)

--- a/tests/backends/lrs/test_es.py
+++ b/tests/backends/lrs/test_es.py
@@ -186,7 +186,6 @@ def test_backends_lrs_es_default_instantiation(monkeypatch, fs):
                                     )
                                 }
                             },
-                            {"term": {"object.objectType.keyword": "Activity"}},
                             {
                                 "term": {
                                     "object.id.keyword": (

--- a/tests/backends/lrs/test_fs.py
+++ b/tests/backends/lrs/test_fs.py
@@ -164,7 +164,7 @@ def test_backends_lrs_fs_query_statements_query(
             "id": "0",
             "actor": {"mbox_sha1sum": "foo_sha1sum"},
             "verb": {"id": "foo_verb"},
-            "object": {"id": "bar_object", "objectType": "Activity"},
+            "object": {"id": "bar_object"},
             "context": {
                 "registration": "de867099-77ee-453b-949e-2c1933734436",
                 "instructor": {"mbox": "mailto:bar@bar.baz"},
@@ -190,7 +190,7 @@ def test_backends_lrs_fs_query_statements_query(
             "id": "2",
             "actor": {"openid": "foo_openid"},
             "verb": {"id": "foo_verb"},
-            "object": {"id": "foo_object", "objectType": "Activity"},
+            "object": {"id": "foo_object"},
             "context": {
                 "registration": "b0d0e57d-9fbf-42e3-ba60-85e0be6f709d",
                 "contextActivities": {"grouping": [{"id": "bar_object"}]},
@@ -232,7 +232,7 @@ def test_backends_lrs_fs_query_statements_query(
                 "objectType": "SubStatement",
                 "actor": {"openid": "foo_openid"},
                 "verb": {"id": "bar_verb"},
-                "object": {"id": "bar_object", "objectType": "Activity"},
+                "object": {"id": "bar_object"},
                 "context": {
                     "instructor": {
                         "account": {"name": "foo_name", "homePage": "foo_home"}

--- a/tests/backends/lrs/test_mongo.py
+++ b/tests/backends/lrs/test_mongo.py
@@ -147,7 +147,6 @@ def test_backends_lrs_mongo_default_instantiation(monkeypatch, fs):
                 "filter": {
                     "_source.verb.id": "http://adlnet.gov/expapi/verbs/attended",
                     "_source.object.id": "http://www.example.com/meetings/34534",
-                    "_source.object.objectType": "Activity",
                 },
                 "limit": 0,
                 "projection": None,
@@ -266,7 +265,7 @@ def test_backends_lrs_mongo_query_statements_with_success(mongo, mongo_lrs_backe
     meta = {
         "actor": {"account": {"name": "test_name", "homePage": "http://example.com"}},
         "verb": {"id": "https://xapi-example.com/verb-id"},
-        "object": {"id": "http://example.com", "objectType": "Activity"},
+        "object": {"id": "http://example.com"},
     }
     documents = [
         {"id": "62b9ce922c26b46b68ffc68f", **timestamp, **meta},

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -67,7 +67,6 @@ def mock_activity(id_: int = 0):
 
     """
     return {
-        "objectType": "Activity",
         "id": f"http://example.com/activity_{id_}",
     }
 


### PR DESCRIPTION
## Purpose

In xAPI version 1.0.3, the presence of `objectType` is optional, defaulting to `Activity` when not specified.

## Proposal

When querying activities, the LRS should exclusively search for `object.id` rather than first filtering on objects with type `Activity`.
This concerns all LRS backends.

