### PR TITLE
🔖(patch) bump release to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [5.0.1] - 2024-07-11
+
 ### Changed
 
-- Force Elasticserach REFRESH_AFTER_WRITE setting to be a string
+- Force Elasticsearch REFRESH_AFTER_WRITE setting to be a string
 
 ### Fixed
 
@@ -490,7 +492,8 @@ as per the xAPI specification
 - Add optional sentry integration
 - Distribute Arnold's tray to deploy Ralph in a k8s cluster as cronjobs
 
-[unreleased]: https://github.com/openfun/ralph/compare/v5.0.0...main
+[unreleased]: https://github.com/openfun/ralph/compare/v5.0.1...main
+[5.0.1]: https://github.com/openfun/ralph/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/openfun/ralph/compare/v4.2.0...v5.0.0
 [4.2.0]: https://github.com/openfun/ralph/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/openfun/ralph/compare/v4.0.0...v4.1.0

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade appVersion to `5.0.1`
+
 ## [0.5.0] - 2024-07-01
 
 ### Changed

--- a/src/helm/ralph/Chart.yaml
+++ b/src/helm/ralph/Chart.yaml
@@ -4,5 +4,5 @@ name: ralph
 description: Ralph, the ultimate Learning Record Store (and more!) for your learning analytics 
 type: application
 version: 0.5.0
-appVersion: "5.0.0"
+appVersion: "5.0.1"
 icon: https://raw.githubusercontent.com/openfun/logos/main/ralph/ralph-color-dark.png

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph module."""
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: ralph
-  version: 5.0.0
+  version: 5.0.1


### PR DESCRIPTION
## Changed

- Force Elasticsearch REFRESH_AFTER_WRITE setting to be a string

## Fixed

- Fix LaxStatement validation to prevent statements IDs modification

