### PR TITLE
🐛(tests) fix missing responses in oidc test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
 ### Changed
 
 - Refactor statements' ExtensionMap
+- Fix oidc test `test_api_auth_oidc_get_whoami_invalid_backend`
+  being misconfigured
 
 ## [5.0.1] - 2024-07-11
 

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -215,6 +215,7 @@ async def test_api_auth_oidc_get_whoami_invalid_header(client, monkeypatch):
 
 
 @pytest.mark.anyio
+@responses.activate
 async def test_api_auth_oidc_get_whoami_invalid_backend(client, fs, monkeypatch):
     """Check for an exception when providing valid OIDC credentials while
     OIDC authentication is not supported.
@@ -231,4 +232,4 @@ async def test_api_auth_oidc_get_whoami_invalid_backend(client, fs, monkeypatch)
     )
 
     assert response.status_code == 401
-    assert response.json() == {"detail": "Could not validate credentials"}
+    assert response.json() == {"detail": "Invalid authentication credentials"}


### PR DESCRIPTION
## Purpose

That test was missing `@responses.activate`, which meant that the reported error was not the right one.
It also made it leek out in tests that were run afterwards.

You can check that despite this test being configured for Basic authentication, it actually ran OpenID backend.
The corrected response comes from Basic backend.