### PR TITLE
🔥(project) remove obsolete docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   app:
     build:


### PR DESCRIPTION
## Purpose

The warning `WARN[0000] docker-compose.yml: `version` is obsolete` is displayed.
The `version` is deprecated and not used anymore by the latest Compose file format 1.27.0+.

## Proposal

Removing the field.

_Note_: A discussion about it here https://github.com/openfun/joanie/pull/721/files#r1547736981
