### PR TITLE
🔖(minor) bump release to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.2.0] - 2024-04-08
+
 ### Added
 
 - Models: Add Edx teams-related events support
@@ -468,7 +470,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v4.1.0...main
+[unreleased]: https://github.com/openfun/ralph/compare/v4.2.0...main
+[4.2.0]: https://github.com/openfun/ralph/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/openfun/ralph/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/openfun/ralph/compare/v3.9.0...v4.0.0
 [3.9.0]: https://github.com/openfun/ralph/compare/v3.8.0...v3.9.0

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade appVersion to `4.2.0`
+
 ## [0.4.0] - 2024-02-12
 
 ### Changed

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -4,5 +4,5 @@ name: ralph
 description: Ralph, the ultimate Learning Record Store (and more!) for your learning analytics 
 type: application
 version: 0.4.0
-appVersion: "4.1.0"
+appVersion: "4.2.0"
 icon: https://raw.githubusercontent.com/openfun/logos/main/ralph/ralph-color-dark.png

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 4.1.0
+  version: 4.2.0


### PR DESCRIPTION
## Added

- Models: Add Edx teams-related events support
- Models: Add Edx notes events support
- Models: Add Edx certificate events support
- Models: Add Edx bookmark (renamed Course Resource) events support
- Models: Add Edx poll and survey events support
- Models: Add Edx Course Content Completion events support
- Models: Add Edx drag and drop events support
- Models: Add Edx cohort events support
- Models: Add Edx content library interaction events support
- Backends: Add `ralph.backends.data` and `ralph.backends.lrs` entry points
  to discover backends from plugins.

## Changed

- Backends: the first argument of the `get_backends` method now requires a list
  of `EntryPoints`, each pointing to a backend class, instead of a tuple of
  packages containing backends.
- API: The `RUNSERVER_BACKEND` configuration value is no longer validated to
  point to an existing backend.

## Fixed

- LRS: Fix querying on `activity` when LRS contains statements with an object
  lacking a `objectType` attribute