### PR TITLE
🐛(models) fix statement.result.score.scaled type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix type of `statement.result.score.scaled` from `int` to `Decimal`
+
 ## [5.0.1] - 2024-07-11
 
 ### Changed

--- a/src/ralph/models/xapi/base/results.py
+++ b/src/ralph/models/xapi/base/results.py
@@ -17,13 +17,13 @@ class BaseXapiResultScore(BaseModelWithConfig):
     """Pydantic model for result `score` property.
 
     Attributes:
-        scaled (int): Consists of the normalized score related to the experience.
+        scaled (Decimal): Consists of the normalized score related to the experience.
         raw (Decimal): Consists of the non-normalized score achieved by the Actor.
         min (Decimal): Consists of the lowest possible score.
         max (Decimal): Consists of the highest possible score.
     """
 
-    scaled: Optional[Annotated[int, Field(ge=-1, le=1)]] = None
+    scaled: Optional[Annotated[Decimal, Field(ge=-1, le=1)]] = None
     raw: Optional[Decimal] = None
     min: Optional[Decimal] = None
     max: Optional[Decimal] = None


### PR DESCRIPTION
## Purpose

The scaled field in result.score was incorrectly set as an integer. According to xAPI documentation, it should be a decimal (ranging from -1 to 1).

Closes #612