### PR TITLE
🔧(dependencies) update ignored dependencies in renovate configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,3 @@ bin/vault_password
 .team
 group_vars/
 k3d-storage/
-
-# hypothesis
-.hypothesis/

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,9 @@
     "ignoreDeps": [
         "backend-clickhouse/clickhouse-connect",
         "backend-lrs/httpx",
-        "dev/hypothesis",
         "dev/pytest",
         "dev/pytest-httpx",
         "dev/responses",
-        "lrs/httpx",
-        "pydantic"
+        "lrs/httpx"
     ]
 }


### PR DESCRIPTION
## Purpose

Pydantic V2 is now supported by ralph. Temporarily, pydantic was a dependency
ignored for renovate to avoid automatic upgrades on its weekly tasks.
Tests for Pydantic are now made with polyfactory. Hypothesis ignored dependency
is removed too and its mention in gitignore.

## Proposal

- Remove pydantic and hypothesis in ignored dependencies of renovate
- Remove .hypothesis in .gitignore.

