### PR TITLE
💚(ci) fix check-changelog, mongo tests, tray and test-helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Check that the CHANGELOG has been modified in the current branch
           command: |
-            git whatchanged --name-only --pretty="" origin..HEAD | grep CHANGELOG
+            git log --name-only --pretty=format: origin..HEAD | grep CHANGELOG
 
   # Check that the CHANGELOG max line length does not exceed 80 characters
   lint-changelog:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,10 +388,16 @@ jobs:
             # Deploy a two-nodes elasticsearch cluster
             kubectl apply -f src/helm/manifests/data-lake.yml
 
-            # Wait on the Elasticsearch resource itself: it exists right after
-            # `apply`, so this avoids the "no matching resources found" race of
-            # `kubectl wait pod` against an empty selector (see kubectl#1516).
-            kubectl wait --for=jsonpath='{.status.phase}'=Ready elasticsearch/data-lake --timeout=600s
+            # The operator writes `.status` asynchronously, so `kubectl wait
+            # --for=jsonpath` errors with "status is not found" when the field
+            # does not exist yet. Poll until the cluster reports a Ready phase.
+            for i in $(seq 1 60); do
+              phase=$(kubectl get elasticsearch data-lake -o jsonpath='{.status.phase}' 2>/dev/null || true)
+              echo "Elasticsearch phase: ${phase:-<none>} ($i/60)"
+              if [ "$phase" = "Ready" ]; then break; fi
+              sleep 10
+            done
+            [ "$phase" = "Ready" ]
 
             # Store elastic user password
             echo 'ELASTIC_PASSWORD="$(kubectl get secret data-lake-es-elastic-user -o jsonpath="{.data.elastic}" | base64 -d)"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,16 +378,20 @@ jobs:
           command: |
             helm repo add elastic https://helm.elastic.co
             helm repo update
-            helm install elastic-operator elastic/eck-operator
+            # Pin the ECK operator: an unpinned chart drifts and breaks CI
+            helm install elastic-operator elastic/eck-operator --version 2.16.1
+
+            # The operator must be running before it can reconcile the
+            # Elasticsearch resource, otherwise no pods are ever created.
+            kubectl rollout status statefulset/elastic-operator --timeout=300s
             
             # Deploy a two-nodes elasticsearch cluster
             kubectl apply -f src/helm/manifests/data-lake.yml
 
-            # Wait for pods to be ready
-            # Still need to wait for pods to be created before waiting for them
-            # to be ready (see https://github.com/kubernetes/kubectl/issues/1516)
-            sleep 5
-            kubectl wait --for=condition=ready pod --selector=common.k8s.elastic.co/type=elasticsearch --timeout=120s
+            # Wait on the Elasticsearch resource itself: it exists right after
+            # `apply`, so this avoids the "no matching resources found" race of
+            # `kubectl wait pod` against an empty selector (see kubectl#1516).
+            kubectl wait --for=jsonpath='{.status.phase}'=Ready elasticsearch/data-lake --timeout=600s
 
             # Store elastic user password
             echo 'ELASTIC_PASSWORD="$(kubectl get secret data-lake-es-elastic-user -o jsonpath="{.data.elastic}" | base64 -d)"' >> $BASH_ENV

--- a/.k3d-cluster.env.sh
+++ b/.k3d-cluster.env.sh
@@ -4,7 +4,7 @@ echo -n "Loading k3d cluster environment... "
 
 export ARNOLD_DEFAULT_VAULT_PASSWORD=arnold
 export ANSIBLE_VAULT_PASSWORD="${ARNOLD_DEFAULT_VAULT_PASSWORD}"
-export ARNOLD_IMAGE_TAG=master
+export ARNOLD_IMAGE_TAG=6.23.0
 export K3D_BIND_HOST_PORT_HTTP=80
 export K3D_BIND_HOST_PORT_HTTPS=443
 export K3D_CLUSTER_NAME=ralph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to
 - Make MongoDB delete-failure tests tolerant to pymongo error message changes
 - Pin Arnold to `6.23.0` (was `master`) to fix the CircleCI `tray` job broken
   by the ansible-core `2.14.18` vault handling change
-- Pin the ECK operator and wait on the Elasticsearch resource in the
-  `test-helm` CI job to fix a "no matching resources found" race
+- Pin the ECK operator and poll the Elasticsearch resource status in the
+  `test-helm` CI job to fix flaky "no matching resources"/"status not found"
 
 ## [5.0.1] - 2024-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
 ### Fixed
 
 - Fix type of `statement.result.score.scaled` from `int` to `Decimal`
+- Fix `check-changelog` CI job by replacing the removed `git whatchanged`
+  command with `git log --name-only`
+- Make MongoDB delete-failure tests tolerant to pymongo error message changes
 
 ## [5.0.1] - 2024-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 - Fix `check-changelog` CI job by replacing the removed `git whatchanged`
   command with `git log --name-only`
 - Make MongoDB delete-failure tests tolerant to pymongo error message changes
+- Pin Arnold to `6.23.0` (was `master`) to fix the CircleCI `tray` job broken
+  by the ansible-core `2.14.18` vault handling change
 
 ## [5.0.1] - 2024-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 - Make MongoDB delete-failure tests tolerant to pymongo error message changes
 - Pin Arnold to `6.23.0` (was `master`) to fix the CircleCI `tray` job broken
   by the ansible-core `2.14.18` vault handling change
+- Pin the ECK operator and wait on the Elasticsearch resource in the
+  `test-helm` CI job to fix a "no matching resources found" race
 
 ## [5.0.1] - 2024-07-11
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ES_INDEX    = statements
 ES_URL      = $(ES_PROTOCOL)://$(ES_HOST):$(ES_PORT)
 
 # -- Arnold
-ARNOLD              = ARNOLD_IMAGE_TAG=master bin/arnold
+ARNOLD              = ARNOLD_IMAGE_TAG=6.23.0 bin/arnold
 ARNOLD_APP          = ralph
 ARNOLD_APP_VARS     = group_vars/customer/$(ARNOLD_CUSTOMER)/$(ARNOLD_ENVIRONMENT)/main.yml
 ARNOLD_CUSTOMER    ?= ralph
@@ -56,11 +56,11 @@ K8S_NAMESPACE                  = $(ARNOLD_ENVIRONMENT)-$(ARNOLD_CUSTOMER)
 default: help
 
 bin/arnold:
-	curl -Lo "bin/arnold" "https://raw.githubusercontent.com/openfun/arnold/master/bin/arnold"
+	curl -Lo "bin/arnold" "https://raw.githubusercontent.com/openfun/arnold/v6.23.0/bin/arnold"
 	chmod +x bin/arnold
 
 bin/init-cluster:
-	curl -Lo "bin/init-cluster" "https://raw.githubusercontent.com/openfun/arnold/master/bin/init-cluster"
+	curl -Lo "bin/init-cluster" "https://raw.githubusercontent.com/openfun/arnold/v6.23.0/bin/init-cluster"
 	chmod +x bin/init-cluster
 
 .env:

--- a/tests/backends/data/test_async_mongo.py
+++ b/tests/backends/data/test_async_mongo.py
@@ -785,12 +785,11 @@ async def test_backends_data_async_mongo_write_with_delete_operation_failure(
     """
 
     backend = async_mongo_backend()
-    msg = (
-        "Failed to delete document chunk: Invalid document "
-        "{'q': {'_source.id': {'$in': [<class 'object'>]}}, 'limit': 0} | "
-        "cannot encode object: <class 'object'>, of type: <class 'type'>"
-    )
-    with pytest.raises(BackendException, match=msg):
+    # The tail of the error message is produced by pymongo/bson and its exact
+    # wording changes across pymongo versions; only assert on the stable prefix
+    # controlled by Ralph.
+    msg_prefix = "Failed to delete document chunk: "
+    with pytest.raises(BackendException, match=re.escape(msg_prefix)):
         await backend.write([{"id": object}], operation_type=BaseOperationType.DELETE)
 
     # Given `ignore_errors` argument set to `True`, the `write` method should not raise
@@ -805,11 +804,12 @@ async def test_backends_data_async_mongo_write_with_delete_operation_failure(
             == 0
         )
 
-    assert (
-        "ralph.backends.data.async_mongo",
-        logging.WARNING,
-        msg,
-    ) in caplog.record_tuples
+    assert any(
+        name == "ralph.backends.data.async_mongo"
+        and level == logging.WARNING
+        and message.startswith(msg_prefix)
+        for name, level, message in caplog.record_tuples
+    )
 
 
 @pytest.mark.anyio

--- a/tests/backends/data/test_mongo.py
+++ b/tests/backends/data/test_mongo.py
@@ -620,16 +620,20 @@ def test_backends_data_mongo_write_with_delete_operation_failure(
     """
 
     backend = mongo_backend()
-    msg = (
-        "Failed to delete document chunk: Invalid document {'q': {'_source.id': {'$in':"
-        " [<class 'object'>]}}, 'limit': 0} | cannot encode object: <class 'object'>, "
-        "of type: <class 'type'>"
-    )
+    # The tail of the error message is produced by pymongo/bson and its exact
+    # wording changes across pymongo versions; only assert on the stable prefix
+    # controlled by Ralph.
+    msg_prefix = "Failed to delete document chunk: "
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(BackendException, match=msg):
+        with pytest.raises(BackendException, match=re.escape(msg_prefix)):
             backend.write([{"id": object}], operation_type=BaseOperationType.DELETE)
 
-    assert ("ralph.backends.data.mongo", logging.ERROR, msg) in caplog.record_tuples
+    assert any(
+        name == "ralph.backends.data.mongo"
+        and level == logging.ERROR
+        and message.startswith(msg_prefix)
+        for name, level, message in caplog.record_tuples
+    )
 
     # Given `ignore_errors` argument set to `True`, the `write` method should not raise
     # an exception.
@@ -643,7 +647,12 @@ def test_backends_data_mongo_write_with_delete_operation_failure(
             == 0
         )
 
-    assert ("ralph.backends.data.mongo", logging.WARNING, msg) in caplog.record_tuples
+    assert any(
+        name == "ralph.backends.data.mongo"
+        and level == logging.WARNING
+        and message.startswith(msg_prefix)
+        for name, level, message in caplog.record_tuples
+    )
     backend.close()
 
 


### PR DESCRIPTION
## Purpose

The CI pipeline is currently red for reasons unrelated to any feature change:

1. The `check-changelog` job runs `git whatchanged`, which recent Git versions
   (>= 2.47) refuse to run (`fatal: refusing to run without --i-still-use-this`),
   so the job fails on every branch.
2. The MongoDB delete-failure tests assert on the *exact* pymongo/bson error
   string. That wording changed across pymongo versions, so the tests fail
   depending on the resolved pymongo version.
3. The `tray` job runs Arnold from the unpinned `master` image tag. `master`
   moved to 6.24.0 (ansible-core 2.14.18), whose stricter vault handling breaks
   the "Decrypt vaulted credentials" step (green->red on unrelated PRs).
4. The `test-helm` job installs the ECK operator from an unpinned chart and then
   waits on pods with a short `sleep`. The freshly installed operator is not
   ready yet, so no pods exist and `kubectl wait` fails immediately
   (`no matching resources found`, then `status is not found`).

This PR restores a green pipeline so functional PRs can be validated on a
reliable CI signal.

## Proposal

- [x] Replace `git whatchanged --name-only --pretty="" origin..HEAD` with
      `git log --name-only --pretty=format: origin..HEAD` in the
      `check-changelog` job (`.circleci/config.yml`).
- [x] Make `test_backends_data_mongo_write_with_delete_operation_failure` and its
      async counterpart assert only on the stable, Ralph-controlled prefix
      `"Failed to delete document chunk: "` instead of the full pymongo/bson
      message.
- [x] Pin Arnold to `6.23.0` (the last release before the ansible-core 2.14.18
      regression) in `Makefile` and `.k3d-cluster.env.sh`, and fetch the
      `bin/arnold` / `bin/init-cluster` wrappers from the `v6.23.0` tag.
- [x] Harden the `test-helm` Elasticsearch deployment: pin `eck-operator` to
      `2.16.1`, wait for the operator to be ready before applying the
      `Elasticsearch` resource, and poll `.status.phase` until `Ready` instead
      of racing on pods.
- [x] Update `CHANGELOG.md`.

### Testing

- Full suite (Docker, Python 3.12 + MongoDB): `1793 passed, 6 skipped`
  (previously `2 failed, 1791 passed`).
- Verified the new `check-changelog` command detects a `CHANGELOG.md` change.
- Reproduced the `tray` failure locally and confirmed the ansible-core
  2.14.17 -> 2.14.18 bump (Arnold 6.23.0 -> 6.24.0) is the trigger.
- `tray` and `test-helm` are now green on CircleCI.

