### PR TITLE
🔧(project) keep cors disabled by default in .env.dist

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -166,7 +166,7 @@ RALPH_RUNSERVER_HOST=0.0.0.0
 RALPH_RUNSERVER_MAX_SEARCH_HITS_COUNT=100
 RALPH_RUNSERVER_POINT_IN_TIME_KEEP_ALIVE=1m
 RALPH_RUNSERVER_PORT=8100
-RALPH_RUNSERVER_CORS_ALLOW_ORIGINS=["http://my-allowed-host.com","http://my-other-allowed-host.com"]
+# RALPH_RUNSERVER_CORS_ALLOW_ORIGINS=["http://my-allowed-host.com","http://my-other-allowed-host.com"]
 
 # Authentication
 # RALPH_AUTH_FILE=/app/.ralph/auth.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
 - Bump the Elasticsearch test service to `8.8.1` so its bundled JDK can read
   cgroup v2 hosts, fixing the `test-python` CI jobs
 - Fix XAPI definitions extensions not accepting empty strings as values.
+- Keep CORS disabled by default in `.env.dist` so a bootstrapped `.env` no
+  longer breaks the `RUNSERVER_CORS_ALLOW_ORIGINS` settings unit tests
 
 ### Changed
 


### PR DESCRIPTION
Follow-up to #629. The `.env.dist` entry was shipped uncommented, so any developer running `make bootstrap` gets a `.env` that sets `RUNSERVER_CORS_ALLOW_ORIGINS`, which makes the two settings tests added in #629 fail locally (they assert the default is `[]`). CI was unaffected since it never creates a `.env`. Commenting the line matches the convention used for the other optional settings in the file.