### PR TITLE
🔖(major) bump release to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [5.0.0] - 2024-05-02
+
 ### Added
 
 - Models: Add Webinar xAPI activity type
@@ -480,7 +482,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v4.2.0...main
+[unreleased]: https://github.com/openfun/ralph/compare/v5.0.0...main
+[5.0.0]: https://github.com/openfun/ralph/compare/v4.2.0...v5.0.0
 [4.2.0]: https://github.com/openfun/ralph/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/openfun/ralph/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/openfun/ralph/compare/v3.9.0...v4.0.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,20 @@ All instructions to upgrade this project from one release to the next will be do
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 4.x to 5.y
+
+#### Upgrade learning events models
+
+xAPI learning statements validator and converter are built with Pydantic. Ralph 5.x
+is compatible with Pydantic 2.x. Please refer to [Pydantic migration
+guide](https://docs.pydantic.dev/dev/migration/) if you are using Ralph `models`
+feature.
+
+> Most of fields in Pydantic models that are optional are set with `None` as
+  default value in Ralph 5.y. If you serialize some Pydantic models from ralph
+  and want to keep the same content in your serialization, please set
+  `exclude_none` to `True` in the serialization method `model_dump`.
+ 
 ### 3.x to 4.y
 
 #### Upgrade user credentials

--- a/docs/theme/announce.html
+++ b/docs/theme/announce.html
@@ -1,5 +1,5 @@
 <!-- the following line is displayed in the announcement bar -->
 <!-- keep length under 164 characters (less HTML tags) to fit on 1280px desktop window -->
-🌟 Big News! Ralph v4 is here. Don't forget to check out our 
+🌟 Big News! Ralph v5 is here. Don't forget to check out our 
 <a href=https://github.com/openfun/ralph/blob/main/UPGRADE.md>migration guide</a> 
 for a seamless transition. 🚀

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -4,5 +4,5 @@ name: ralph
 description: Ralph, the ultimate Learning Record Store (and more!) for your learning analytics 
 type: application
 version: 0.4.0
-appVersion: "4.2.0"
+appVersion: "5.0.0"
 icon: https://raw.githubusercontent.com/openfun/logos/main/ralph/ralph-color-dark.png

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "4.2.0"
+__version__ = "5.0.0"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 4.2.0
+  version: 5.0.0


### PR DESCRIPTION
### Added

- Models: Add Webinar xAPI activity type

### Changed

- Upgrade `pydantic` to `2.7.0`
- Migrate model tests from hypothesis strategies to polyfactory
- Replace soon-to-be deprecated `parse_obj_as` with `TypeAdapter`

