### PR TITLE
♻️(models) set missing default values for xAPI activity types

### DIFF
--- a/src/ralph/models/xapi/concepts/activity_types/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/activity_types/acrossx_profile.py
@@ -47,7 +47,9 @@ class WebpageActivityDefinition(BaseXapiActivityDefinition):
             `https://w3id.org/xapi/acrossx/activities/webpage`.
     """
 
-    type: Literal["https://w3id.org/xapi/acrossx/activities/webpage"]
+    type: Literal["https://w3id.org/xapi/acrossx/activities/webpage"] = (
+        "https://w3id.org/xapi/acrossx/activities/webpage"
+    )
 
 
 class WebpageActivity(BaseXapiActivity):

--- a/src/ralph/models/xapi/concepts/activity_types/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/activity_types/activity_streams_vocabulary.py
@@ -45,7 +45,7 @@ class FileActivityDefinition(BaseXapiActivityDefinition):
        type (str): Consists of the value `http://activitystrea.ms/file`.
     """
 
-    type: Literal["http://activitystrea.ms/file"]
+    type: Literal["http://activitystrea.ms/file"] = "http://activitystrea.ms/file"
 
 
 class FileActivity(BaseXapiActivity):

--- a/src/ralph/models/xapi/concepts/activity_types/audio.py
+++ b/src/ralph/models/xapi/concepts/activity_types/audio.py
@@ -21,7 +21,9 @@ class AudioActivityDefinition(BaseXapiActivityDefinition):
             `https://w3id.org/xapi/audio/activity-type/audio`.
     """
 
-    type: Literal["https://w3id.org/xapi/audio/activity-type/audio"]
+    type: Literal["https://w3id.org/xapi/audio/activity-type/audio"] = (
+        "https://w3id.org/xapi/audio/activity-type/audio"
+    )
 
 
 class AudioActivity(BaseXapiActivity):

--- a/src/ralph/models/xapi/concepts/activity_types/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/activity_types/tincan_vocabulary.py
@@ -21,7 +21,9 @@ class DocumentActivityDefinition(BaseXapiActivityDefinition):
             `http://id.tincanapi.com/activitytype/document`.
     """
 
-    type: Literal["http://id.tincanapi.com/activitytype/document"]
+    type: Literal["http://id.tincanapi.com/activitytype/document"] = (
+        "http://id.tincanapi.com/activitytype/document"
+    )
 
 
 class DocumentActivity(BaseXapiActivity):
@@ -45,7 +47,9 @@ class WebinarActivityDefinition(BaseXapiActivityDefinition):
             `http://id.tincanapi.com/activitytype/webinar`.
     """
 
-    type: Literal["http://id.tincanapi.com/activitytype/webinar"]
+    type: Literal["http://id.tincanapi.com/activitytype/webinar"] = (
+        "http://id.tincanapi.com/activitytype/webinar"
+    )
 
 
 class WebinarActivity(BaseXapiActivity):


### PR DESCRIPTION
## Purpose

Some activity types declared with Pydantic were missing default values for types
field which forces library users to declare the type value when model is
instantiated.

## Proposal

However, as these values are constants in xAPI semantics, we do
not want to request this from lib users.

