### PR TITLE
👽️(project) replace deprecated `parse_obj_as`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Upgrade `pydantic` to `2.7.0`
 - Migrate model tests from hypothesis strategies to polyfactory
+- Replace soon-to-be deprecated `parse_obj_as` with `TypeAdapter`
 
 ## [4.2.0] - 2024-04-08
 

--- a/src/ralph/backends/data/async_lrs.py
+++ b/src/ralph/backends/data/async_lrs.py
@@ -6,7 +6,7 @@ from typing import AsyncIterator, Iterable, Optional, Union
 from urllib.parse import ParseResult, parse_qs, urljoin, urlparse
 
 from httpx import AsyncClient, HTTPError, HTTPStatusError, RequestError
-from pydantic import AnyHttpUrl, PositiveInt, parse_obj_as
+from pydantic import AnyHttpUrl, PositiveInt, TypeAdapter
 
 from ralph.backends.data.base import (
     AsyncWritable,
@@ -44,7 +44,7 @@ class AsyncLRSDataBackend(
                 If `settings` is `None`, a default settings instance is used instead.
         """
         super().__init__(settings)
-        self.base_url = parse_obj_as(AnyHttpUrl, self.settings.BASE_URL)
+        self.base_url = TypeAdapter(AnyHttpUrl).validate_python(self.settings.BASE_URL)
         self.auth = (self.settings.USERNAME, self.settings.PASSWORD)
         self._client = None
 

--- a/src/ralph/backends/data/lrs.py
+++ b/src/ralph/backends/data/lrs.py
@@ -6,7 +6,13 @@ from typing import Iterable, Iterator, List, Optional, Union
 from urllib.parse import ParseResult, parse_qs, urljoin, urlparse
 
 from httpx import Client, HTTPError, HTTPStatusError, RequestError
-from pydantic import AnyHttpUrl, BaseModel, Field, PositiveInt, parse_obj_as
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    Field,
+    PositiveInt,
+    TypeAdapter,
+)
 from pydantic_settings import SettingsConfigDict
 from typing_extensions import Annotated
 
@@ -90,7 +96,7 @@ class LRSDataBackend(
                 If `settings` is `None`, a default settings instance is used instead.
         """
         super().__init__(settings)
-        self.base_url = parse_obj_as(AnyHttpUrl, self.settings.BASE_URL)
+        self.base_url = TypeAdapter(AnyHttpUrl).validate_python(self.settings.BASE_URL)
         self.auth = (self.settings.USERNAME, self.settings.PASSWORD)
         self._client = None
 

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -13,8 +13,8 @@ from pydantic import (
     ConfigDict,
     Field,
     StringConstraints,
+    TypeAdapter,
     model_validator,
-    parse_obj_as,
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Annotated
@@ -198,7 +198,9 @@ class Settings(BaseSettings):
         },
     }
     PARSERS: ParserSettings = ParserSettings()
-    RUNSERVER_AUTH_BACKENDS: AuthBackends = parse_obj_as(AuthBackends, "Basic")
+    RUNSERVER_AUTH_BACKENDS: AuthBackends = TypeAdapter(AuthBackends).validate_python(
+        "Basic"
+    )
     RUNSERVER_AUTH_OIDC_AUDIENCE: Optional[str] = None
     RUNSERVER_AUTH_OIDC_ISSUER_URI: Optional[AnyHttpUrl] = None
     RUNSERVER_BACKEND: str = "es"

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -2,7 +2,7 @@
 
 import pytest
 import responses
-from pydantic import parse_obj_as
+from pydantic import TypeAdapter
 
 from ralph.api.auth.oidc import discover_provider, get_public_keys
 from ralph.conf import AuthBackend
@@ -40,7 +40,9 @@ async def test_api_auth_oidc_get_whoami_valid(
     assert response.status_code == 200
     assert len(response.json().keys()) == 2
     assert response.json()["agent"] == {"openid": "https://iss.example.com/123|oidc"}
-    assert parse_obj_as(BaseXapiAgentWithOpenId, response.json()["agent"])
+    assert TypeAdapter(BaseXapiAgentWithOpenId).validate_python(
+        response.json()["agent"]
+    )
     assert sorted(response.json()["scopes"]) == ["all", "profile/read"]
     assert "target" not in response.json()
 

--- a/tests/backends/data/test_async_lrs.py
+++ b/tests/backends/data/test_async_lrs.py
@@ -11,7 +11,7 @@ from functools import partial
 import httpx
 import pytest
 from httpx import HTTPStatusError, RequestError
-from pydantic import AnyHttpUrl, AnyUrl, parse_obj_as
+from pydantic import AnyHttpUrl, AnyUrl, TypeAdapter
 from pytest_httpx import HTTPXMock
 
 from ralph.backends.data.async_lrs import AsyncLRSDataBackend
@@ -46,7 +46,9 @@ def test_backends_data_async_lrs_default_instantiation(monkeypatch, fs, lrs_back
     assert backend_class.settings_class == LRSDataBackendSettings
     backend = backend_class()
     assert backend.query_class == LRSStatementsQuery
-    assert backend.base_url == parse_obj_as(AnyHttpUrl, "http://0.0.0.0:8100")
+    assert backend.base_url == TypeAdapter(AnyHttpUrl).validate_python(
+        "http://0.0.0.0:8100"
+    )
     assert backend.auth == ("ralph", "secret")
     assert backend.settings.HEADERS == LRSHeaders()
     assert backend.settings.LOCALE_ENCODING == "utf8"

--- a/tests/backends/data/test_async_ws.py
+++ b/tests/backends/data/test_async_ws.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 import websockets
-from pydantic import AnyUrl, parse_obj_as
+from pydantic import AnyUrl, TypeAdapter
 
 from ralph.backends.data.async_ws import AsyncWSDataBackend, WSDataBackendSettings
 from ralph.backends.data.base import DataBackendStatus
@@ -49,7 +49,7 @@ def test_backends_data_async_ws_instantiation_with_settings(monkeypatch):
     uri = f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}"
     settings = WSDataBackendSettings(URI=uri)
     backend = AsyncWSDataBackend(settings)
-    assert backend.settings.URI == parse_obj_as(AnyUrl, uri)
+    assert backend.settings.URI == TypeAdapter(AnyUrl).validate_python(uri)
     assert backend.settings.LOCALE_ENCODING == "utf8"
     assert backend.settings.READ_CHUNK_SIZE == 500
     assert backend.settings.WRITE_CHUNK_SIZE == 500
@@ -59,7 +59,7 @@ def test_backends_data_async_ws_instantiation_with_settings(monkeypatch):
     monkeypatch.setenv("RALPH_BACKENDS__DATA__WS__URI", "ws://foo")
     backend = AsyncWSDataBackend()
     assert backend.settings.READ_CHUNK_SIZE == 1
-    assert backend.settings.URI == parse_obj_as(AnyUrl, "ws://foo")
+    assert backend.settings.URI == TypeAdapter(AnyUrl).validate_python("ws://foo")
 
 
 @pytest.mark.anyio
@@ -79,7 +79,7 @@ async def test_backends_data_async_ws_status_with_error_status(ws, events, caplo
         "[Errno 111] Connect call failed ('127.0.0.1', 1)",
     ) in caplog.record_tuples
 
-    uri = parse_obj_as(AnyUrl, f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}")
+    uri = TypeAdapter(AnyUrl).validate_python(f"ws://{WS_TEST_HOST}:{WS_TEST_PORT}")
     settings = WSDataBackendSettings(URI=uri)
     backend = AsyncWSDataBackend(settings)
     assert [_ async for _ in backend.read(raw_output=False)] == events

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -18,7 +18,7 @@ import uvicorn
 import websockets
 from elasticsearch import BadRequestError, Elasticsearch
 from httpx import AsyncClient, ConnectError
-from pydantic import AnyHttpUrl, parse_obj_as
+from pydantic import AnyHttpUrl, TypeAdapter
 from pymongo import MongoClient
 from pymongo.errors import CollectionInvalid
 
@@ -313,7 +313,7 @@ def lrs_backend(
             "CONTENT_TYPE": "application/json",
         }
         settings = backend_class.settings_class(
-            BASE_URL=parse_obj_as(AnyHttpUrl, base_url),
+            BASE_URL=TypeAdapter(AnyHttpUrl).validate_python(base_url),
             USERNAME="user",
             PASSWORD="pass",
             HEADERS=LRSHeaders.model_validate(headers),


### PR DESCRIPTION
## Purpose

Replace soon-to-be-deprecated `parse_obj_as` with `TypeAdapter` after Pydantic V2 migration.

Closes #551 