### PR TITLE
💚(ci) bump elasticsearch test service to 8.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           password: $DOCKER_HUB_PASSWORD
         environment:
           RALPH_APP_DIR: ~/fun/.ralph
-      - image: elasticsearch:8.1.0
+      - image: elasticsearch:8.8.1
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to
   `test-helm` CI job to fix flaky "no matching resources"/"status not found"
 - Drop the stale `add_ssh_keys` entry from the `deploy-docs` CI job so it
   pushes to `gh-pages` with the read-write checkout key
-- Fix XAPI definitions extensions not accepting empty strings as values.
+- Bump the Elasticsearch test service to `8.8.1` so its bundled JDK can read
+  cgroup v2 hosts, fixing the `test-python` CI jobs
+- Fix XAPI definitions extensions not accepting empty strings as values.
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   # -- backends
   elasticsearch:
-    image: elasticsearch:8.1.0
+    image: elasticsearch:8.8.1
     environment:
       bootstrap.memory_lock: true
       discovery.type: single-node

--- a/tests/backends/data/test_async_es.py
+++ b/tests/backends/data/test_async_es.py
@@ -745,24 +745,21 @@ async def test_backends_data_async_es_write_without_ignore_errors(
     assert len([statement async for statement in backend.read()]) == 0
 
     # By default, we should raise an error and stop the importation.
-    msg = (
-        r"1 document\(s\) failed to index. "
-        r"\[\{'index': \{'_index': 'test-index-foo', '_id': '4', 'status': 400, 'error'"
-        r": \{'type': 'mapper_parsing_exception', 'reason': \"failed to parse field "
-        r"\[count\] of type \[long\] in document with id '4'. Preview of field's value:"
-        r" 'wrong'\", 'caused_by': \{'type': 'illegal_argument_exception', 'reason': "
-        r"'For input string: \"wrong\"'\}\}, 'data': \{'id': 4, 'count': 'wrong'\}\}\}"
-        r"\] Total succeeded writes: 5"
-    )
-    with pytest.raises(BackendException, match=msg):
+    # Only assert on the parts Ralph controls: Elasticsearch rewords its own
+    # parsing errors between releases.
+    msg_prefix = "1 document(s) failed to index."
+    msg_suffix = "Total succeeded writes: 5"
+    with pytest.raises(BackendException, match=re.escape(msg_prefix)):
         with caplog.at_level(logging.ERROR):
             await backend.write(data, chunk_size=2)
 
-    assert (
-        "ralph.backends.data.async_es",
-        logging.ERROR,
-        msg.replace("\\", ""),
-    ) in caplog.record_tuples
+    assert any(
+        name == "ralph.backends.data.async_es"
+        and level == logging.ERROR
+        and message.startswith(msg_prefix)
+        and message.endswith(msg_suffix)
+        for name, level, message in caplog.record_tuples
+    )
 
     es.indices.refresh(index=ES_TEST_INDEX)
     hits = [statement async for statement in backend.read()]

--- a/tests/backends/data/test_es.py
+++ b/tests/backends/data/test_es.py
@@ -643,24 +643,21 @@ def test_backends_data_es_write_without_ignore_errors(es, es_backend, caplog):
     assert len(list(backend.read())) == 0
 
     # By default, we should raise an error and stop the importation.
-    msg = (
-        r"1 document\(s\) failed to index. "
-        r"\[\{'index': \{'_index': 'test-index-foo', '_id': '4', 'status': 400, 'error'"
-        r": \{'type': 'mapper_parsing_exception', 'reason': \"failed to parse field "
-        r"\[count\] of type \[long\] in document with id '4'. Preview of field's value:"
-        r" 'wrong'\", 'caused_by': \{'type': 'illegal_argument_exception', 'reason': "
-        r"'For input string: \"wrong\"'\}\}, 'data': \{'id': 4, 'count': 'wrong'\}\}\}"
-        r"\] Total succeeded writes: 5"
-    )
-    with pytest.raises(BackendException, match=msg):
+    # Only assert on the parts Ralph controls: Elasticsearch rewords its own
+    # parsing errors between releases.
+    msg_prefix = "1 document(s) failed to index."
+    msg_suffix = "Total succeeded writes: 5"
+    with pytest.raises(BackendException, match=re.escape(msg_prefix)):
         with caplog.at_level(logging.ERROR):
             backend.write(data, chunk_size=2)
 
-    assert (
-        "ralph.backends.data.es",
-        logging.ERROR,
-        msg.replace("\\", ""),
-    ) in caplog.record_tuples
+    assert any(
+        name == "ralph.backends.data.es"
+        and level == logging.ERROR
+        and message.startswith(msg_prefix)
+        and message.endswith(msg_suffix)
+        for name, level, message in caplog.record_tuples
+    )
 
     es.indices.refresh(index=ES_TEST_INDEX)
     hits = list(backend.read())


### PR DESCRIPTION
## Purpose

The four `test-python` jobs are red on `main` since bc65861b, and no code change
is involved: the `elasticsearch:8.1.0` service container crashes before the
tests even start.

Its bundled JDK 17.0.2 hits a cgroup v2 bug:

    Exception in thread "main" java.lang.NullPointerException:
      Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()"
      because "anyController" is null
        at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance

`Run tests` then dies waiting on its dependencies:

    Timeout after 1m0s waiting on dependencies to become available:
      [tcp://...:9200 tcp://...:27017 tcp://...:9000]

Because `package` requires `test`, and `deploy-docs` requires `package`, the
documentation is no longer published either. PRs #638, #639 and #640 fail the
same way.

## Proposal

Bump the Elasticsearch test service to `8.8.1`, whose bundled JDK 20.0.1 does
not have the bug. The repository already runs `8.8.1` in
`src/helm/manifests/data-lake.yml`, and the client pin
`elasticsearch[async]>=8.0.0,<9.0.0` covers it.

The bump alone breaks two tests that assert on Elasticsearch's own error
wording, which changed between 8.1 and 8.8: `mapper_parsing_exception` became
`document_parsing_exception`, and the reason is now prefixed with a position.
Those assertions are relaxed to the parts Ralph controls, as was done for
pymongo in #634.

- [x] Bump `elasticsearch:8.1.0` to `8.8.1` in `.circleci/config.yml` and `docker-compose.yml`
- [x] Relax the two `write_without_ignore_errors` assertions to Ralph-controlled text
- [x] Fix a non-breaking space in the CHANGELOG extensions entry
- [x] Verified locally: the full suite yields `1784 passed` on both 8.8.1 and
      8.1.0, with an

