### PR TITLE
🐛(validation) replace `TypeError`s with `ValueError`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - Fix type of `statement.result.score.scaled` from `int` to `Decimal`
+- Fix misregistered `TypeError` in Pydantic models validation
 
 ## [5.0.1] - 2024-07-11
 

--- a/src/ralph/backends/lrs/base.py
+++ b/src/ralph/backends/lrs/base.py
@@ -56,7 +56,7 @@ def validate_iso_datetime_str(value: Union[str, datetime]) -> datetime:
     to an ISO 8601 date time string.
     """
     if not isinstance(value, (str, datetime)):
-        raise TypeError("a string or datetime is required")
+        raise ValueError("a string or datetime is required")
 
     if isinstance(value, datetime):
         return value.isoformat()

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -40,7 +40,7 @@ class LanguageTag(RootModel[Union[str, "LanguageTag"]]):
     def validate_language_tag(cls, tag):
         """Check whether the provided tag is a valid RFC 5646 Language tag."""
         if not tag_is_valid(str(tag)):
-            raise TypeError("Invalid RFC 5646 Language tag")
+            raise ValueError("Invalid RFC 5646 Language tag")
         return str(tag)
 
 
@@ -54,7 +54,7 @@ class MailtoEmail(RootModel[str]):
     def validate(self) -> Type["MailtoEmail"]:
         """Check whether the provided value follows the `mailto:email` format."""
         if not self.root.startswith("mailto:"):
-            raise TypeError("Invalid `mailto:email` value")
+            raise ValueError("Invalid `mailto:email` value")
         valid = validate_email(self.root[7:])
         self.root = f"mailto:{valid[1]}"
         return self

--- a/tests/models/xapi/base/test_common.py
+++ b/tests/models/xapi/base/test_common.py
@@ -88,7 +88,7 @@ def test_models_xapi_base_common_field_language_tag_with_invalid_data(values):
 
         tag: LanguageTag
 
-    with pytest.raises(TypeError, match="Invalid RFC 5646 Language tag"):
+    with pytest.raises(ValidationError, match="Invalid RFC 5646 Language tag"):
         DummyLanguageTagModel(**values)
 
 
@@ -116,7 +116,7 @@ def test_models_xapi_base_common_field_language_map_with_valid_data(values):
             ValidationError,
             "map\n  Input should be a valid dictionary",
         ),
-        ({"map": {"en-US-en": 1}}, TypeError, "Invalid RFC 5646 Language tag"),
+        ({"map": {"en-US-en": 1}}, ValidationError, "Invalid RFC 5646 Language tag"),
         (
             {"map": {"en-US": []}},
             ValidationError,

--- a/tests/models/xapi/base/test_statements.py
+++ b/tests/models/xapi/base/test_statements.py
@@ -186,13 +186,13 @@ def test_models_xapi_base_statement_with_invalid_data_types(path, value, err):
         (
             "actor",
             {"mbox": "example@mail.com"},
-            TypeError,
+            ValidationError,
             "Invalid `mailto:email` value",
         ),
         (
             "verb__display",
             {"bad language tag": "foo"},
-            TypeError,
+            ValidationError,
             "Invalid RFC 5646 Language tag",
         ),
         ("object__id", ["This is not an IRI"], ValidationError, "is not a valid 'IRI'"),


### PR DESCRIPTION
## Purpose

[`TypeError`s are not supported as validation errors by Pydantic](https://pydantic.dev/docs/validation/latest/concepts/validators/ \#raising-validation-errors).
So Pydantic won't encapsulate them in a `ValidationError`.

## Proposal

We replace them with `ValueError`s, which work as expected.

- [x] Replaced `TypeError`s with `ValueError`s in Pydantic models
- [x] Updated tests
- [x] Updated `CHANGELOG.md` 

