### PR TITLE
💚(circle) trigger release only on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -842,6 +842,6 @@ workflows:
             - package
           filters:
             branches:
-              only: main
+              ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
               soft: 262144
               hard: 262144
       healthcheck:
-        test:  wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+        test:  wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping || exit 1
         interval: 1s
         retries: 60
 


### PR DESCRIPTION
## Purpose

- Release workflow was triggered on tags and on changes on the `main` branch. Changing it so it is triggered only on tags.
- Clickhouse is stuck unhealthy as localhost is not accessible in the container anymore. Fixing it by pinging `0.0.0.0` instead.

