### PR TITLE
🐛(api) fix LaxStatement validation to prevent IDs modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Force Elasticserach REFRESH_AFTER_WRITE setting to be a string
 
+### Fixed
+
+- Fix LaxStatement validation to prevent statements IDs modification
+
 ## [5.0.0] - 2024-05-02
 
 ### Added

--- a/src/ralph/api/models.py
+++ b/src/ralph/api/models.py
@@ -7,7 +7,7 @@ validation.
 from typing import Optional, Union
 from uuid import UUID
 
-from pydantic import AnyUrl, BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict
 
 from ..models.xapi.base.agents import BaseXapiAgent
 from ..models.xapi.base.groups import BaseXapiGroup
@@ -39,7 +39,7 @@ class LaxObjectField(BaseModelWithLaxConfig):
     Lightest definition of an object field compliant to the specification.
     """
 
-    id: AnyUrl
+    id: str
 
 
 class LaxVerbField(BaseModelWithLaxConfig):
@@ -48,7 +48,7 @@ class LaxVerbField(BaseModelWithLaxConfig):
     Lightest definition of a verb field compliant to the specification.
     """
 
-    id: AnyUrl
+    id: str
 
 
 class LaxStatement(BaseModelWithLaxConfig):

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,0 +1,54 @@
+"""Tests for the BaseXapiStatement."""
+
+import pytest
+from pydantic import ValidationError
+
+from ralph.api.models import LaxStatement
+
+from tests.factories import mock_xapi_instance
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["actor", "verb", "object"],
+)
+def test_api_models_laxstatement_must_use_actor_verb_and_object(field):
+    """Test that the statement raises an exception if required fields are missing.
+
+    XAPI-00003
+    An LRS rejects with error code 400 Bad Request a Statement which does not contain an
+    "actor" property.
+    XAPI-00004
+    An LRS rejects with error code 400 Bad Request a Statement which does not contain a
+    "verb" property.
+    XAPI-00005
+    An LRS rejects with error code 400 Bad Request a Statement which does not contain an
+    "object" property.
+    """
+
+    statement = mock_xapi_instance(LaxStatement)
+
+    statement = statement.model_dump(exclude_none=True)
+    del statement[field]
+    with pytest.raises(ValidationError, match="Field required"):
+        LaxStatement(**statement)
+
+
+def test_api_models_laxstatement_should_not_change_fields():
+    """Test that the statement fields should not be changed by validation."""
+
+    object_id = "https://localhost:443/course/1"
+    verb_id = "https://localhost:443/didthat"
+    statement = mock_xapi_instance(LaxStatement)
+
+    statement = statement.model_dump(exclude_none=True)
+    statement["object"]["id"] = object_id
+    statement["verb"]["id"] = verb_id
+
+    try:
+        output = LaxStatement(**statement)
+    except ValidationError as err:
+        pytest.fail(f"Valid statement should not raise exceptions: {err}")
+
+    assert output.object.id == object_id
+    assert output.verb.id == verb_id


### PR DESCRIPTION
## Purpose

Some statement with an object id  consisting of an url with https scheme and a
port were altered during validation, losing the port.

## Proposal

Since ids should remain unchanged, we now ensure that validation preserves the
ids by validating only against the string type.

