### PR TITLE
🐛(models) fix groups' optional member field defaulting to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - Fix type of `statement.result.score.scaled` from `int` to `Decimal`
+- Fix optional `member` field in Identified Groups not actually being optional
 
 ## [5.0.1] - 2024-07-11
 

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -56,7 +56,7 @@ class BaseXapiIdentifiedGroup(BaseXapiGroupCommonProperties):
         member (list): Consist of a list of the members of this Group.
     """
 
-    member: Optional[List[BaseXapiAgent]]
+    member: Optional[List[BaseXapiAgent]] = None
 
 
 class BaseXapiIdentifiedGroupWithMbox(BaseXapiIdentifiedGroup, BaseXapiMboxIFI):

--- a/tests/models/xapi/base/test_groups.py
+++ b/tests/models/xapi/base/test_groups.py
@@ -1,6 +1,13 @@
 """Tests for the base xAPI `Group` definitions."""
 
-from ralph.models.xapi.base.groups import BaseXapiGroupCommonProperties
+import pytest
+from pydantic import ValidationError
+
+from ralph.models.xapi.base.groups import (
+    BaseXapiGroupCommonProperties,
+    BaseXapiIdentifiedGroupWithMbox,
+    BaseXapiIdentifiedGroupWithMboxSha1Sum,
+)
 
 from tests.factories import mock_xapi_instance
 
@@ -12,3 +19,53 @@ def test_models_xapi_base_groups_group_common_properties_with_valid_field():
     field = mock_xapi_instance(BaseXapiGroupCommonProperties)
 
     assert field.objectType == "Group"
+
+
+@pytest.mark.parametrize(
+    "group",
+    [
+        {
+            "name": "d75662f7c72c8d12267712aaf31b649cdab13cb8",
+            "mbox_sha1sum": "6395037c217b04eae94355900bcaf014772c7d7c",
+            "objectType": "Group",
+        },
+        {
+            "name": "d75662f7c72c8d12267712aaf31b649cdab13cb8",
+            "mbox_sha1sum": "6395037c217b04eae94355900bcaf014772c7d7c",
+            "objectType": "Group",
+            "member": [],
+        },
+    ],
+)
+def test_models_xapi_base_group_mbox_sha1sum_valid(group):
+    """Test an invalid group with `mbox_sha1sum` property"""
+
+    try:
+        BaseXapiIdentifiedGroupWithMboxSha1Sum(**group)
+    except ValidationError as err:
+        pytest.fail(f"Valid statement should not raise exceptions: {err}")
+
+
+@pytest.mark.parametrize(
+    "group",
+    [
+        {
+            "name": "d75662f7c72c8d12267712aaf31b649cdab13cb8",
+            "mbox": "mailto:foob@r.com",
+            "objectType": "Group",
+        },
+        {
+            "name": "d75662f7c72c8d12267712aaf31b649cdab13cb8",
+            "mbox": "mailto:foob@r.com",
+            "objectType": "Group",
+            "member": [],
+        },
+    ],
+)
+def test_models_xapi_base_group_mbox_valid(group):
+    """Test an invalid group with `mbox` property"""
+
+    try:
+        BaseXapiIdentifiedGroupWithMbox(**group)
+    except ValidationError as err:
+        pytest.fail(f"Valid statement should not raise exceptions: {err}")


### PR DESCRIPTION
## Purpose

[The `member` field is optional in an Identified Group ](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#details-3)
Without this fix, the mbox, mbox_sha1sum etc. kinds of groups still expect a member.

## Proposal

The `member` field of `BaseXxapiIdentifiedGroup` did not have a default value even though it is `Optional`.
This commit sets it to `None`, which is in line with other optional fields.

- [x] Added above fix
- [x] Added tests
- [x] Updated `CHANGELOG.md` 

