### PR TITLE
📌(project) pin ovh dependency to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ backend-es = [
     "elasticsearch[async]>=8.0.0",
 ]
 backend-ldp = [
-    "ovh>=1.0.0",
+    "ovh==1.1.0",
     "requests>=2.0.0",
 ]
 backend-lrs = [


### PR DESCRIPTION
## Purpose

The CI is failing on tests over the LDP backend.
The OVH Python dependency was previously set to a minimum version of 1.0.0, which left Ralph vulnerable to breaking changes in the LDP backend.

## Proposal

Pinning to version 1.1.0 as the 1.2.0 requires additional integration.

