### PR TITLE
♻️(models) change default value "Agent" object type

### DIFF
--- a/src/ralph/models/xapi/base/agents.py
+++ b/src/ralph/models/xapi/base/agents.py
@@ -43,7 +43,7 @@ class BaseXapiAgentCommonProperties(BaseModelWithConfig, ABC):
         name (str): Consists of the full name of the Agent.
     """
 
-    objectType: Optional[Literal["Agent"]] = None
+    objectType: Literal["Agent"] = "Agent"
     name: Optional[NonEmptyStrictStr] = None
 
 

--- a/tests/api/auth/test_basic.py
+++ b/tests/api/auth/test_basic.py
@@ -231,7 +231,10 @@ async def test_api_auth_basic_get_whoami_correct_credentials(
     assert response.status_code == 200
 
     assert len(response.json().keys()) == 2
-    assert response.json()["agent"] == {"mbox": "mailto:ralph@example.com"}
+    assert response.json()["agent"] == {
+        "mbox": "mailto:ralph@example.com",
+        "objectType": "Agent",
+    }
     assert sorted(response.json()["scopes"]) == [
         "statements/read/mine",
         "statements/write",

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -39,7 +39,10 @@ async def test_api_auth_oidc_get_whoami_valid(
     )
     assert response.status_code == 200
     assert len(response.json().keys()) == 2
-    assert response.json()["agent"] == {"openid": "https://iss.example.com/123|oidc"}
+    assert response.json()["agent"] == {
+        "openid": "https://iss.example.com/123|oidc",
+        "objectType": "Agent",
+    }
     assert TypeAdapter(BaseXapiAgentWithOpenId).validate_python(
         response.json()["agent"]
     )

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -219,7 +219,10 @@ async def test_api_statements_post_enriching_without_existing_values(
 
     # Test pre-processing: authority
     assert "authority" in statement
-    assert statement["authority"] == {"mbox": "mailto:test_ralph@example.com"}
+    assert statement["authority"] == {
+        "mbox": "mailto:test_ralph@example.com",
+        "objectType": "Agent",
+    }
 
 
 @pytest.mark.anyio
@@ -229,7 +232,11 @@ async def test_api_statements_post_enriching_without_existing_values(
         ("id", str(uuid4()), 200),
         ("timestamp", "2022-06-22T08:31:38Z", 200),
         ("stored", "2022-06-22T08:31:38Z", 200),
-        ("authority", {"mbox": "mailto:test_ralph@example.com"}, 200),
+        (
+            "authority",
+            {"mbox": "mailto:test_ralph@example.com", "objectType": "Agent"},
+            200,
+        ),
     ],
 )
 async def test_api_statements_post_enriching_with_existing_values(  # noqa: PLR0913

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -202,7 +202,10 @@ async def test_api_statements_put_enriching_without_existing_values(
 
     # Test pre-processing: authority
     assert "authority" in statement
-    assert statement["authority"] == {"mbox": "mailto:test_ralph@example.com"}
+    assert statement["authority"] == {
+        "mbox": "mailto:test_ralph@example.com",
+        "objectType": "Agent",
+    }
 
 
 @pytest.mark.anyio
@@ -211,7 +214,11 @@ async def test_api_statements_put_enriching_without_existing_values(
     [
         ("timestamp", "2022-06-22T08:31:38Z", 204),
         ("stored", "2022-06-22T08:31:38Z", 204),
-        ("authority", {"mbox": "mailto:test_ralph@example.com"}, 204),
+        (
+            "authority",
+            {"mbox": "mailto:test_ralph@example.com", "objectType": "Agent"},
+            204,
+        ),
     ],
 )
 async def test_api_statements_put_enriching_with_existing_values(  # noqa: PLR0913

--- a/tests/models/edx/converters/xapi/test_enrollment.py
+++ b/tests/models/edx/converters/xapi/test_enrollment.py
@@ -43,7 +43,10 @@ def test_models_edx_converters_xapi_enrollment_edx_course_enrollment_activated_t
 
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "http://adlnet.gov/expapi/verbs/registered"},
         "context": {
             "contextActivities": {
@@ -99,7 +102,10 @@ def test_models_edx_converters_xapi_enrollment_edx_course_enrollment_deactivated
 
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "http://id.tincanapi.com/verb/unregistered"},
         "context": {
             "contextActivities": {

--- a/tests/models/edx/converters/xapi/test_navigational.py
+++ b/tests/models/edx/converters/xapi/test_navigational.py
@@ -34,6 +34,7 @@ def test_models_edx_converters_xapi_navigational_ui_page_close_to_page_terminate
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
         "actor": {
+            "objectType": "Agent",
             "account": {"homePage": platform_url, "name": "1"},
         },
         "object": {

--- a/tests/models/edx/converters/xapi/test_server.py
+++ b/tests/models/edx/converters/xapi/test_server.py
@@ -55,6 +55,7 @@ def test_models_edx_converters_xapi_server_server_event_to_page_viewed(uuid_name
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
         "actor": {
             "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
         },
         "object": {
             "definition": {

--- a/tests/models/edx/converters/xapi/test_video.py
+++ b/tests/models/edx/converters/xapi/test_video.py
@@ -50,7 +50,10 @@ def test_models_edx_converters_xapi_video_ui_load_video_to_video_initialized(
 
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "http://adlnet.gov/expapi/verbs/initialized"},
         "context": {
             "contextActivities": {
@@ -108,7 +111,10 @@ def test_models_edx_converters_xapi_video_ui_play_video_to_video_played(uuid_nam
     )
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "https://w3id.org/xapi/video/verbs/played"},
         "object": {
             "id": platform_url.rstrip("/")
@@ -173,7 +179,10 @@ def test_models_edx_converters_xapi_video_ui_pause_video_to_video_paused(
     )
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "https://w3id.org/xapi/video/verbs/paused"},
         "object": {
             "id": platform_url.rstrip("/")
@@ -239,7 +248,10 @@ def test_models_edx_converters_xapi_video_ui_stop_video_to_video_terminated(
     )
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "http://adlnet.gov/expapi/verbs/terminated"},
         "object": {
             "id": platform_url.rstrip("/")
@@ -304,7 +316,10 @@ def test_models_edx_converters_xapi_video_ui_seek_video_to_video_seeked(uuid_nam
     )
     assert xapi_event_dict == {
         "id": str(uuid5(UUID(uuid_namespace), event_str)),
-        "actor": {"account": {"homePage": platform_url, "name": "1"}},
+        "actor": {
+            "account": {"homePage": platform_url, "name": "1"},
+            "objectType": "Agent",
+        },
         "verb": {"id": "https://w3id.org/xapi/video/verbs/seeked"},
         "object": {
             "id": platform_url.rstrip("/")

--- a/tests/models/xapi/base/test_agents.py
+++ b/tests/models/xapi/base/test_agents.py
@@ -6,9 +6,21 @@ import re
 import pytest
 from pydantic import ValidationError
 
-from ralph.models.xapi.base.agents import BaseXapiAgentWithMboxSha1Sum
+from ralph.models.xapi.base.agents import (
+    BaseXapiAgentCommonProperties,
+    BaseXapiAgentWithMboxSha1Sum,
+)
 
 from tests.factories import mock_xapi_instance
+
+
+def test_models_xapi_base_agents_agent_common_properties_with_valid_field():
+    """Test a valid BaseXapiAgentCommonProperties has the expected
+    `objectType` value.
+    """
+    field = mock_xapi_instance(BaseXapiAgentCommonProperties)
+
+    assert field.objectType == "Agent"
 
 
 def test_models_xapi_base_agent_with_mbox_sha1_sum_ifi_with_valid_field():


### PR DESCRIPTION
## Purpose

Until now, "Agent" object type was set to None as default value. When using
ralph xapi models to generate statements instances, objectType Agent is
generated with None value which is not the required behavior. 

## Proposal

We keep this field as optional in Pydantic model for validation and force
"Agent" value as a default value.

