### PR TITLE
💚(ci) fix deploy-docs push to gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,9 +624,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-dependencies-python:3.12-{{ .Revision }}
-      - add_ssh_keys:
-          fingerprints:
-            - "43:a9:5b:a0:b5:8b:f5:b4:6d:73:66:a0:27:b1:ce:92"
       - run:
           name: Deploying to GitHub Pages
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   by the ansible-core `2.14.18` vault handling change
 - Pin the ECK operator and poll the Elasticsearch resource status in the
   `test-helm` CI job to fix flaky "no matching resources"/"status not found"
+- Drop the stale `add_ssh_keys` entry from the `deploy-docs` CI job so it
+  pushes to `gh-pages` with the read-write checkout key
 
 ## [5.0.1] - 2024-07-11
 


### PR DESCRIPTION
## Purpose

`deploy-docs` builds the docs correctly but fails to publish: pushing the
`gh-pages` branch is rejected with `git@github.com: Permission denied
(publickey)`.

The job pinned a stale key via `add_ssh_keys` (fingerprint `43:a9:...`),
which makes git use only that now-invalid identity for `github.com` and
ignore the read-write checkout key.

## Proposal

- [x] Remove the `add_ssh_keys` block from `deploy-docs` so it pushes with
      the read-write checkout key (the project user key).
- [x] Update `CHANGELOG.md`.

## Note

`deploy-docs` only runs on `main`, so this can only be validated after
merge (a project write-enabled checkout/user key must be configured in
CircleCI SSH Keys, which it now is).