### PR TITLE
🔧(project) add docker and ci managers in renovatebot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "extends": [
         "github>openfun/renovate-configuration"
     ],
+    "enabledManagers": ["npm", "setup-cfg", "pep621", "dockerfile", "docker-compose", "circleci"],
     "commitMessagePrefix": "⬆️(project)",
     "commitMessageAction": "upgrade",
     "commitBodyTable": true,
@@ -12,5 +13,13 @@
         "dev/pytest-httpx",
         "dev/responses",
         "lrs/httpx"
+    ],
+    "packageRules": [
+        {
+            "groupName": "docker dependencies",
+            "matchManagers": ["dockerfile", "docker-compose", "circleci"],
+            "schedule": ["before 7am on monday"],
+            "matchPackagePatterns": ["*"]
+        }
     ]
 }


### PR DESCRIPTION
## Purpose 

Renovatebot can automatically upgrade images used in `Dockerfile`,
`docker-compose` and `circleci` configuration.

## Proposal

To avoid upgrade manually packages when developers have noticed an image has
been freshly released, we set the automatic upgrades on Ralph, for a first test.

